### PR TITLE
fix: chain id is expected to be a felt

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub const DEFAULT_STORAGE_TREE_HEIGHT: usize = 251;
 pub const DEFAULT_INNER_TREE_HEIGHT: u64 = 64;
 pub const DEFAULT_FEE_TOKEN_ADDR: &str = "482bc27fc5627bf974a72b65c43aa8a0464a70aab91ad8379b56a4f17a84c3";
 pub const SEQUENCER_ADDR_0_12_2: &str = "6c95526293b61fa708c6cba66fd015afee89309666246952456ab970e9650aa";
+pub const SN_GOERLI: &str = "534e5f474f45524c49";
 
 use crate::utils::ChainIdNum;
 #[serde_as]
@@ -71,7 +72,7 @@ impl Default for StarknetGeneralConfig {
             Ok(conf) => conf,
             Err(_) => Self {
                 starknet_os_config: StarknetOsConfig {
-                    chain_id: ChainId("SN_GOERLI".to_string()),
+                    chain_id: ChainId(SN_GOERLI.to_string()),
                     fee_token_address: contract_address!(DEFAULT_FEE_TOKEN_ADDR),
                 },
                 contract_storage_commitment_tree_height: DEFAULT_STORAGE_TREE_HEIGHT as u64,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -208,8 +208,16 @@ impl SerializeAs<ChainId> for ChainIdNum {
 #[cfg(test)]
 mod tests {
     use bitvec::prelude::*;
+    use serde_with::serde_as;
 
     use super::*;
+
+    #[serde_as]
+    #[derive(Serialize)]
+    struct ChainIdOnly {
+        #[serde_as(as = "ChainIdNum")]
+        chain_id: ChainId,
+    }
 
     #[test]
     fn felt_conversions() {
@@ -230,5 +238,20 @@ mod tests {
 
         assert_eq!(bv, felt_to_bits_api(api_felt));
         assert_eq!(api_felt, felt_from_bits_api(&bv).unwrap());
+    }
+
+    #[test]
+    fn chain_id_num_ok() {
+        let c = ChainIdOnly { chain_id: ChainId("534e5f474f45524c49".to_string()) };
+
+        serde_json::to_string(&c).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn chain_id_num_fail() {
+        let c = ChainIdOnly { chain_id: ChainId("SN_GOERLI".to_string()) };
+
+        serde_json::to_string(&c).unwrap();
     }
 }


### PR DESCRIPTION
Issue Number: N/A

## Type

- [ ] feature
- [X] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description

Fixes the default `StarknetOsConfig` where the chain id didn't have a valid value.
This prevented one to initialize a default configuration and dump it into a file.

## Breaking changes?

- [ ] yes
- [X] no
