### PR TITLE
Add list-hints script

### DIFF
--- a/scripts/list-hints.sh
+++ b/scripts/list-hints.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+jq -r "[.hints|to_entries|.[].value.[]|pick(.code)]|unique|sort_by(.code)" build/os_latest.json


### PR DESCRIPTION
It will return sorted and unique list of hints from os_latest.json:
```
scripts/list-hints.sh
[
  {
    "code": "# A builtin should be selected iff its encoding appears in the selected encodings list\n# and the list wasn't exhausted.\n# Note that testing inclusion by a single comparison is possible since the lists are sorted.\nids.select_builtin = int(\n  n_selected_builtins > 0 and memory[ids.selected_encodings] == memory[ids.all_encodings])\nif ids.select_builtin:\n  n_selected_builtins = n_selected_builtins - 1"
  },
  {
    "code": "# Check that the actual return value matches the expected one.\nexpected = memory.get_range(\n    addr=ids.call_response.retdata, size=ids.call_response.retdata_size\n)\nactual = memory.get_range(addr=ids.retdata, size=ids.retdata_size)\n\nassert expected == actual, f'Return value mismatch expected={expected}, actual={actual}.'"
  },
...
```
To count total number of hints:
```
scripts/list-hints.sh | jq length
```
