### PR TITLE
Feature: port of all Patricia trie related functions from cairo-lang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,6 +3182,8 @@ name = "snos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
+ "async-stream",
  "base64",
  "bitvec",
  "blockifier",
@@ -3167,7 +3191,10 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-type-derive",
  "cairo-vm 1.0.0-rc0",
+ "futures",
+ "futures-util",
  "getset",
+ "heck 0.4.1",
  "hex",
  "indexmap 1.9.3",
  "indoc",
@@ -3177,6 +3204,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.18",
  "pretty_assertions",
+ "rand",
  "regex",
  "reqwest",
  "rstest 0.18.2",
@@ -3188,6 +3216,7 @@ dependencies = [
  "starknet_api",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "uuid",
  "zip",
 ]
@@ -3596,6 +3625,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,19 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.75"
+assert_matches = "1.5.0"
+async-stream = "0.3.5"
 base64 = "0.21.3"
 bitvec = { version = "1.0.1", features = ["serde"] }
 blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "snos/callinfo-clone", features = ["clone", "testing"] }
-cairo-type-derive = { version = "0.1.0", path = "cairo-type-derive" }
 cairo-lang-starknet = { version = "2.5.4" }
 cairo-lang-casm = { version = "2.5.4" }
+cairo-type-derive = { version = "0.1.0", path = "cairo-type-derive" }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", features = ["extensive_hints", "cairo-1-hints"] }
+futures = "0.3.30"
+futures-util = "0.3.30"
 getset = "0.1.2"
+heck = "0.4.1"
 hex = "0.4.3"
 indexmap = "1.9.2"
 indoc = "2"
@@ -32,9 +37,11 @@ starknet-crypto = "0.6.0"
 starknet_api = { version = "0.7.0-dev.0", features = ["testing"] }
 thiserror = "1.0.48"
 tokio = "1.32.0"
+tokio-stream = "0.1.14"
 uuid = { version = "1.4.0", features = ["v4", "serde"] }
 zip = { version = "0.6.6", features = ["deflate-zlib"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+rand = "0.8.5"
 rstest = "0.18.2"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,1 @@
+pub mod pedersen;

--- a/src/crypto/pedersen.rs
+++ b/src/crypto/pedersen.rs
@@ -2,7 +2,7 @@ use starknet_crypto::{pedersen_hash, FieldElement};
 
 use crate::storage::storage::HashFunctionType;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PedersenHash;
 
 impl HashFunctionType for PedersenHash {

--- a/src/crypto/pedersen.rs
+++ b/src/crypto/pedersen.rs
@@ -1,0 +1,15 @@
+use starknet_crypto::{pedersen_hash, FieldElement};
+
+use crate::storage::storage::HashFunctionType;
+
+#[derive(Debug, PartialEq)]
+pub struct PedersenHash;
+
+impl HashFunctionType for PedersenHash {
+    fn hash(x: &[u8], y: &[u8]) -> Vec<u8> {
+        let x_felt = FieldElement::from_byte_slice_be(x).unwrap();
+        let y_felt = FieldElement::from_byte_slice_be(y).unwrap();
+
+        pedersen_hash(&x_felt, &y_felt).to_bytes_be().to_vec()
+    }
+}

--- a/src/execution/deprecated_syscall_handler.rs
+++ b/src/execution/deprecated_syscall_handler.rs
@@ -6,12 +6,12 @@ use cairo_vm::types::relocatable::Relocatable;
 
 use super::helper::ExecutionHelperWrapper;
 
-/// DeprecatedSyscallHandlerimplementation for execution of system calls in the StarkNet OS
+/// DeprecatedSyscallHandler implementation for execution of system calls in the StarkNet OS
 #[derive(Debug)]
 pub struct DeprecatedOsSyscallHandler {
     pub exec_wrapper: ExecutionHelperWrapper,
     pub syscall_ptr: Relocatable,
-    pub segments: ReadOnlySegments,
+    pub _segments: ReadOnlySegments,
 }
 
 /// DeprecatedOsSyscallHandler is wrapped in Rc<RefCell<_>> in order
@@ -28,13 +28,14 @@ impl DeprecatedOsSyscallHandlerWrapper {
             deprecated_syscall_handler: Rc::new(RefCell::new(DeprecatedOsSyscallHandler {
                 exec_wrapper,
                 syscall_ptr,
-                segments: ReadOnlySegments::default(),
+                _segments: ReadOnlySegments::default(),
             })),
         }
     }
     pub fn call_contract(&self, syscall_ptr: Relocatable) {
         println!("call_contract (TODO): {}", syscall_ptr);
     }
+    #[allow(unused)]
     pub fn delegate_call(&self, syscall_ptr: Relocatable) {
         println!("delegate_call (TODO): {}", syscall_ptr);
     }
@@ -95,6 +96,7 @@ impl DeprecatedOsSyscallHandlerWrapper {
         syscall_handler.syscall_ptr = syscall_ptr;
     }
 
+    #[allow(unused)]
     pub fn syscall_ptr(&self) -> Relocatable {
         self.deprecated_syscall_handler.as_ref().borrow().syscall_ptr
     }

--- a/src/execution/helper.rs
+++ b/src/execution/helper.rs
@@ -12,22 +12,12 @@ use cairo_vm::Felt252;
 use starknet_api::deprecated_contract_class::EntryPointType;
 
 use crate::config::STORED_BLOCK_HASH_BUFFER;
+use crate::crypto::pedersen::PedersenHash;
 use crate::starknet::starknet_storage::OsSingleStarknetStorage;
 use crate::storage::dict_storage::DictStorage;
-use crate::storage::storage::HashFunctionType;
 
-// This struct is a placeholder until we know exactly how to implement storage + hashing for
-// `ExecutionHelper.storage_by_address`.
-#[derive(Clone, Debug)]
-pub struct ExecutionHelperHashFunction;
-
-impl HashFunctionType for ExecutionHelperHashFunction {
-    fn hash(_x: &[u8], _y: &[u8]) -> Vec<u8> {
-        todo!()
-    }
-}
-
-type StorageByAddress = HashMap<Felt252, OsSingleStarknetStorage<DictStorage, ExecutionHelperHashFunction>>;
+// TODO: make the execution helper generic over the storage and hash function types.
+type StorageByAddress = HashMap<Felt252, OsSingleStarknetStorage<DictStorage, PedersenHash>>;
 
 /// Maintains the info for executing txns in the OS
 #[derive(Clone, Debug)]

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -775,7 +775,7 @@ pub fn cache_contract_storage(
 
     let contract_address =
         get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?.into_owned();
-    let request_ptr = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
+    let request_ptr = get_relocatable_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
     let key = vm.get_integer(&request_ptr + 1)?.into_owned();
 
     let value = execution_helper
@@ -784,10 +784,104 @@ pub fn cache_contract_storage(
 
     let ids_value = get_integer_from_var_name(vars::ids::VALUE, vm, ids_data, ap_tracking)?.into_owned();
     if ids_value != value {
-        return Err(HintError::AssertionFailed("Inconsistent storage value".to_string().into_boxed_str()));
+        return Err(HintError::AssertionFailed(
+            format!("Inconsistent storage value (expected {}, got {})", ids_value, value).into_boxed_str(),
+        ));
     }
 
     exec_scopes.insert_value(vars::scopes::VALUE, value);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use blockifier::block_context::BlockContext;
+    use cairo_vm::types::relocatable::Relocatable;
+    use num_bigint::BigUint;
+    use rstest::{fixture, rstest};
+    use starknet_api::block::BlockNumber;
+
+    use super::*;
+    use crate::crypto::pedersen::PedersenHash;
+    use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, OsSingleStarknetStorage, StorageLeaf};
+    use crate::starkware_utils::commitment_tree::base_types::Height;
+    use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
+    use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
+    use crate::storage::dict_storage::DictStorage;
+    use crate::storage::storage::FactFetchingContext;
+
+    #[fixture]
+    pub fn block_context() -> BlockContext {
+        BlockContext { block_number: BlockNumber(0), ..BlockContext::create_for_account_testing() }
+    }
+
+    #[fixture]
+    fn execution_helper(block_context: BlockContext) -> ExecutionHelperWrapper {
+        ExecutionHelperWrapper::new(vec![], &block_context)
+    }
+
+    #[fixture]
+    fn contract_address() -> Felt252 {
+        Felt252::from(300)
+    }
+
+    #[fixture]
+    fn execution_helper_with_storage(
+        execution_helper: ExecutionHelperWrapper,
+        contract_address: Felt252,
+    ) -> ExecutionHelperWrapper {
+        let storage = DictStorage::default();
+        let mut ffc = FactFetchingContext::<_, PedersenHash>::new(storage);
+
+        // Run async functions in a dedicated runtime to keep the test functions sync.
+        // Otherwise, we run into "cannot spawn a runtime from another runtime" issues.
+        let patricia_tree = execute_coroutine_threadsafe(async {
+            let mut tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
+            let modifications = vec![(BigUint::from(42u32), StorageLeaf::new(Felt252::from(8000)))];
+            let mut facts = None;
+            tree.update(&mut ffc, modifications, &mut facts).await.unwrap()
+        });
+        let os_single_starknet_storage = OsSingleStarknetStorage::new::<StorageLeaf>(patricia_tree, ffc);
+
+        {
+            let storage_by_address = &mut execution_helper.execution_helper.as_ref().borrow_mut().storage_by_address;
+            storage_by_address.insert(contract_address, os_single_starknet_storage);
+        }
+
+        execution_helper
+    }
+
+    #[rstest]
+    fn test_cache_contract_storage(execution_helper_with_storage: ExecutionHelperWrapper, contract_address: Felt252) {
+        let mut vm = VirtualMachine::new(false);
+        vm.add_memory_segment();
+        vm.add_memory_segment();
+        vm.set_fp(4);
+
+        let ap_tracking = ApTracking::new();
+        let constants = HashMap::new();
+
+        let ids_data = HashMap::from([
+            (vars::ids::REQUEST.to_string(), HintReference::new_simple(-4)),
+            (vars::ids::CONTRACT_ADDRESS.to_string(), HintReference::new_simple(-2)),
+            (vars::ids::VALUE.to_string(), HintReference::new_simple(-1)),
+        ]);
+
+        let key = Felt252::from(42);
+        // request.key is at offset 1 in the structure
+        vm.insert_value(Relocatable::from((1, 1)), key).unwrap();
+
+        insert_value_from_var_name(vars::ids::CONTRACT_ADDRESS, contract_address, &mut vm, &ids_data, &ap_tracking)
+            .unwrap();
+        insert_value_from_var_name(vars::ids::VALUE, Felt252::from(8000), &mut vm, &ids_data, &ap_tracking).unwrap();
+
+        let mut exec_scopes: ExecutionScopes = Default::default();
+        exec_scopes.insert_value(vars::scopes::EXECUTION_HELPER, execution_helper_with_storage);
+
+        // Just make sure that the hint goes through, all meaningful assertions are
+        // in the implementation of the hint
+        cache_contract_storage(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
+            .expect("Hint should not fail");
+    }
 }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -43,7 +43,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 86] = [
+static HINTS: [(&str, HintImpl); 87] = [
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
     (IS_N_GE_TWO, is_n_ge_two),
@@ -77,6 +77,7 @@ static HINTS: [(&str, HintImpl); 86] = [
     (execution::ASSERT_TRANSACTION_HASH, execution::assert_transaction_hash),
     (execution::ASSERT_TRANSACTION_HASH, execution::assert_transaction_hash),
     (execution::CHECK_IS_DEPRECATED, execution::check_is_deprecated),
+    (execution::CACHE_CONTRACT_STORAGE, execution::cache_contract_storage),
     (execution::CONTRACT_ADDRESS, execution::contract_address),
     (execution::END_TX, execution::end_tx),
     (execution::ENTER_CALL, execution::enter_call),

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-pub(crate) mod tests {
+pub mod tests {
     use std::sync::Arc;
 
     use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -5,12 +5,14 @@ pub mod scopes {
     pub const OS_INPUT: &str = "os_input";
     pub const PREIMAGE: &str = "preimage";
     pub const SYSCALL_HANDLER: &str = "syscall_handler";
+    pub const VALUE: &str = "value";
 }
 
 pub mod ids {
     pub const COMPILED_CLASS: &str = "compiled_class";
     pub const COMPILED_CLASS_FACT: &str = "compiled_class_fact";
     pub const CONTRACT_STATE_CHANGES: &str = "contract_state_changes";
+    pub const CONTRACT_ADDRESS: &str = "contract_address";
     pub const DEPRECATED_TX_INFO: &str = "deprecated_tx_info";
     pub const EDGE: &str = "edge";
     pub const FINAL_ROOT: &str = "final_root";
@@ -21,11 +23,13 @@ pub mod ids {
     pub const N: &str = "n";
     pub const NODE: &str = "node";
     pub const OS_CONTEXT: &str = "os_context";
+    pub const REQUEST: &str = "request";
     pub const SECP_P: &str = "SECP_P";
     pub const SIGNATURE_LEN: &str = "signature_len";
     pub const SIGNATURE_START: &str = "signature_start";
     pub const STATE_ENTRY: &str = "state_entry";
     pub const SYSCALL_PTR: &str = "syscall_ptr";
+    pub const VALUE: &str = "value";
     pub const Y: &str = "y";
     pub const Y_SQUARE_INT: &str = "y_square_int";
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,16 @@ use crate::io::input::StarknetOsInput;
 
 mod cairo_types;
 pub mod config;
+pub mod crypto;
 pub mod error;
 pub mod execution;
 pub mod hints;
 pub mod io;
 pub mod sharp;
+pub mod starknet;
+pub mod starkware_utils;
 pub mod state;
+pub mod storage;
 pub mod utils;
 
 pub fn run_os(

--- a/src/starknet/mod.rs
+++ b/src/starknet/mod.rs
@@ -1,0 +1,1 @@
+pub mod starknet_storage;

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+
+use cairo_vm::Felt252;
+
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::{PatriciaTree, EMPTY_NODE_HASH};
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StorageLeaf {
+    pub value: Felt252,
+}
+
+impl<S, H> Fact<S, H> for StorageLeaf
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn hash(&self) -> Vec<u8> {
+        if <StorageLeaf as LeafFact<S, H>>::is_empty(self) {
+            return EMPTY_NODE_HASH.to_vec();
+        }
+        self.serialize().unwrap()
+    }
+}
+
+impl DbObject for StorageLeaf {}
+
+impl Serializable for StorageLeaf {
+    fn prefix() -> Vec<u8> {
+        "starknet_storage_leaf".as_bytes().to_vec()
+    }
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        Ok(self.value.to_bytes_be().to_vec())
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        let value = Felt252::from_bytes_be_slice(data);
+        Ok(Self { value })
+    }
+}
+
+impl<S, H> LeafFact<S, H> for StorageLeaf
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    fn is_empty(&self) -> bool {
+        self.value == Felt252::ZERO
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OsSingleStarknetStorage<S, H>
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    previous_tree: PatriciaTree,
+    _expected_updated_root: Felt252,
+    ongoing_storage_changes: HashMap<Felt252, Felt252>,
+    ffc: FactFetchingContext<S, H>,
+}
+
+fn execute_coroutine_threadsafe<F, T>(coroutine: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    runtime.block_on(coroutine)
+}
+
+impl<S, H> OsSingleStarknetStorage<S, H>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + Sync + Send + 'static,
+{
+    pub fn read(&mut self, key: Felt252) -> Option<Felt252> {
+        let mut value = self.ongoing_storage_changes.get(&key).cloned();
+
+        if value.is_none() {
+            let value_from_storage = self.fetch_storage_leaf(key).value;
+            self.ongoing_storage_changes.insert(key, value_from_storage);
+            value = Some(value_from_storage);
+        }
+
+        value
+    }
+
+    fn fetch_storage_leaf(&mut self, key: Felt252) -> StorageLeaf {
+        let coroutine = self.previous_tree.get_leaf(&mut self.ffc, key.to_biguint());
+        let result: Result<Option<StorageLeaf>, _> = execute_coroutine_threadsafe(coroutine);
+
+        // TODO: resolve this double unwrap() somehow
+        result.unwrap().unwrap()
+    }
+}

--- a/src/starkware_utils/commitment_tree/base_types.rs
+++ b/src/starkware_utils/commitment_tree/base_types.rs
@@ -1,0 +1,78 @@
+use std::fmt::{Display, Formatter};
+use std::ops::Sub;
+
+use num_bigint::BigUint;
+
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::storage::storage::HASH_BYTES;
+
+pub type TreeIndex = BigUint;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NodePath(pub BigUint);
+
+impl Display for NodePath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serializable for NodePath {
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        let bytes = self.0.to_bytes_be();
+        let mut serialized = vec![0; HASH_BYTES - bytes.len()];
+        serialized.extend(bytes);
+        Ok(serialized)
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        Ok(Self(BigUint::from_bytes_be(data)))
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
+pub struct Length(pub u64);
+
+impl Sub<u64> for Length {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl Display for Length {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Serializable for Length {
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        if self.0 > u8::MAX as u64 {
+            return Err(SerializeError::ValueTooLong(1));
+        }
+        Ok(vec![self.0 as u8])
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        Ok(Self(data[0] as u64))
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
+pub struct Height(pub u64);
+
+impl Sub<u64> for Height {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl Display for Height {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/src/starkware_utils/commitment_tree/binary_fact_tree.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree.rs
@@ -12,14 +12,14 @@ pub trait Leaf: Clone {}
 pub type BinaryFactDict = HashMap<BigUint, Vec<BigUint>>;
 
 #[allow(async_fn_in_trait)]
-pub trait BinaryFactTree<S, H, L>: Sized
+pub trait BinaryFactTree<S, H, LF>: Sized
 where
     S: Storage,
     H: HashFunctionType,
-    L: LeafFact<S, H>,
+    LF: LeafFact<S, H>,
 {
     /// Initializes an empty BinaryFactTree of the given height.
-    async fn empty_tree(ffc: &mut FactFetchingContext<S, H>, height: Height, leaf_fact: L) -> Result<Self, TreeError>;
+    async fn empty_tree(ffc: &mut FactFetchingContext<S, H>, height: Height, leaf_fact: LF) -> Result<Self, TreeError>;
 
     /// Returns the values of the leaves whose indices are given.
     async fn get_leaves(
@@ -27,9 +27,9 @@ where
         ffc: &mut FactFetchingContext<S, H>,
         indices: &[TreeIndex],
         facts: &mut Option<BinaryFactDict>,
-    ) -> Result<HashMap<TreeIndex, L>, TreeError>;
+    ) -> Result<HashMap<TreeIndex, LF>, TreeError>;
 
-    async fn get_leaf(&self, ffc: &mut FactFetchingContext<S, H>, index: TreeIndex) -> Result<Option<L>, TreeError> {
+    async fn get_leaf(&self, ffc: &mut FactFetchingContext<S, H>, index: TreeIndex) -> Result<Option<LF>, TreeError> {
         let mut facts = None;
         let leaves = self.get_leaves(ffc, vec![index.clone()].as_ref(), &mut facts).await?;
         Ok(leaves.get(&index).cloned())
@@ -43,7 +43,7 @@ where
     async fn update(
         &mut self,
         ffc: &mut FactFetchingContext<S, H>,
-        modifications: Vec<(TreeIndex, L)>,
+        modifications: Vec<(TreeIndex, LF)>,
         facts: &mut Option<BinaryFactDict>,
     ) -> Result<Self, TreeError>;
 }

--- a/src/starkware_utils/commitment_tree/binary_fact_tree.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use num_bigint::BigUint;
+
+use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
+
+pub trait Leaf: Clone {}
+
+pub type BinaryFactDict = HashMap<BigUint, Vec<BigUint>>;
+
+#[allow(async_fn_in_trait)]
+pub trait BinaryFactTree<S, H, L>: Sized
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    /// Initializes an empty BinaryFactTree of the given height.
+    async fn empty_tree(ffc: &mut FactFetchingContext<S, H>, height: Height, leaf_fact: L) -> Result<Self, TreeError>;
+
+    /// Returns the values of the leaves whose indices are given.
+    async fn get_leaves(
+        &self,
+        ffc: &mut FactFetchingContext<S, H>,
+        indices: &[TreeIndex],
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<HashMap<TreeIndex, L>, TreeError>;
+
+    async fn get_leaf(&self, ffc: &mut FactFetchingContext<S, H>, index: TreeIndex) -> Result<Option<L>, TreeError> {
+        let mut facts = None;
+        let leaves = self.get_leaves(ffc, vec![index.clone()].as_ref(), &mut facts).await?;
+        Ok(leaves.get(&index).cloned())
+    }
+
+    /// Updates the tree with the given list of modifications, writes all the new facts to the
+    /// storage and returns a new BinaryFactTree representing the fact of the root of the new tree.
+    ///
+    /// If facts argument is not None, this dictionary is filled during traversal through the tree
+    /// by the facts of their paths from the leaves up.
+    async fn update(
+        &mut self,
+        ffc: &mut FactFetchingContext<S, H>,
+        modifications: Vec<(TreeIndex, L)>,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Self, TreeError>;
+}

--- a/src/starkware_utils/commitment_tree/binary_fact_tree.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree.rs
@@ -11,6 +11,8 @@ pub trait Leaf: Clone {}
 
 pub type BinaryFactDict = HashMap<BigUint, Vec<BigUint>>;
 
+/// An abstract base class for Merkle and Patricia-Merkle tree.
+/// An immutable binary tree backed by an immutable fact storage.
 #[allow(async_fn_in_trait)]
 pub trait BinaryFactTree<S, H, LF>: Sized
 where

--- a/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
@@ -1,0 +1,322 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+
+use futures::future::FutureExt;
+use num_bigint::BigUint;
+
+use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::merkle_tree::traverse_tree::{traverse_tree, TreeTraverser};
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage, StorageError};
+
+#[derive(Debug, PartialEq)]
+pub struct BinaryFactTreeNodeDiff<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    pub path: usize,
+    previous: LF,
+    current: LF,
+    _storage: PhantomData<S>,
+    _hash_function_type: PhantomData<H>,
+}
+
+impl<S, H, LF> BinaryFactTreeNodeDiff<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    pub fn new(path: usize, previous: LF, current: LF) -> Self {
+        Self { path, previous, current, _storage: Default::default(), _hash_function_type: Default::default() }
+    }
+}
+
+struct BinaryFactTreeTraverser<'trav, S, H, LF, N>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    N: BinaryFactTreeNode<S, H, LF> + Send,
+{
+    pub ffc: &'trav mut FactFetchingContext<S, H>,
+    pub facts: &'trav mut Option<BinaryFactDict>,
+    pub result: Vec<BinaryFactTreeNodeDiff<S, H, LF>>,
+    _n: PhantomData<N>,
+}
+
+impl<'trav, S, H, LF, N> BinaryFactTreeTraverser<'trav, S, H, LF, N>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    N: BinaryFactTreeNode<S, H, LF> + Send,
+{
+    #[allow(unused)]
+    pub fn new(ffc: &'trav mut FactFetchingContext<S, H>, facts: &'trav mut Option<BinaryFactDict>) -> Self {
+        Self { ffc, facts, result: vec![], _n: Default::default() }
+    }
+}
+
+struct BinaryFactTreeDiff<S, H, LF, N>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    N: BinaryFactTreeNode<S, H, LF> + Send,
+{
+    path: usize,
+    previous: N,
+    current: N,
+    _storage: PhantomData<S>,
+    _hash_function_type: PhantomData<H>,
+    _leaf_fact: PhantomData<LF>,
+}
+
+impl<S, H, LF, N> BinaryFactTreeDiff<S, H, LF, N>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    N: BinaryFactTreeNode<S, H, LF> + Send,
+{
+    pub fn new(path: usize, previous: N, current: N) -> Self {
+        Self {
+            path,
+            previous,
+            current,
+            _storage: Default::default(),
+            _hash_function_type: Default::default(),
+            _leaf_fact: Default::default(),
+        }
+    }
+}
+
+impl<'test, S, H, LF, N> TreeTraverser<'test, S, H, LF> for BinaryFactTreeTraverser<'test, S, H, LF, N>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Sync + Send,
+    N: BinaryFactTreeNode<S, H, LF> + Sync + 'test,
+{
+    type NodeType = BinaryFactTreeDiff<S, H, LF, N>;
+
+    async fn get_children(&mut self, node: &Self::NodeType) -> Result<Vec<Self::NodeType>, TreeError> {
+        if node.previous.is_leaf() {
+            // unwrap() on leaf_hash is guaranteed to be safe because of the check above
+            let previous = LF::get_or_fail(&self.ffc.storage, &node.previous.leaf_hash().unwrap()).await?;
+            let current = LF::get_or_fail(&self.ffc.storage, &node.current.leaf_hash().unwrap()).await?;
+            self.result.push(BinaryFactTreeNodeDiff::new(node.path, previous, current));
+            return Ok(vec![]);
+        }
+
+        let (previous_left, previous_right) = node.previous.get_children(self.ffc, self.facts).await?;
+        let (current_left, current_right) = node.current.get_children(self.ffc, self.facts).await?;
+
+        let mut children = vec![];
+        if previous_left != current_left {
+            // Shift left for the left child
+            let path = node.path << 1;
+            children.push(BinaryFactTreeDiff::new(path, previous_left, current_left));
+        }
+        if previous_right != current_right {
+            // Shift left and turn on the LSB bit for the right child
+            let path = (node.path << 1) + 1;
+            children.push(BinaryFactTreeDiff::new(path, previous_right, current_right));
+        }
+
+        Ok(children)
+    }
+}
+
+pub trait BinaryFactTreeNode<S, H, LF>: Sized + PartialEq + Sync + Send
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Sync + Send,
+{
+    fn is_leaf(&self) -> bool {
+        self.get_height_in_tree() == Height(0)
+    }
+    fn _leaf_hash(&self) -> Vec<u8>;
+    fn leaf_hash(&self) -> Option<Vec<u8>> {
+        match self.is_leaf() {
+            true => Some(self._leaf_hash()),
+            false => None,
+        }
+    }
+
+    /// Returns the height of the node in a tree.
+    fn get_height_in_tree(&self) -> Height;
+
+    fn create_leaf(hash_value: Vec<u8>) -> Self;
+
+    /// Returns the two BinaryFactTreeNode objects which are the roots of the subtrees of the
+    /// current BinaryFactTreeNode.
+    ///
+    /// If facts argument is not None, this dictionary is filled with facts read from the DB.
+    fn get_children<'a>(
+        &'a self,
+        ffc: &'a mut FactFetchingContext<S, H>,
+        facts: &'a mut Option<BinaryFactDict>,
+    ) -> impl std::future::Future<Output = Result<(Self, Self), TreeError>> + Send;
+
+    fn _get_leaves<'a>(
+        &'a self,
+        ffc: &'a mut FactFetchingContext<S, H>,
+        indices: &'a [TreeIndex],
+        facts: &'a mut Option<BinaryFactDict>,
+    ) -> impl std::future::Future<Output = Result<HashMap<TreeIndex, LF>, TreeError>> + Send {
+        async move {
+            if indices.is_empty() {
+                return Ok(HashMap::default());
+            }
+
+            if self.is_leaf() {
+                return self._get_leaf(ffc, indices).await;
+            }
+
+            self._get_binary_node_leaves(ffc, indices, facts).await
+        }
+        .boxed()
+    }
+
+    /// Returns the values of the leaves whose indices are given.
+    fn _get_binary_node_leaves<'a>(
+        &'a self,
+        ffc: &'a mut FactFetchingContext<S, H>,
+        indices: &'a [TreeIndex],
+        facts: &'a mut Option<BinaryFactDict>,
+    ) -> impl std::future::Future<Output = Result<HashMap<TreeIndex, LF>, TreeError>> + Send {
+        async move {
+            // Partition indices.
+            let height_in_tree = self.get_height_in_tree();
+            debug_assert!(height_in_tree.0 > 0, "otherwise pow() below will overflow");
+            let mid = BigUint::from(1u64) << (height_in_tree.0 - 1);
+
+            let (left_indices, right_indices) = {
+                let mut left = vec![];
+                let mut right = vec![];
+                for index in indices {
+                    if index < &mid {
+                        left.push(index.clone());
+                    } else {
+                        right.push(index.clone() - &mid);
+                    }
+                }
+                (left, right)
+            };
+
+            let (left_child, right_child) = self.get_children(ffc, facts).await?;
+
+            let left_leaves = left_child._get_leaves(ffc, &left_indices, facts).await?;
+            let right_leaves = right_child._get_leaves(ffc, &right_indices, facts).await?;
+
+            Ok(unify_binary_leaves(mid, left_leaves, right_leaves))
+        }
+        .boxed()
+    }
+
+    /// Returns a list of (key, old_fact, new_fact) that are different
+    /// between this tree and another.
+    ///
+    /// The height of the two trees must be equal.
+    ///
+    /// If the 'facts' argument is not None, this dictionary is filled with facts read from the DB.
+    async fn get_diff_between_trees(
+        self,
+        other: Self,
+        ffc: &mut FactFetchingContext<S, H>,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Vec<BinaryFactTreeNodeDiff<S, H, LF>>, TreeError> {
+        // Tree heights must be equal
+        let height = self.get_height_in_tree();
+        let other_height = other.get_height_in_tree();
+        if height != other_height {
+            return Err(TreeError::TreeHeightsMismatch(height, other_height));
+        }
+        let mut tree_traverser = BinaryFactTreeTraverser::new(ffc, facts);
+
+        let root = BinaryFactTreeDiff::new(0, self, other);
+        traverse_tree(&mut tree_traverser, root).await?;
+
+        Ok(tree_traverser.result)
+    }
+
+    fn _get_leaf<'a>(
+        &'a self,
+        ffc: &'a FactFetchingContext<S, H>,
+        _indices: &'a [TreeIndex],
+    ) -> impl std::future::Future<Output = Result<HashMap<TreeIndex, LF>, TreeError>> + Send {
+        async move {
+            // TODO: determine what to do with the assertion in the Python code
+            // assert set(indices) == {0}, f"Commitment tree indices out of range: {indices}."
+
+            let leaf = LF::get_or_fail(&ffc.storage, &self._leaf_hash()).await?;
+            Ok(HashMap::from([(BigUint::from(0u64), leaf)]))
+        }
+        .boxed()
+    }
+}
+
+pub fn unify_binary_leaves<S, H, LF>(
+    middle_index: TreeIndex,
+    left_leaves: HashMap<TreeIndex, LF>,
+    right_leaves: HashMap<TreeIndex, LF>,
+) -> HashMap<TreeIndex, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    let mut leaves = left_leaves;
+    for (index, leaf) in right_leaves {
+        leaves.insert(index + &middle_index, leaf);
+    }
+
+    leaves
+}
+
+pub async fn read_node_fact<S, H, INF>(
+    ffc: &FactFetchingContext<S, H>,
+    fact_hash: &[u8],
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<INF, StorageError>
+where
+    S: Storage,
+    H: HashFunctionType,
+    INF: InnerNodeFact<S, H>,
+{
+    let inner_node_fact = INF::get_or_fail(&ffc.storage, fact_hash).await?;
+
+    if let Some(facts) = facts {
+        let fact_key = BigUint::from_bytes_be(fact_hash);
+        facts.insert(fact_key, inner_node_fact.to_tuple());
+    }
+    Ok(inner_node_fact)
+}
+
+pub async fn write_node_fact<S, H, INF>(
+    ffc: &mut FactFetchingContext<S, H>,
+    inner_node_fact: INF,
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<Vec<u8>, StorageError>
+where
+    S: Storage,
+    H: HashFunctionType,
+    INF: InnerNodeFact<S, H>,
+{
+    let fact_hash = inner_node_fact.set_fact(ffc).await?;
+
+    if let Some(facts) = facts {
+        let fact_key = BigUint::from_bytes_be(&fact_hash);
+        facts.insert(fact_key, inner_node_fact.to_tuple());
+    }
+
+    Ok(fact_hash)
+}

--- a/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
@@ -97,12 +97,12 @@ where
     }
 }
 
-impl<'test, S, H, LF, N> TreeTraverser<'test, S, H, LF> for BinaryFactTreeTraverser<'test, S, H, LF, N>
+impl<'trav, S, H, LF, N> TreeTraverser<'trav, S, H, LF> for BinaryFactTreeTraverser<'trav, S, H, LF, N>
 where
     S: Storage + Sync + Send,
     H: HashFunctionType + Sync + Send,
     LF: LeafFact<S, H> + Sync + Send,
-    N: BinaryFactTreeNode<S, H, LF> + Sync + 'test,
+    N: BinaryFactTreeNode<S, H, LF> + Sync + 'trav,
 {
     type NodeType = BinaryFactTreeDiff<S, H, LF, N>;
 

--- a/src/starkware_utils/commitment_tree/calculation.rs
+++ b/src/starkware_utils/commitment_tree/calculation.rs
@@ -33,7 +33,7 @@ impl<LF> Default for NodeFactDict<LF> {
 /// of other calculations. Those calculations can be of type other than T.
 /// The result of the calculation can be produced when the results of the dependency calculations
 /// are given.
-pub trait Calculation<T, LF> {
+pub(crate) trait Calculation<T, LF> {
     /// Returns a list of the calculations that this calculation depends on.
     fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>>;
 
@@ -85,7 +85,7 @@ pub trait Calculation<T, LF> {
     }
 }
 
-pub struct DependencyWrapper<D, T, LF>
+pub(crate) struct DependencyWrapper<D, T, LF>
 where
     D: Calculation<T, LF>,
 {
@@ -116,7 +116,7 @@ where
     }
 }
 
-pub trait HashCalculation<LF>: Calculation<Vec<u8>, LF> {
+pub(crate) trait HashCalculation<LF>: Calculation<Vec<u8>, LF> {
     /// Method that allows cloning a Box<dyn HashCalculation> despite not being able to
     /// require Clone.
     /// Note that we could use https://github.com/dtolnay/dyn-clone for a more generic
@@ -245,7 +245,7 @@ where
 
 /// A calculation that produces a BinaryFactTreeNode. The calculation can be created from either
 /// a node or from a combination of two other calculations of the same type.
-pub trait CalculationNode<S, H, LF>: Sized + Clone
+pub(crate) trait CalculationNode<S, H, LF>: Sized + Clone
 where
     S: Storage + Sync + Send,
     H: HashFunctionType + Sync + Send,

--- a/src/starkware_utils/commitment_tree/calculation.rs
+++ b/src/starkware_utils/commitment_tree/calculation.rs
@@ -1,0 +1,276 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
+use crate::starkware_utils::commitment_tree::errors::CombineError;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::nodes::PatriciaNodeFact;
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
+
+// These enums are used instead of trait objects because the conditions to turn
+// LeafFact and InnerNodeFact into object safe traits are complex to lift: multiple places where
+// `Sized` is required, async methods, generic type parameters, etc.
+// This can be solved somehow by moving some features to `Storage`, but is out of scope for now.
+// These enums do the trick in the meantime, at the cost of a little flexibility.
+
+pub type CalculationInnerNodeFact = PatriciaNodeFact;
+
+/// A mapping between a hash and its corresponding fact. Split into two maps, one for leaves and
+/// one for inner nodes.
+pub struct NodeFactDict<LF> {
+    pub inner_nodes: HashMap<Vec<u8>, CalculationInnerNodeFact>,
+    pub leaves: HashMap<Vec<u8>, LF>,
+}
+
+impl<LF> Default for NodeFactDict<LF> {
+    fn default() -> Self {
+        Self { inner_nodes: Default::default(), leaves: Default::default() }
+    }
+}
+
+/// A calculation that can produce a result of type T. The calculation is dependent on the results
+/// of other calculations. Those calculations can be of type other than T.
+/// The result of the calculation can be produced when the results of the dependency calculations
+/// are given.
+pub trait Calculation<T, LF> {
+    /// Returns a list of the calculations that this calculation depends on.
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>>;
+
+    /// Produces the result of this calculation, given a list of results for the dependency
+    /// calculations. The order of dependency_results should match the order of the list returned by
+    /// get_dependency_calculations.
+    ///
+    /// The calculation might need to calculate hashes along the way. It will use hash_func for
+    /// that.
+    ///
+    /// Any facts generated during the calculation will be saved in fact_nodes
+    /// (using their hash as the key).
+    fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> T;
+
+    /// Same as calculate(), but return the facts.
+
+    fn calculate_new_fact_nodes(&self, dependency_results: Vec<Box<dyn Any>>) -> (T, NodeFactDict<LF>) {
+        let mut fact_nodes = NodeFactDict::default();
+        let result = self.calculate(dependency_results, &mut fact_nodes);
+
+        (result, fact_nodes)
+    }
+
+    /// Produces the result of this calculation.
+    ///
+    /// Recursively calculates the result of the dependency calculations.
+    ///
+    /// Any facts generated during the calculation will be saved in fact_nodes
+    /// (using their hash as the key).
+    fn full_calculate(&self, fact_nodes: &mut NodeFactDict<LF>) -> T {
+        let dependency_results: Vec<Box<dyn Any>> = self
+            .get_dependency_calculations()
+            .iter()
+            .map(|calculation| calculation.full_calculate(fact_nodes))
+            .collect();
+
+        self.calculate(dependency_results, fact_nodes)
+    }
+
+    /// Produces the result of this calculation. Returns the result and a dict containing generated
+    /// facts.
+    ///
+    /// Recursively calculates the result of the dependency calculations.
+    fn full_calculate_new_fact_nodes(&self) -> (T, NodeFactDict<LF>) {
+        let mut fact_nodes = NodeFactDict::default();
+        let result = self.full_calculate(&mut fact_nodes);
+
+        (result, fact_nodes)
+    }
+}
+
+pub struct DependencyWrapper<D, T, LF>
+where
+    D: Calculation<T, LF>,
+{
+    inner: D,
+    _t: PhantomData<T>,
+    _lf: PhantomData<LF>,
+}
+
+impl<D, T, LF> DependencyWrapper<D, T, LF>
+where
+    D: Calculation<T, LF>,
+{
+    pub fn new(wrapped: D) -> Self {
+        Self { inner: wrapped, _t: Default::default(), _lf: Default::default() }
+    }
+}
+impl<D, T, LF> Calculation<Box<dyn Any>, LF> for DependencyWrapper<D, T, LF>
+where
+    D: Calculation<T, LF>,
+    T: 'static,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        self.inner.get_dependency_calculations()
+    }
+
+    fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Box<dyn Any> {
+        Box::new(self.inner.calculate(dependency_results, fact_nodes))
+    }
+}
+
+pub trait HashCalculation<LF>: Calculation<Vec<u8>, LF> {
+    /// Method that allows cloning a Box<dyn HashCalculation> despite not being able to
+    /// require Clone.
+    /// Note that we could use https://github.com/dtolnay/dyn-clone for a more generic
+    /// approach.
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>>;
+}
+
+/// A calculation that contains a value and simply produces it. It doesn't depend on any other
+/// calculations.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConstantCalculation<T>
+where
+    T: Clone,
+{
+    pub value: T,
+}
+
+impl<T> ConstantCalculation<T>
+where
+    T: Clone,
+{
+    pub fn new(value: T) -> Self {
+        Self { value }
+    }
+}
+
+impl<T, LF> Calculation<T, LF> for ConstantCalculation<T>
+where
+    T: Clone,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        vec![]
+    }
+
+    fn calculate(&self, _dependency_results: Vec<Box<dyn Any>>, _fact_nodes: &mut NodeFactDict<LF>) -> T {
+        self.value.clone()
+    }
+}
+
+impl<LF> HashCalculation<LF> for ConstantCalculation<Vec<u8>> {
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
+        Box::new(self.clone())
+    }
+}
+
+// Required for the implementation of VirtualCalculationNode
+impl<LF> Calculation<Vec<u8>, LF> for Box<dyn HashCalculation<LF>> {
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        (**self).get_dependency_calculations()
+    }
+
+    fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Vec<u8> {
+        (**self).calculate(dependency_results, fact_nodes)
+    }
+}
+
+// Required for the implementation of VirtualCalculationNode
+impl<LF> HashCalculation<LF> for Box<dyn HashCalculation<LF>> {
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
+        (**self).clone_box()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct LeafFactCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    pub fact: LF,
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
+}
+
+impl<S, H, LF> LeafFactCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    pub fn new(fact: LF) -> Self {
+        Self { fact, _s: Default::default(), _h: Default::default() }
+    }
+}
+
+// A custom implementation is required to avoid requiring Clone on Storage and HashFunctionType
+// because of the PhantomData fields in the struct.
+impl<S, H, LF> Clone for LeafFactCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.fact.clone())
+    }
+}
+
+impl<S, H, LF> Calculation<Vec<u8>, LF> for LeafFactCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        vec![]
+    }
+
+    fn calculate(&self, _dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Vec<u8> {
+        let hash_result = self.fact.hash();
+        fact_nodes.leaves.insert(hash_result.clone(), self.fact.clone());
+        hash_result
+    }
+}
+
+impl<S, H, LF> HashCalculation<LF> for LeafFactCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
+        Box::new(Self { fact: self.fact.clone(), _s: Default::default(), _h: Default::default() })
+    }
+}
+
+/// A calculation that produces a BinaryFactTreeNode. The calculation can be created from either
+/// a node or from a combination of two other calculations of the same type.
+pub trait CalculationNode<S, H, LF>: Sized + Clone
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H>,
+{
+    type BinaryFactTreeNodeType;
+
+    /// Combines two calculations into a calculation that its children are the given calculations.
+    /// The function might need to read facts from the DB using FFC.
+    /// If so, and if facts argument is not None, facts is filled with the facts read.
+    async fn combine(
+        ffc: &mut FactFetchingContext<S, H>,
+        left: Self,
+        right: Self,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Self, CombineError>;
+
+    /// Creates a Calculation object from a node. It will produce the node and will have no
+    /// dependencies.
+    /// This will be used in order to create calculations that represent unchanged subtrees.
+    fn create_from_node(node: &Self::BinaryFactTreeNodeType) -> Self;
+
+    /// Creates a Calculation object from a fact. It will calculate the fact's hash and produce a
+    /// node with the hash result. It will have no dependencies.
+    /// This will be used in order to create calculations that represent changed leaves.
+    fn create_from_fact(fact: LF) -> Self;
+}

--- a/src/starkware_utils/commitment_tree/calculation.rs
+++ b/src/starkware_utils/commitment_tree/calculation.rs
@@ -188,8 +188,7 @@ where
     LF: LeafFact<S, H>,
 {
     pub fact: LF,
-    _s: PhantomData<S>,
-    _h: PhantomData<H>,
+    _phantom: PhantomData<(S, H)>,
 }
 
 impl<S, H, LF> LeafFactCalculation<S, H, LF>
@@ -199,7 +198,7 @@ where
     LF: LeafFact<S, H>,
 {
     pub fn new(fact: LF) -> Self {
-        Self { fact, _s: Default::default(), _h: Default::default() }
+        Self { fact, _phantom: Default::default() }
     }
 }
 
@@ -240,7 +239,7 @@ where
     LF: LeafFact<S, H> + 'static,
 {
     fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
-        Box::new(Self { fact: self.fact.clone(), _s: Default::default(), _h: Default::default() })
+        Box::new(Self { fact: self.fact.clone(), _phantom: Default::default() })
     }
 }
 

--- a/src/starkware_utils/commitment_tree/errors.rs
+++ b/src/starkware_utils/commitment_tree/errors.rs
@@ -1,0 +1,44 @@
+use crate::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath};
+use crate::storage::storage::StorageError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CombineError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+
+    #[error("Only trees of same height can be combined; got left={0} right={1}")]
+    TreeHeightsDiffer(Height, Height),
+
+    #[error("Combining to virtual edge node can only be done on one empty and one non-empty node")]
+    CannotCombineToVirtualEdgeNode,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum UpdateTreeError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+
+    #[error(transparent)]
+    Combine(#[from] CombineError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum TreeError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+
+    #[error(transparent)]
+    UpdateTree(#[from] UpdateTreeError),
+
+    #[error("Got mismatching heights while comparing trees: {0} vs {1}")]
+    TreeHeightsMismatch(Height, Height),
+
+    #[error("Did not expect a leaf node")]
+    IsLeaf,
+
+    #[error("Did not expect an empty node")]
+    IsEmpty,
+
+    #[error("Edge path ({0}) must be at most of length {1}")]
+    InvalidEdgePath(NodePath, Length),
+}

--- a/src/starkware_utils/commitment_tree/inner_node_fact.rs
+++ b/src/starkware_utils/commitment_tree/inner_node_fact.rs
@@ -1,0 +1,11 @@
+use num_bigint::BigUint;
+
+use crate::storage::storage::{Fact, HashFunctionType, Storage};
+
+pub trait InnerNodeFact<S, H>: Fact<S, H>
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    fn to_tuple(&self) -> Vec<BigUint>;
+}

--- a/src/starkware_utils/commitment_tree/leaf_fact.rs
+++ b/src/starkware_utils/commitment_tree/leaf_fact.rs
@@ -1,0 +1,5 @@
+use crate::storage::storage::{Fact, HashFunctionType, Storage};
+
+pub trait LeafFact<S: Storage, H: HashFunctionType>: Fact<S, H> + Sync + Sized + Clone {
+    fn is_empty(&self) -> bool;
+}

--- a/src/starkware_utils/commitment_tree/merkle_tree/mod.rs
+++ b/src/starkware_utils/commitment_tree/merkle_tree/mod.rs
@@ -1,0 +1,1 @@
+pub mod traverse_tree;

--- a/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
+++ b/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
@@ -1,0 +1,48 @@
+use std::collections::VecDeque;
+
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::storage::storage::{HashFunctionType, Storage};
+
+pub trait TreeTraverser<'test, S, H, L>
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    type NodeType;
+
+    async fn get_children(&mut self, node: &Self::NodeType) -> Result<Vec<Self::NodeType>, TreeError>;
+}
+
+/// Traverses a tree as follows:
+/// 1. Starts by calling get_children_callback(root). This function should return the children of
+/// root in the tree that you want to visit.
+/// 2. Call get_children_callback() on each of the children to get more nodes, and repeat.
+///
+/// The order of execution is not guaranteed, except that it is more similar to DFS than BFS in
+/// terms of memory consumption.
+pub async fn traverse_tree<'tree, S, H, L, N, TT>(traverser: &mut TT, root: N) -> Result<(), TreeError>
+where
+    S: Storage + Sync,
+    H: HashFunctionType + Sync,
+    L: LeafFact<S, H>,
+    N: Sync,
+    TT: TreeTraverser<'tree, S, H, L, NodeType = N> + Send,
+{
+    // The Python implementation (https://github.com/starkware-libs/cairo-lang/blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/starkware_utils/commitment_tree/merkle_tree/traverse_tree.py#L16)
+    // uses an async priority queue that ultimately should look like depth-first search (DFS).
+    // For now, we implement it as a single-thread DFS out of simplicity.
+
+    let mut stack = VecDeque::new();
+    stack.push_back(root);
+
+    while let Some(node) = stack.pop_back() {
+        let children = traverser.get_children(&node).await?;
+        for child in children {
+            stack.push_back(child);
+        }
+    }
+
+    Ok(())
+}

--- a/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
+++ b/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
@@ -34,13 +34,13 @@ where
     // uses an async priority queue that ultimately should look like depth-first search (DFS).
     // For now, we implement it as a single-thread DFS out of simplicity.
 
-    let mut stack = VecDeque::new();
-    stack.push_back(root);
+    let mut queue = VecDeque::new();
+    queue.push_back(root);
 
-    while let Some(node) = stack.pop_front() {
+    while let Some(node) = queue.pop_front() {
         let children = traverser.get_children(&node).await?;
         for child in children {
-            stack.push_back(child);
+            queue.push_back(child);
         }
     }
 

--- a/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
+++ b/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
@@ -37,7 +37,7 @@ where
     let mut stack = VecDeque::new();
     stack.push_back(root);
 
-    while let Some(node) = stack.pop_back() {
+    while let Some(node) = stack.pop_front() {
         let children = traverser.get_children(&node).await?;
         for child in children {
             stack.push_back(child);

--- a/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
+++ b/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
@@ -4,11 +4,11 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::storage::storage::{HashFunctionType, Storage};
 
-pub trait TreeTraverser<'test, S, H, L>
+pub trait TreeTraverser<'test, S, H, LF>
 where
     S: Storage,
     H: HashFunctionType,
-    L: LeafFact<S, H>,
+    LF: LeafFact<S, H>,
 {
     type NodeType;
 
@@ -22,13 +22,13 @@ where
 ///
 /// The order of execution is not guaranteed, except that it is more similar to DFS than BFS in
 /// terms of memory consumption.
-pub async fn traverse_tree<'tree, S, H, L, N, TT>(traverser: &mut TT, root: N) -> Result<(), TreeError>
+pub async fn traverse_tree<'tree, S, H, LF, N, TT>(traverser: &mut TT, root: N) -> Result<(), TreeError>
 where
     S: Storage + Sync,
     H: HashFunctionType + Sync,
-    L: LeafFact<S, H>,
+    LF: LeafFact<S, H>,
     N: Sync,
-    TT: TreeTraverser<'tree, S, H, L, NodeType = N> + Send,
+    TT: TreeTraverser<'tree, S, H, LF, NodeType = N> + Send,
 {
     // The Python implementation (https://github.com/starkware-libs/cairo-lang/blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/starkware_utils/commitment_tree/merkle_tree/traverse_tree.py#L16)
     // uses an async priority queue that ultimately should look like depth-first search (DFS).

--- a/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
+++ b/src/starkware_utils/commitment_tree/merkle_tree/traverse_tree.rs
@@ -4,7 +4,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::storage::storage::{HashFunctionType, Storage};
 
-pub trait TreeTraverser<'test, S, H, LF>
+pub trait TreeTraverser<'trav, S, H, LF>
 where
     S: Storage,
     H: HashFunctionType,

--- a/src/starkware_utils/commitment_tree/mod.rs
+++ b/src/starkware_utils/commitment_tree/mod.rs
@@ -1,0 +1,10 @@
+mod base_types;
+pub mod binary_fact_tree;
+mod binary_fact_tree_node;
+mod calculation;
+pub mod errors;
+mod inner_node_fact;
+pub mod leaf_fact;
+mod merkle_tree;
+pub mod patricia_tree;
+mod update_tree;

--- a/src/starkware_utils/commitment_tree/mod.rs
+++ b/src/starkware_utils/commitment_tree/mod.rs
@@ -1,4 +1,4 @@
-mod base_types;
+pub mod base_types;
 pub mod binary_fact_tree;
 mod binary_fact_tree_node;
 mod calculation;

--- a/src/starkware_utils/commitment_tree/patricia_tree/mod.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/mod.rs
@@ -1,0 +1,6 @@
+pub mod nodes;
+#[allow(clippy::module_inception)] // Use the same name as the parent module
+pub mod patricia_tree;
+pub mod patricia_utils;
+pub mod virtual_calculation_node;
+pub mod virtual_patricia_node;

--- a/src/starkware_utils/commitment_tree/patricia_tree/nodes.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/nodes.rs
@@ -1,0 +1,291 @@
+use cairo_vm::Felt252;
+use num_bigint::BigUint;
+
+use crate::starkware_utils::commitment_tree::base_types::{Length, NodePath};
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage, HASH_BYTES};
+
+const PATRICIA_NODE_PREFIX: &[u8] = "patricia_node".as_bytes();
+
+/// Represents the root of an empty (all leaves are 0) full binary tree.
+pub struct EmptyNodeFact;
+
+impl EmptyNodeFact {
+    const PREIMAGE_LENGTH: usize = 0;
+}
+
+impl<S, H> InnerNodeFact<S, H> for EmptyNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn to_tuple(&self) -> Vec<BigUint> {
+        vec![]
+    }
+}
+
+impl<S, H> Fact<S, H> for EmptyNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn hash(&self) -> Vec<u8> {
+        EMPTY_NODE_HASH.to_vec()
+    }
+}
+
+impl DbObject for EmptyNodeFact {}
+
+impl Serializable for EmptyNodeFact {
+    fn prefix() -> Vec<u8> {
+        PATRICIA_NODE_PREFIX.to_vec()
+    }
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        Ok("".as_bytes().to_vec())
+    }
+
+    fn deserialize(_data: &[u8]) -> Result<Self, DeserializeError> {
+        Ok(Self {})
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum BinaryNodeError {
+    #[allow(unused)]
+    #[error("Left node hash is empty hash")]
+    LeftNodeIsEmpty,
+    #[allow(unused)]
+    #[error("Right node hash is empty hash")]
+    RightNodeIsEmpty,
+}
+
+/// A binary node in a Patricia-Merkle tree; this is a regular Merkle node.
+pub struct BinaryNodeFact {
+    pub left_node: Vec<u8>,
+    pub right_node: Vec<u8>,
+}
+
+impl BinaryNodeFact {
+    const PREIMAGE_LENGTH: usize = 2 * HASH_BYTES;
+
+    #[allow(unused)]
+    pub fn new(left_node: Vec<u8>, right_node: Vec<u8>) -> Result<Self, BinaryNodeError> {
+        if left_node == EMPTY_NODE_HASH {
+            return Err(BinaryNodeError::LeftNodeIsEmpty);
+        }
+        if right_node == EMPTY_NODE_HASH {
+            return Err(BinaryNodeError::RightNodeIsEmpty);
+        }
+
+        Ok(Self { left_node, right_node })
+    }
+}
+
+impl<S, H> InnerNodeFact<S, H> for BinaryNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn to_tuple(&self) -> Vec<BigUint> {
+        vec![BigUint::from_bytes_be(&self.left_node), BigUint::from_bytes_be(&self.right_node)]
+    }
+}
+
+impl<S, H> Fact<S, H> for BinaryNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn hash(&self) -> Vec<u8> {
+        H::hash(&self.left_node, &self.right_node)
+    }
+}
+
+impl DbObject for BinaryNodeFact {}
+
+impl Serializable for BinaryNodeFact {
+    fn prefix() -> Vec<u8> {
+        PATRICIA_NODE_PREFIX.to_vec()
+    }
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        let serialized = self.left_node.iter().cloned().chain(self.right_node.iter().cloned()).collect();
+        Ok(serialized)
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        let expected_len = 2 * HASH_BYTES;
+        if data.len() != 2 * HASH_BYTES {
+            return Err(DeserializeError::LengthMismatch(expected_len, data.len()));
+        }
+
+        let mut hashes = data.chunks(HASH_BYTES);
+        // Unwrapping is safe thanks to the length check above
+        let left_node = hashes.next().unwrap().to_vec();
+        let right_node = hashes.next().unwrap().to_vec();
+        Ok(Self { left_node, right_node })
+    }
+}
+
+/// A node in a Patricia-Merkle tree that represents the edge to a subtree that contains data
+/// with value != 0.
+/// Represented by three values embedding this information (elaborated below).
+/// Note that the bottom_node cannot be an edge node itself (otherwise, they would have both been
+/// fused to a bigger edge node).
+pub struct EdgeNodeFact {
+    /// The root of the subtree containing data with value != 0.
+    pub bottom_node: Vec<u8>,
+    /// The binary representation of the leaf index in the subtree that this node is root of.
+    pub edge_path: NodePath,
+    /// The height of the edge node (the length of the path to the leaf).
+    pub edge_length: Length,
+}
+
+impl EdgeNodeFact {
+    const PREIMAGE_LENGTH: usize = 2 * HASH_BYTES + 1;
+
+    pub fn new(bottom_node: Vec<u8>, path: NodePath, length: Length) -> Result<Self, TreeError> {
+        verify_path_value(&path, length)?;
+        Ok(Self { bottom_node, edge_path: path, edge_length: length })
+    }
+
+    pub fn new_unchecked(bottom_node: Vec<u8>, path: NodePath, length: Length) -> Self {
+        debug_assert!(verify_path_value(&path, length).is_ok());
+        Self { bottom_node, edge_path: path, edge_length: length }
+    }
+}
+
+impl<S, H> InnerNodeFact<S, H> for EdgeNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn to_tuple(&self) -> Vec<BigUint> {
+        vec![BigUint::from(self.edge_length.0), self.edge_path.0.clone(), BigUint::from_bytes_be(&self.bottom_node)]
+    }
+}
+
+impl<S, H> Fact<S, H> for EdgeNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn hash(&self) -> Vec<u8> {
+        hash_edge::<H>(&self.bottom_node, self.edge_path.clone(), self.edge_length)
+    }
+}
+
+impl DbObject for EdgeNodeFact {}
+
+impl Serializable for EdgeNodeFact {
+    fn prefix() -> Vec<u8> {
+        PATRICIA_NODE_PREFIX.to_vec()
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        serialize_edge(&self.bottom_node, self.edge_path.clone(), self.edge_length)
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        let expected_len = 2 * HASH_BYTES + 1;
+        if data.len() != expected_len {
+            return Err(DeserializeError::LengthMismatch(expected_len, data.len()));
+        }
+
+        // Unwrapping is safe thanks to the length check above
+        let mut data_iter = data.chunks(HASH_BYTES);
+        let bottom = data_iter.next().unwrap();
+        let path = NodePath::deserialize(data_iter.next().unwrap())?;
+        let length = Length::deserialize(data_iter.next().unwrap())?;
+
+        Ok(Self::new_unchecked(bottom.to_vec(), path, length))
+    }
+}
+
+pub fn verify_path_value(path: &NodePath, length: Length) -> Result<(), TreeError> {
+    // TODO: NodePath probably needs to be defined as BigUint
+    if path.0 >= (BigUint::from(1u64) << length.0) {
+        return Err(TreeError::InvalidEdgePath(path.clone(), length));
+    }
+    Ok(())
+}
+
+fn serialize_edge(bottom: &[u8], path: NodePath, length: Length) -> Result<Vec<u8>, SerializeError> {
+    let path_bytes = path.serialize()?;
+    let length_bytes = length.serialize()?;
+
+    let serialized = [bottom, &path_bytes, &length_bytes].iter().flat_map(|v| v.iter().cloned()).collect();
+    Ok(serialized)
+}
+
+fn hash_edge<H: HashFunctionType>(bottom: &[u8], path: NodePath, length: Length) -> Vec<u8> {
+    let bottom_path_hash = H::hash(bottom, path.0.to_bytes_be().as_ref());
+
+    // Warning: this may be too small?
+    let hash_value = Felt252::from_bytes_be_slice(&bottom_path_hash) + length.0;
+    hash_value.to_bytes_be().to_vec()
+}
+
+pub enum PatriciaNodeFact {
+    Empty(EmptyNodeFact),
+    Binary(BinaryNodeFact),
+    Edge(EdgeNodeFact),
+}
+
+impl Serializable for PatriciaNodeFact {
+    fn prefix() -> Vec<u8> {
+        PATRICIA_NODE_PREFIX.to_vec()
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        match self {
+            Self::Empty(empty) => empty.serialize(),
+            Self::Binary(binary) => binary.serialize(),
+            Self::Edge(edge) => edge.serialize(),
+        }
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        let node = match data.len() {
+            EmptyNodeFact::PREIMAGE_LENGTH => Self::Empty(EmptyNodeFact::deserialize(data)?),
+            BinaryNodeFact::PREIMAGE_LENGTH => Self::Binary(BinaryNodeFact::deserialize(data)?),
+            EdgeNodeFact::PREIMAGE_LENGTH => Self::Edge(EdgeNodeFact::deserialize(data)?),
+            other => {
+                return Err(DeserializeError::NoVariantWithLength(other));
+            }
+        };
+        Ok(node)
+    }
+}
+
+impl<S, H> Fact<S, H> for PatriciaNodeFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn hash(&self) -> Vec<u8> {
+        match self {
+            Self::Empty(empty) => <EmptyNodeFact as Fact<S, H>>::hash(empty),
+            Self::Binary(binary) => <BinaryNodeFact as Fact<S, H>>::hash(binary),
+            Self::Edge(edge) => <EdgeNodeFact as Fact<S, H>>::hash(edge),
+        }
+    }
+}
+
+impl DbObject for PatriciaNodeFact {}
+
+impl<S, H> InnerNodeFact<S, H> for PatriciaNodeFact
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    fn to_tuple(&self) -> Vec<BigUint> {
+        match self {
+            Self::Empty(empty) => <EmptyNodeFact as InnerNodeFact<S, H>>::to_tuple(empty),
+            Self::Binary(binary) => <BinaryNodeFact as InnerNodeFact<S, H>>::to_tuple(binary),
+            Self::Edge(edge) => <EdgeNodeFact as InnerNodeFact<S, H>>::to_tuple(edge),
+        }
+    }
+}

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
+use crate::starkware_utils::commitment_tree::binary_fact_tree::{BinaryFactDict, BinaryFactTree};
+use crate::starkware_utils::commitment_tree::binary_fact_tree_node::BinaryFactTreeNode;
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::virtual_calculation_node::VirtualCalculationNode;
+use crate::starkware_utils::commitment_tree::patricia_tree::virtual_patricia_node::VirtualPatriciaNode;
+use crate::starkware_utils::commitment_tree::update_tree::update_tree;
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
+
+pub const EMPTY_NODE_HASH: [u8; 32] = [0; 32];
+
+#[derive(Clone, Debug)]
+pub struct PatriciaTree {
+    pub root: Vec<u8>,
+    pub height: Height,
+}
+
+impl<S, H, L> BinaryFactTree<S, H, L> for PatriciaTree
+where
+    S: Storage + 'static,
+    H: HashFunctionType + Sync + Send + 'static,
+    L: LeafFact<S, H> + Send + 'static,
+{
+    async fn empty_tree(ffc: &mut FactFetchingContext<S, H>, height: Height, leaf_fact: L) -> Result<Self, TreeError> {
+        let empty_leaf_fact_hash = leaf_fact.set_fact(ffc).await?;
+        Ok(Self { root: empty_leaf_fact_hash, height })
+    }
+
+    async fn get_leaves(
+        &self,
+        ffc: &mut FactFetchingContext<S, H>,
+        indices: &[TreeIndex],
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<HashMap<TreeIndex, L>, TreeError> {
+        let virtual_root_node = VirtualPatriciaNode::from_hash(self.root.clone(), self.height);
+        virtual_root_node._get_leaves(ffc, indices, facts).await
+    }
+
+    async fn update(
+        &mut self,
+        ffc: &mut FactFetchingContext<S, H>,
+        modifications: Vec<(TreeIndex, L)>,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Self, TreeError> {
+        let virtual_root_node = VirtualPatriciaNode::from_hash(self.root.clone(), self.height);
+        let updated_virtual_root_node = update_tree::<
+            S,
+            H,
+            L,
+            VirtualPatriciaNode<S, H, L>,
+            VirtualCalculationNode<S, H, L>,
+        >(virtual_root_node, ffc, modifications, facts)
+        .await?;
+
+        // In case root is an edge node, its fact must be explicitly written to DB.
+        let root_hash = updated_virtual_root_node.commit(ffc, facts).await?;
+        Ok(Self { root: root_hash, height: updated_virtual_root_node.height })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::{fixture, rstest};
+
+    use super::*;
+    use crate::crypto::pedersen::PedersenHash;
+    use crate::storage::dict_storage::DictStorage;
+    use crate::storage::storage_utils::SimpleLeafFact;
+
+    #[fixture]
+    fn storage() -> impl Storage {
+        DictStorage::default()
+    }
+
+    #[fixture]
+    fn hash_function() -> impl HashFunctionType {
+        PedersenHash
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_empty_tree() {
+        let height = Height(10);
+        let mut ffc = FactFetchingContext::<_, PedersenHash>::new(DictStorage::default());
+
+        let leaf_node = SimpleLeafFact::empty();
+
+        let patricia_tree = PatriciaTree::empty_tree(&mut ffc, height, leaf_node).await.unwrap();
+        assert_eq!(patricia_tree.root, EMPTY_NODE_HASH);
+        assert_eq!(patricia_tree.height, height);
+    }
+}

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -18,13 +18,13 @@ pub struct PatriciaTree {
     pub height: Height,
 }
 
-impl<S, H, L> BinaryFactTree<S, H, L> for PatriciaTree
+impl<S, H, LF> BinaryFactTree<S, H, LF> for PatriciaTree
 where
     S: Storage + 'static,
     H: HashFunctionType + Sync + Send + 'static,
-    L: LeafFact<S, H> + Send + 'static,
+    LF: LeafFact<S, H> + Send + 'static,
 {
-    async fn empty_tree(ffc: &mut FactFetchingContext<S, H>, height: Height, leaf_fact: L) -> Result<Self, TreeError> {
+    async fn empty_tree(ffc: &mut FactFetchingContext<S, H>, height: Height, leaf_fact: LF) -> Result<Self, TreeError> {
         let empty_leaf_fact_hash = leaf_fact.set_fact(ffc).await?;
         Ok(Self { root: empty_leaf_fact_hash, height })
     }
@@ -34,7 +34,7 @@ where
         ffc: &mut FactFetchingContext<S, H>,
         indices: &[TreeIndex],
         facts: &mut Option<BinaryFactDict>,
-    ) -> Result<HashMap<TreeIndex, L>, TreeError> {
+    ) -> Result<HashMap<TreeIndex, LF>, TreeError> {
         let virtual_root_node = VirtualPatriciaNode::from_hash(self.root.clone(), self.height);
         virtual_root_node._get_leaves(ffc, indices, facts).await
     }
@@ -42,16 +42,16 @@ where
     async fn update(
         &mut self,
         ffc: &mut FactFetchingContext<S, H>,
-        modifications: Vec<(TreeIndex, L)>,
+        modifications: Vec<(TreeIndex, LF)>,
         facts: &mut Option<BinaryFactDict>,
     ) -> Result<Self, TreeError> {
         let virtual_root_node = VirtualPatriciaNode::from_hash(self.root.clone(), self.height);
         let updated_virtual_root_node = update_tree::<
             S,
             H,
-            L,
-            VirtualPatriciaNode<S, H, L>,
-            VirtualCalculationNode<S, H, L>,
+            LF,
+            VirtualPatriciaNode<S, H, LF>,
+            VirtualCalculationNode<S, H, LF>,
         >(virtual_root_node, ffc, modifications, facts)
         .await?;
 

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -63,33 +63,131 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashSet, VecDeque};
+
+    use cairo_vm::Felt252;
+    use num_bigint::BigUint;
+    use num_traits::ToPrimitive;
+    use rand::seq::IteratorRandom;
+    use rand::Rng;
     use rstest::{fixture, rstest};
 
     use super::*;
     use crate::crypto::pedersen::PedersenHash;
+    use crate::starkware_utils::commitment_tree::base_types::{Length, NodePath};
+    use crate::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
     use crate::storage::dict_storage::DictStorage;
+    use crate::storage::storage::Fact;
     use crate::storage::storage_utils::SimpleLeafFact;
 
-    #[fixture]
-    fn storage() -> impl Storage {
-        DictStorage::default()
-    }
+    type StorageType = DictStorage;
+    type HashFunction = PedersenHash;
+    type FFC = FactFetchingContext<StorageType, HashFunction>;
 
     #[fixture]
-    fn hash_function() -> impl HashFunctionType {
-        PedersenHash
+    fn ffc() -> FFC {
+        FactFetchingContext::<_, HashFunction>::new(DictStorage::default())
+    }
+
+    /// Binary node facts are simply the hash of the two children; edge node facts are the hash of
+    /// the bottom node fact and the path, plus the path length.
+    fn hash_preimage(preimage: &[BigUint]) -> BigUint {
+        let hash = if preimage.len() == 2 {
+            let node_fact =
+                BinaryNodeFact::new(preimage[0].to_bytes_be().to_vec(), preimage[1].to_bytes_be().to_vec()).unwrap();
+            <BinaryNodeFact as Fact<StorageType, HashFunction>>::hash(&node_fact)
+        } else {
+            let length = Length(preimage[0].to_u64().unwrap());
+            let path = NodePath(preimage[1].clone());
+            let bottom = preimage[2].to_bytes_be().to_vec();
+            let node_fact = EdgeNodeFact::new(bottom, path, length).unwrap();
+            <EdgeNodeFact as Fact<StorageType, HashFunction>>::hash(&node_fact)
+        };
+
+        BigUint::from_bytes_be(&hash)
+    }
+
+    /// Given a list of leaves and a collection of preimages, verifies that the preimages suffice to
+    /// descend to all leaves.
+    fn verify_leaves_are_reachable_from_root(root: BigUint, leaf_hashes: &[BigUint], preimages: BinaryFactDict) {
+        let mut leaves_reached = HashSet::<BigUint>::new();
+        let mut facts_to_open = VecDeque::new();
+        facts_to_open.push_back(root);
+
+        while let Some(next_fact) = facts_to_open.pop_front() {
+            if leaf_hashes.contains(&next_fact) {
+                leaves_reached.insert(next_fact);
+                continue;
+            }
+
+            let preimage = preimages.get(&next_fact).unwrap();
+            if preimage.len() == 3 {
+                // Edge node. Next fact is the third entry.
+                facts_to_open.push_back(preimage[2].clone());
+            } else {
+                let left_child = &preimage[0];
+                let right_child = &preimage[1];
+                facts_to_open.push_back(left_child.clone());
+                facts_to_open.push_back(right_child.clone());
+            }
+        }
+
+        let leaves_to_reach: HashSet<_> = leaf_hashes.iter().cloned().collect();
+        assert_eq!(leaves_reached, leaves_to_reach);
     }
 
     #[rstest]
     #[tokio::test]
-    async fn test_empty_tree() {
+    async fn test_empty_tree(mut ffc: FFC) {
         let height = Height(10);
-        let mut ffc = FactFetchingContext::<_, PedersenHash>::new(DictStorage::default());
 
         let leaf_node = SimpleLeafFact::empty();
 
         let patricia_tree = PatriciaTree::empty_tree(&mut ffc, height, leaf_node).await.unwrap();
         assert_eq!(patricia_tree.root, EMPTY_NODE_HASH);
         assert_eq!(patricia_tree.height, height);
+    }
+
+    /// Builds a Patricia tree using update(), and tests that the facts stored suffice to decommit.
+    #[rstest]
+    #[case::full_tree_small(Height(2), 1 << 2)]
+    #[case::full_tree_large(Height(10), 1 << 10)]
+    #[case::sparse_tree(Height(10), 5)]
+    #[case::dense_tree(Height(10), 1 << 9)]
+    #[tokio::test]
+    async fn test_update_and_decommit(mut ffc: FFC, #[case] height: Height, #[case] n_leaves: usize) {
+        let mut rng = rand::thread_rng();
+
+        let mut tree = PatriciaTree::empty_tree(&mut ffc, height, SimpleLeafFact::empty()).await.unwrap();
+
+        // Create some random modifications, store the facts and update the tree.
+        // Note that leaves with value 0 are not modifications (hence, range(1, ...)).
+        let leaves: Vec<_> =
+            (0..n_leaves).map(|_| rng.gen_range(1..=1000u64)).map(|x| SimpleLeafFact::new(Felt252::from(x))).collect();
+
+        let mut leaf_hashes_bytes = vec![];
+        for leaf_fact in leaves.iter() {
+            let leaf_hash = leaf_fact.set_fact(&mut ffc).await.unwrap();
+            leaf_hashes_bytes.push(leaf_hash);
+        }
+        let leaf_hashes: Vec<_> =
+            leaf_hashes_bytes.iter().map(|leaf_hash_bytes| BigUint::from_bytes_be(leaf_hash_bytes)).collect();
+        let indices: Vec<_> =
+            (0u64..1 << height.0).choose_multiple(&mut rng, n_leaves).into_iter().map(BigUint::from).collect();
+        let modifications: Vec<_> = indices.iter().cloned().zip(leaves.iter().cloned()).collect();
+        let mut preimages = Some(BinaryFactDict::new());
+
+        let tree = tree.update(&mut ffc, modifications, &mut preimages).await.unwrap();
+        let root = BigUint::from_bytes_be(&tree.root);
+
+        // Sanity check - the hash of the values should be the keys.
+        let preimages = preimages.unwrap();
+        for (fact, preimage) in preimages.iter() {
+            let preimage_hash = hash_preimage(preimage);
+            assert_eq!(fact, &preimage_hash);
+        }
+
+        // Verify that the root can be reached using the preimages, from every leaf.
+        verify_leaves_are_reachable_from_root(root, &leaf_hashes, preimages);
     }
 }

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
@@ -23,7 +23,7 @@ use num_traits::ToPrimitive;
 
 use crate::storage::storage::HashFunctionType;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Node {
     bottom: Felt252,
     path: Felt252,
@@ -36,8 +36,7 @@ impl Node {
     }
 
     fn is_empty(&self) -> bool {
-        let empty_node = Self::empty();
-        self.bottom == empty_node.bottom && self.path == empty_node.path && self.length == empty_node.length
+        self == &Self::empty()
     }
 }
 

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
@@ -1,0 +1,173 @@
+//! Starkware's Merkle-Patricia tree is based on this representation:
+//! Each node can be one of these:
+//! 1. Empty, with value of 0.
+//! 2. Edge node, with value of hash(bottom_node, edge_path) + edge_length.
+//! 3. Binary node, with value of hash(left, right).
+//!
+//! An edge node represents a path in a maximal subtree with a single non-empty node.
+//! for example, the following is encoded
+//! #    0
+//! #  0   0
+//! # 0 h 0 0
+//! as
+//! (2, 1, h)
+//!
+//! If that maximal subtree is trivial, it is encoded as (0, 0, h) where h is the value of
+//! the leaf or the hash corresponding to that subtree.
+#![cfg(test)]
+
+use std::collections::HashMap;
+
+use cairo_vm::Felt252;
+use num_traits::ToPrimitive;
+
+use crate::storage::storage::HashFunctionType;
+
+#[derive(Clone, Debug)]
+pub struct Node {
+    bottom: Felt252,
+    path: Felt252,
+    length: Felt252,
+}
+
+impl Node {
+    fn empty() -> Self {
+        Self { bottom: Felt252::ZERO, path: Felt252::ZERO, length: Felt252::ZERO }
+    }
+
+    fn is_empty(&self) -> bool {
+        let empty_node = Self::empty();
+        self.bottom == empty_node.bottom && self.path == empty_node.path && self.length == empty_node.length
+    }
+}
+
+fn hash_node<H: HashFunctionType>(node: Node, preimage: &mut HashMap<Felt252, Node>) -> Felt252 {
+    if node.length == Felt252::ZERO {
+        return node.bottom;
+    }
+
+    let result = H::hash_felts(node.bottom, node.path) + node.length;
+    preimage.insert(result, node);
+    result
+}
+
+/// Computes the root of a Merkle-Patricia tree from the list of all the leaves.
+/// This function is not efficient, and should only be used for tests.
+/// Returns:
+/// * The hash of the root.
+/// * A preimage dict from hash to either (left, right) for binary nodes, or (edge_length,
+///   edge_path, bottom_node) for edge nodes.
+/// * node_at_path - a dictionary from height, path to a node encoding triplet.
+pub fn compute_patricia_from_leaves_for_test<H: HashFunctionType>(
+    leaves: &[Felt252],
+) -> (Felt252, HashMap<Felt252, Node>, HashMap<(Felt252, Felt252), Node>)
+where
+{
+    assert!(leaves.len().is_power_of_two());
+
+    let mut preimage: HashMap<Felt252, Node> = HashMap::new();
+    let mut node_at_path: HashMap<(Felt252, Felt252), Node> = HashMap::new();
+
+    // All the nodes are stored as edge nodes representation of non-negative length:
+    // (length, path, hash of bottom node).
+    let mut layer: Vec<Node> =
+        leaves.iter().copied().map(|leaf| Node { bottom: leaf, path: Felt252::ZERO, length: Felt252::ZERO }).collect();
+    let mut height = Felt252::ZERO;
+
+    while layer.len() > 1 {
+        let values: Vec<_> = layer.iter().map(|node| node.bottom.to_biguint()).collect();
+        println!("{:?}", values);
+        for (i, x) in layer.iter().enumerate() {
+            node_at_path.insert((height, Felt252::from(i)), x.clone());
+        }
+
+        let mut next_layer = vec![];
+        for chunk in layer.chunks_exact(2) {
+            let left = &chunk[0];
+            let right = &chunk[1];
+
+            let next_node = if left.is_empty() && right.is_empty() {
+                Node::empty()
+            } else if left.is_empty() {
+                Node {
+                    bottom: right.bottom,
+                    path: right.path + Felt252::from(1 << right.length.to_u64().unwrap()),
+                    length: right.length + 1,
+                }
+            } else if right.is_empty() {
+                Node { bottom: left.bottom, path: left.path, length: left.length + 1 }
+            } else {
+                Node {
+                    bottom: H::hash_felts(
+                        hash_node::<H>(left.clone(), &mut preimage),
+                        hash_node::<H>(right.clone(), &mut preimage),
+                    ),
+                    path: Felt252::ZERO,
+                    length: Felt252::ZERO,
+                }
+            };
+            next_layer.push(next_node);
+        }
+        layer = next_layer;
+        height = height + 1;
+    }
+
+    let root = layer[0].clone();
+    node_at_path.insert((height, Felt252::ZERO), root.clone());
+    let root_hash = hash_node::<H>(root, &mut preimage);
+
+    (root_hash, preimage, node_at_path)
+}
+
+#[cfg(test)]
+mod tests {
+    // Sanity tests comparing results generated with the Python implementation.
+    use super::*;
+    use crate::crypto::pedersen::PedersenHash;
+
+    #[test]
+    fn test_hash_node() {
+        let expected_hash =
+            Felt252::from_dec_str("1321142004022994845681377299801403567378503530250467610343381590909832171181")
+                .unwrap();
+
+        let mut preimage = HashMap::new();
+        let node = Node { bottom: Felt252::ONE, path: Felt252::ONE, length: Felt252::ONE };
+        let hash = hash_node::<PedersenHash>(node, &mut preimage);
+
+        assert_eq!(hash, expected_hash);
+        println!("{}", hash);
+    }
+
+    #[test]
+    fn test_compute_root_two_leaves() {
+        let expected_root_hash =
+            Felt252::from_dec_str("2592987851775965742543459319508348457290966253241455514226127639100457844774")
+                .unwrap();
+
+        let (root_hash, _, _) = compute_patricia_from_leaves_for_test::<PedersenHash>(&[Felt252::ONE, Felt252::TWO]);
+        assert_eq!(root_hash, expected_root_hash);
+    }
+
+    #[test]
+    fn test_compute_root_eight_leaves() {
+        let expected_root_hash =
+            Felt252::from_dec_str("3206463776576638577137066366647706846226995569381452684870955234387294439611")
+                .unwrap();
+
+        let leaves = vec![
+            Felt252::ZERO,
+            Felt252::from(12),
+            Felt252::ZERO,
+            Felt252::ZERO,
+            Felt252::from(1000),
+            Felt252::ZERO,
+            Felt252::from(30),
+            Felt252::ZERO,
+        ];
+        let (root_hash, _, _) = compute_patricia_from_leaves_for_test::<PedersenHash>(&leaves);
+        println!("{}", root_hash);
+
+        assert_eq!(root_hash, expected_root_hash);
+    }
+}

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
@@ -1,0 +1,650 @@
+use std::any::Any;
+use std::marker::PhantomData;
+
+use num_bigint::BigUint;
+
+use crate::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath};
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
+use crate::starkware_utils::commitment_tree::binary_fact_tree_node::read_node_fact;
+use crate::starkware_utils::commitment_tree::calculation::{
+    Calculation, CalculationNode, ConstantCalculation, DependencyWrapper, HashCalculation, LeafFactCalculation,
+    NodeFactDict,
+};
+use crate::starkware_utils::commitment_tree::errors::{CombineError, TreeError};
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::nodes::{
+    verify_path_value, BinaryNodeFact, EdgeNodeFact, PatriciaNodeFact,
+};
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
+use crate::starkware_utils::commitment_tree::patricia_tree::virtual_patricia_node::VirtualPatriciaNode;
+use crate::storage::storage::{Fact, FactFetchingContext, HashFunctionType, Storage, StorageError};
+
+#[derive(Debug, PartialEq)]
+pub struct BinaryCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    left: Box<HashCalculationImpl<S, H, LF>>,
+    right: Box<HashCalculationImpl<S, H, LF>>,
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
+}
+
+impl<S, H, LF> BinaryCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    pub fn new(left: Box<HashCalculationImpl<S, H, LF>>, right: Box<HashCalculationImpl<S, H, LF>>) -> Self {
+        Self { left, right, _s: Default::default(), _h: Default::default() }
+    }
+}
+
+// A custom implementation is required to avoid requiring Clone on Storage and HashFunctionType
+// because of the PhantomData fields in the struct.
+impl<S, H, LF> Clone for BinaryCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.left.clone(), self.right.clone())
+    }
+}
+
+impl<S, H, LF> Calculation<Vec<u8>, LF> for BinaryCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        vec![
+            Box::new(DependencyWrapper::new(self.left.clone_box())),
+            Box::new(DependencyWrapper::new(self.right.clone_box())),
+        ]
+    }
+
+    fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Vec<u8> {
+        let left_hash: &Vec<u8> = dependency_results[0].downcast_ref().unwrap();
+        let right_hash: &Vec<u8> = dependency_results[1].downcast_ref().unwrap();
+
+        let fact = BinaryNodeFact { left_node: left_hash.clone(), right_node: right_hash.clone() };
+        let fact_hash = <BinaryNodeFact as Fact<S, H>>::hash(&fact);
+        fact_nodes.inner_nodes.insert(fact_hash.clone(), PatriciaNodeFact::Binary(fact));
+
+        fact_hash
+    }
+}
+
+impl<S, H, LF> HashCalculation<LF> for BinaryCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
+        Box::new(Self {
+            left: self.left.clone(),
+            right: self.right.clone(),
+            _s: Default::default(),
+            _h: Default::default(),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct EdgeCalculation<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    // Use Box here as `EdgeCalculation` is also a variant of `BottomCalculation`.
+    bottom: Box<HashCalculationImpl<S, H, LF>>,
+    path: NodePath,
+    length: Length,
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
+}
+
+impl<S, H, LF> EdgeCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    pub fn new(bottom: Box<HashCalculationImpl<S, H, LF>>, path: NodePath, length: Length) -> Self {
+        debug_assert!(verify_path_value(&path, length).is_ok());
+        Self { bottom, path, length, _s: Default::default(), _h: Default::default() }
+    }
+}
+
+// A custom implementation is required to avoid requiring Clone on Storage and HashFunctionType
+// because of the PhantomData fields in the struct.
+impl<S, H, LF> Clone for EdgeCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bottom: self.bottom.clone(),
+            path: self.path.clone(),
+            length: self.length,
+            _s: Default::default(),
+            _h: Default::default(),
+        }
+    }
+}
+
+impl<S, H, LF> Calculation<Vec<u8>, LF> for EdgeCalculation<S, H, LF>
+where
+    H: HashFunctionType + 'static,
+    S: Storage,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        vec![Box::new(DependencyWrapper::new(self.bottom.clone_box()))]
+    }
+
+    fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Vec<u8> {
+        let bottom_hash: &Vec<u8> = dependency_results[0].downcast_ref().unwrap();
+        let fact = EdgeNodeFact::new_unchecked(bottom_hash.clone(), self.path.clone(), self.length);
+        let fact_hash = <EdgeNodeFact as Fact<S, H>>::hash(&fact);
+        fact_nodes.inner_nodes.insert(fact_hash.clone(), PatriciaNodeFact::Edge(fact));
+
+        fact_hash
+    }
+}
+
+impl<S, H, LF> HashCalculation<LF> for EdgeCalculation<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
+        Box::new(Self {
+            bottom: self.bottom.clone(),
+            path: self.path.clone(),
+            length: self.length,
+            _s: Default::default(),
+            _h: Default::default(),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum HashCalculationImpl<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    Binary(BinaryCalculation<S, H, LF>),
+    Edge(EdgeCalculation<S, H, LF>),
+    LeafFact(LeafFactCalculation<S, H, LF>),
+    Constant(ConstantCalculation<Vec<u8>>),
+}
+
+impl<S, H, LF> HashCalculationImpl<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    pub fn is_empty(&self) -> bool {
+        match self {
+            HashCalculationImpl::Constant(constant_calculation) => constant_calculation.value == EMPTY_NODE_HASH,
+            HashCalculationImpl::LeafFact(leaf_fact_calculation) => leaf_fact_calculation.fact.is_empty(),
+            _ => false,
+        }
+    }
+}
+
+impl<S, H, LF> Clone for HashCalculationImpl<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: LeafFact<S, H>,
+{
+    fn clone(&self) -> Self {
+        match self {
+            HashCalculationImpl::Binary(binary) => HashCalculationImpl::Binary(binary.clone()),
+            HashCalculationImpl::Edge(edge) => HashCalculationImpl::Edge(edge.clone()),
+            HashCalculationImpl::LeafFact(leaf_fact) => HashCalculationImpl::LeafFact(leaf_fact.clone()),
+            HashCalculationImpl::Constant(constant) => HashCalculationImpl::Constant(constant.clone()),
+        }
+    }
+}
+
+// impl<S, H> Clone for
+
+impl<S, H, LF> Calculation<Vec<u8>, LF> for HashCalculationImpl<S, H, LF>
+where
+    H: 'static + HashFunctionType,
+    S: Storage,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        match self {
+            HashCalculationImpl::Binary(binary) => binary.get_dependency_calculations(),
+            HashCalculationImpl::Edge(edge) => edge.get_dependency_calculations(),
+            HashCalculationImpl::LeafFact(leaf_fact) => leaf_fact.get_dependency_calculations(),
+            HashCalculationImpl::Constant(constant) => constant.get_dependency_calculations(),
+        }
+    }
+
+    fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Vec<u8> {
+        match self {
+            HashCalculationImpl::Binary(binary) => binary.calculate(dependency_results, fact_nodes),
+            HashCalculationImpl::Edge(edge) => edge.calculate(dependency_results, fact_nodes),
+            HashCalculationImpl::LeafFact(leaf_fact) => leaf_fact.calculate(dependency_results, fact_nodes),
+            HashCalculationImpl::Constant(constant) => constant.calculate(dependency_results, fact_nodes),
+        }
+    }
+}
+
+impl<S, H, LF> HashCalculation<LF> for HashCalculationImpl<S, H, LF>
+where
+    S: Storage,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H> + 'static,
+{
+    fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
+        match self {
+            HashCalculationImpl::Binary(binary) => binary.clone_box(),
+            HashCalculationImpl::Edge(edge) => edge.clone_box(),
+            HashCalculationImpl::LeafFact(leaf_fact) => leaf_fact.clone_box(),
+            HashCalculationImpl::Constant(constant) => constant.clone_box(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct VirtualCalculationNode<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    bottom_calculation: HashCalculationImpl<S, H, LF>,
+    path: NodePath,
+    length: Length,
+    /// The height of the subtree rooted at this node.
+    /// In other words, this is the length of the path from this node to the leaves.
+    height: Height,
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
+}
+
+impl<S, H, LF> VirtualCalculationNode<S, H, LF>
+where
+    S: Storage + Sync + Send + 'static,
+    H: HashFunctionType + Sync + Send + 'static,
+    LF: LeafFact<S, H>,
+{
+    pub fn new_unchecked(
+        bottom_calculation: HashCalculationImpl<S, H, LF>,
+        path: NodePath,
+        length: Length,
+        height: Height,
+    ) -> Self {
+        debug_assert!(verify_path_value(&path, length).is_ok());
+        Self { bottom_calculation, path, length, height, _s: Default::default(), _h: Default::default() }
+    }
+
+    #[allow(unused)]
+    pub fn new(
+        bottom_calculation: HashCalculationImpl<S, H, LF>,
+        path: NodePath,
+        length: Length,
+        height: Height,
+    ) -> Result<Self, TreeError> {
+        verify_path_value(&path, length)?;
+        Ok(Self::new_unchecked(bottom_calculation, path.clone(), length, height))
+    }
+
+    pub fn empty_node(height: Height) -> Self {
+        let bottom_calculation = HashCalculationImpl::Constant(ConstantCalculation::new(EMPTY_NODE_HASH.to_vec()));
+        VirtualCalculationNode::new_unchecked(bottom_calculation, NodePath(0u64.into()), Length(0), height)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bottom_calculation.is_empty()
+    }
+
+    fn is_virtual_edge(&self) -> bool {
+        self.length.0 != 0
+    }
+
+    fn is_leaf(&self) -> bool {
+        self.height.0 == 0
+    }
+
+    /// Converts self into a non-virtual calculation. Enters the virtual edge (if it exists) into
+    /// the resulting calculation.
+    fn commit(self) -> HashCalculationImpl<S, H, LF> {
+        if !self.is_virtual_edge() {
+            return self.bottom_calculation;
+        }
+
+        HashCalculationImpl::Edge(EdgeCalculation::<S, H, LF>::new(
+            Box::new(self.bottom_calculation),
+            self.path,
+            self.length,
+        ))
+    }
+
+    fn combine_to_binary_node(left: Self, right: Self) -> Self {
+        let height = Height(&right.height.0 + 1);
+        let bottom_calculation =
+            HashCalculationImpl::Binary(BinaryCalculation::new(Box::new(left.commit()), Box::new(right.commit())));
+        VirtualCalculationNode::new_unchecked(bottom_calculation, NodePath(0u64.into()), Length(0), height)
+    }
+
+    async fn decommit(
+        self,
+        ffc: &mut FactFetchingContext<S, H>,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Self, StorageError> {
+        if self.is_leaf() || self.is_empty() || self.is_virtual_edge() {
+            return Ok(self);
+        }
+
+        // Check if the bottom calculation represents an edge.
+        if let HashCalculationImpl::Edge(edge_calculation) = &self.bottom_calculation {
+            // Moving the edge of bottom_calculation into the virtual edge.
+            return Ok(Self::new_unchecked(
+                *edge_calculation.bottom.clone(),
+                edge_calculation.path.clone(),
+                edge_calculation.length,
+                self.height,
+            ));
+        }
+
+        if let HashCalculationImpl::Constant(constant_calculation) = &self.bottom_calculation {
+            let bottom_fact = read_node_fact::<S, H, PatriciaNodeFact>(ffc, &constant_calculation.value, facts).await?;
+            if let PatriciaNodeFact::Edge(edge_node_fact) = bottom_fact {
+                return Ok(Self::new_unchecked(
+                    HashCalculationImpl::Constant(ConstantCalculation::new(edge_node_fact.bottom_node)),
+                    edge_node_fact.edge_path,
+                    edge_node_fact.edge_length,
+                    self.height,
+                ));
+            }
+        }
+
+        Ok(self)
+    }
+
+    async fn combine_to_virtual_edge_node(
+        ffc: &mut FactFetchingContext<S, H>,
+        left: Self,
+        right: Self,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Self, CombineError> {
+        let (left_is_empty, non_empty_child) = match (left.is_empty(), right.is_empty()) {
+            (true, false) => (true, right),
+            (false, true) => (false, left),
+            (_, _) => {
+                return Err(CombineError::CannotCombineToVirtualEdgeNode);
+            }
+        };
+        let non_empty_child = non_empty_child.decommit(ffc, facts).await?;
+
+        let mut parent_path = non_empty_child.path;
+        if left_is_empty {
+            // Turn on the MSB bit if the non-empty child is on the right.
+            parent_path = NodePath(parent_path.0 + (BigUint::from(1u64) << non_empty_child.length.0));
+        }
+
+        let length = Length(non_empty_child.length.0 + 1);
+        let height = Height(non_empty_child.height.0 + 1);
+        Ok(Self::new_unchecked(non_empty_child.bottom_calculation, parent_path, length, height))
+    }
+}
+
+impl<S, H, LF> Clone for VirtualCalculationNode<S, H, LF>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + 'static,
+    LF: LeafFact<S, H>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bottom_calculation: self.bottom_calculation.clone(),
+            path: self.path.clone(),
+            length: self.length,
+            height: self.height,
+            _s: Default::default(),
+            _h: Default::default(),
+        }
+    }
+}
+
+impl<S, H, LF> Calculation<VirtualPatriciaNode<S, H, LF>, LF> for VirtualCalculationNode<S, H, LF>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send + 'static,
+    LF: LeafFact<S, H> + Send + 'static,
+{
+    fn get_dependency_calculations(&self) -> Vec<Box<dyn Calculation<Box<dyn Any>, LF>>> {
+        self.bottom_calculation.get_dependency_calculations()
+    }
+
+    fn calculate(
+        &self,
+        dependency_results: Vec<Box<dyn Any>>,
+        fact_nodes: &mut NodeFactDict<LF>,
+    ) -> VirtualPatriciaNode<S, H, LF> {
+        let bottom_hash = self.bottom_calculation.calculate(dependency_results, fact_nodes);
+        VirtualPatriciaNode::new_unchecked(bottom_hash, self.path.clone(), self.length, self.height)
+    }
+}
+
+impl<S, H, LF> CalculationNode<S, H, LF> for VirtualCalculationNode<S, H, LF>
+where
+    S: Storage + Sync + Send + 'static,
+    H: HashFunctionType + Sync + Send + 'static,
+    LF: LeafFact<S, H>,
+{
+    type BinaryFactTreeNodeType = VirtualPatriciaNode<S, H, LF>;
+
+    /// Gets two VirtualCalculationNode objects left and right representing children nodes, and
+    /// builds their parent node. Returns a new VirtualCalculationNode.
+    ///
+    /// If facts argument is not None, this dictionary is filled with facts read from the DB.
+    async fn combine(
+        ffc: &mut FactFetchingContext<S, H>,
+        left: Self,
+        right: Self,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Self, CombineError> {
+        if left.height != right.height {
+            return Err(CombineError::TreeHeightsDiffer(left.height, right.height));
+        }
+
+        let parent_height = Height(right.height.0 + 1);
+        if left.is_empty() && right.is_empty() {
+            return Ok(Self::empty_node(parent_height));
+        }
+
+        if !left.is_empty() && !right.is_empty() {
+            return Ok(Self::combine_to_binary_node(left, right));
+        }
+
+        Self::combine_to_virtual_edge_node(ffc, left, right, facts).await
+    }
+
+    fn create_from_node(node: &Self::BinaryFactTreeNodeType) -> Self {
+        let bottom_calculation = HashCalculationImpl::Constant(ConstantCalculation::new(node.bottom_node.clone()));
+        Self::new_unchecked(bottom_calculation, node.path.clone(), node.length, node.height)
+    }
+
+    fn create_from_fact(fact: LF) -> Self {
+        let bottom_calculation = HashCalculationImpl::LeafFact(LeafFactCalculation::new(fact));
+        Self::new_unchecked(bottom_calculation, NodePath(0u64.into()), Length(0), Height(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use cairo_vm::Felt252;
+    use rstest::{fixture, rstest};
+
+    use super::*;
+    use crate::crypto::pedersen::PedersenHash;
+    use crate::storage::dict_storage::DictStorage;
+    use crate::storage::storage::FactFetchingContext;
+    use crate::storage::storage_utils::SimpleLeafFact;
+
+    type StorageType = DictStorage;
+    type HashFunction = PedersenHash;
+    type LeafFactType = SimpleLeafFact;
+    type FFC = FactFetchingContext<StorageType, HashFunction>;
+    type LeafCalculation = HashCalculationImpl<StorageType, HashFunction, LeafFactType>;
+
+    type VCN = VirtualCalculationNode<StorageType, HashFunction, LeafFactType>;
+
+    #[fixture]
+    fn ffc() -> FFC {
+        FactFetchingContext::<_, HashFunction>::new(DictStorage::default())
+    }
+
+    #[fixture]
+    async fn leaf_calculation(mut ffc: FFC) -> LeafCalculation {
+        let leaf_hash = SimpleLeafFact::new(Felt252::from(42)).set_fact(&mut ffc).await.unwrap();
+        HashCalculationImpl::Constant(ConstantCalculation::new(leaf_hash))
+    }
+
+    #[fixture]
+    async fn leaf_calculation2(mut ffc: FFC) -> LeafCalculation {
+        let leaf_hash = SimpleLeafFact::new(Felt252::from(153)).set_fact(&mut ffc).await.unwrap();
+        HashCalculationImpl::Constant(ConstantCalculation::new(leaf_hash))
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_invalid_length(#[future] leaf_calculation: LeafCalculation) {
+        let leaf_calculation = leaf_calculation.await;
+        let result = VCN::new(leaf_calculation, NodePath(1u64.into()), Length(0), Height(1));
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case(Height(0))]
+    #[case(Height(7))]
+    #[tokio::test]
+    async fn test_combine_two_empty(mut ffc: FFC, #[case] height: Height) {
+        let mut facts = None;
+        let left_child = VCN::empty_node(height);
+        let right_child = VCN::empty_node(height);
+        let parent = VCN::combine(&mut ffc, left_child, right_child, &mut facts).await.unwrap();
+        assert_eq!(parent, VCN::empty_node(Height(height.0 + 1)));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_combine_unmatching_height(mut ffc: FFC) {
+        let mut facts = None;
+        let (height_0, height_1) = (Height(0), Height(1));
+        let empty_node_0 = VCN::empty_node(height_0);
+        let empty_node_1 = VCN::empty_node(height_1);
+
+        let result = VCN::combine(&mut ffc, empty_node_0, empty_node_1, &mut facts).await;
+        assert_matches!(result, Err(CombineError::TreeHeightsDiffer(left,right)) if left == height_0 && right == height_1);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_combine_left_empty_right_leaf(mut ffc: FFC, #[future] leaf_calculation: LeafCalculation) {
+        let leaf_calculation = leaf_calculation.await;
+        let mut facts = None;
+
+        let left = VCN::empty_node(Height(0u64.into()));
+        let right = VCN::new(leaf_calculation.clone(), NodePath(0u64.into()), Length(0), Height(0)).unwrap();
+        let parent = VCN::combine(&mut ffc, left, right, &mut facts).await.unwrap();
+        assert_eq!(parent, VCN::new(leaf_calculation, NodePath(1u64.into()), Length(1), Height(1)).unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_combine_left_leaf_right_empty(mut ffc: FFC, #[future] leaf_calculation: LeafCalculation) {
+        let leaf_calculation = leaf_calculation.await;
+        let mut facts = None;
+
+        let left = VCN::new(leaf_calculation.clone(), NodePath(0u64.into()), Length(0), Height(0)).unwrap();
+        let right = VCN::empty_node(Height(0));
+        let parent = VCN::combine(&mut ffc, left, right, &mut facts).await.unwrap();
+        assert_eq!(parent, VCN::new(leaf_calculation, NodePath(0u64.into()), Length(1), Height(1)).unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_combine_left_empty_right_virtual_edge(mut ffc: FFC, #[future] leaf_calculation: LeafCalculation) {
+        let leaf_calculation = leaf_calculation.await;
+        let mut facts = None;
+
+        let left = VCN::empty_node(Height(1));
+        let right = VCN::new(leaf_calculation.clone(), NodePath(0u64.into()), Length(1), Height(1)).unwrap();
+        let parent = VCN::combine(&mut ffc, left, right, &mut facts).await.unwrap();
+        assert_eq!(parent, VCN::new(leaf_calculation, NodePath(0b10u64.into()), Length(2), Height(2)).unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_combine_left_virtual_edge_right_empty(mut ffc: FFC, #[future] leaf_calculation: LeafCalculation) {
+        let leaf_calculation = leaf_calculation.await;
+        let mut facts = None;
+
+        let left = VCN::new(leaf_calculation.clone(), NodePath(1u64.into()), Length(1), Height(1)).unwrap();
+        let right = VCN::empty_node(Height(1));
+        let parent = VCN::combine(&mut ffc, left, right, &mut facts).await.unwrap();
+        assert_eq!(parent, VCN::new(leaf_calculation, NodePath(0b01u64.into()), Length(2), Height(2)).unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_combine_two_virtual_edges(
+        mut ffc: FFC,
+        #[future] leaf_calculation: LeafCalculation,
+        #[future] leaf_calculation2: LeafCalculation,
+    ) {
+        let leaf_calculation = leaf_calculation.await;
+        let leaf_calculation2 = leaf_calculation2.await;
+        let mut facts = None;
+
+        let left = VCN::new(leaf_calculation.clone(), NodePath(1u64.into()), Length(1), Height(1)).unwrap();
+        let right = VCN::new(leaf_calculation2.clone(), NodePath(0u64.into()), Length(1), Height(1)).unwrap();
+        let parent = VCN::combine(&mut ffc, left, right, &mut facts).await.unwrap();
+        assert_eq!(
+            parent,
+            VCN::new(
+                HashCalculationImpl::Binary(BinaryCalculation::new(
+                    Box::new(HashCalculationImpl::Edge(EdgeCalculation::new(
+                        Box::new(leaf_calculation),
+                        NodePath(1u64.into()),
+                        Length(1)
+                    ))),
+                    Box::new(HashCalculationImpl::Edge(EdgeCalculation::new(
+                        Box::new(leaf_calculation2),
+                        NodePath(0u64.into()),
+                        Length(1)
+                    )))
+                )),
+                NodePath(0u64.into()),
+                Length(0),
+                Height(2)
+            )
+            .unwrap()
+        );
+    }
+}

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
@@ -28,8 +28,7 @@ where
 {
     left: Box<HashCalculationImpl<S, H, LF>>,
     right: Box<HashCalculationImpl<S, H, LF>>,
-    _s: PhantomData<S>,
-    _h: PhantomData<H>,
+    _phantom: PhantomData<(S, H)>,
 }
 
 impl<S, H, LF> BinaryCalculation<S, H, LF>
@@ -39,7 +38,7 @@ where
     LF: LeafFact<S, H>,
 {
     pub fn new(left: Box<HashCalculationImpl<S, H, LF>>, right: Box<HashCalculationImpl<S, H, LF>>) -> Self {
-        Self { left, right, _s: Default::default(), _h: Default::default() }
+        Self { left, right, _phantom: Default::default() }
     }
 }
 
@@ -88,12 +87,7 @@ where
     LF: LeafFact<S, H> + 'static,
 {
     fn clone_box(&self) -> Box<dyn HashCalculation<LF>> {
-        Box::new(Self {
-            left: self.left.clone(),
-            right: self.right.clone(),
-            _s: Default::default(),
-            _h: Default::default(),
-        })
+        Box::new(Self { left: self.left.clone(), right: self.right.clone(), _phantom: Default::default() })
     }
 }
 
@@ -108,8 +102,7 @@ where
     bottom: Box<HashCalculationImpl<S, H, LF>>,
     path: NodePath,
     length: Length,
-    _s: PhantomData<S>,
-    _h: PhantomData<H>,
+    _phantom: PhantomData<(S, H)>,
 }
 
 impl<S, H, LF> EdgeCalculation<S, H, LF>
@@ -120,7 +113,7 @@ where
 {
     pub fn new(bottom: Box<HashCalculationImpl<S, H, LF>>, path: NodePath, length: Length) -> Self {
         debug_assert!(verify_path_value(&path, length).is_ok());
-        Self { bottom, path, length, _s: Default::default(), _h: Default::default() }
+        Self { bottom, path, length, _phantom: Default::default() }
     }
 }
 
@@ -133,13 +126,7 @@ where
     LF: LeafFact<S, H>,
 {
     fn clone(&self) -> Self {
-        Self {
-            bottom: self.bottom.clone(),
-            path: self.path.clone(),
-            length: self.length,
-            _s: Default::default(),
-            _h: Default::default(),
-        }
+        Self { bottom: self.bottom.clone(), path: self.path.clone(), length: self.length, _phantom: Default::default() }
     }
 }
 
@@ -174,8 +161,7 @@ where
             bottom: self.bottom.clone(),
             path: self.path.clone(),
             length: self.length,
-            _s: Default::default(),
-            _h: Default::default(),
+            _phantom: Default::default(),
         })
     }
 }
@@ -280,8 +266,7 @@ where
     /// The height of the subtree rooted at this node.
     /// In other words, this is the length of the path from this node to the leaves.
     height: Height,
-    _s: PhantomData<S>,
-    _h: PhantomData<H>,
+    _phantom: PhantomData<(S, H)>,
 }
 
 impl<S, H, LF> VirtualCalculationNode<S, H, LF>
@@ -297,7 +282,7 @@ where
         height: Height,
     ) -> Self {
         debug_assert!(verify_path_value(&path, length).is_ok());
-        Self { bottom_calculation, path, length, height, _s: Default::default(), _h: Default::default() }
+        Self { bottom_calculation, path, length, height, _phantom: Default::default() }
     }
 
     #[allow(unused)]
@@ -423,8 +408,7 @@ where
             path: self.path.clone(),
             length: self.length,
             height: self.height,
-            _s: Default::default(),
-            _h: Default::default(),
+            _phantom: Default::default(),
         }
     }
 }

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -31,9 +31,7 @@ where
     /// In other words, this is the length of the path from this node to the leaves.
     pub height: Height,
 
-    _s: PhantomData<S>,
-    _h: PhantomData<H>,
-    _l: PhantomData<LF>,
+    _phantom: PhantomData<(S, H, LF)>,
 }
 
 impl<S, H, LF> VirtualPatriciaNode<S, H, LF>
@@ -43,30 +41,14 @@ where
     LF: LeafFact<S, H> + Send,
 {
     #[allow(unused)]
-    pub fn new(bottom_nodes: Vec<u8>, path: NodePath, length: Length, height: Height) -> Result<Self, TreeError> {
+    pub fn new(bottom_node: Vec<u8>, path: NodePath, length: Length, height: Height) -> Result<Self, TreeError> {
         verify_path_value(&path, length)?;
-        Ok(Self {
-            bottom_node: bottom_nodes,
-            path: path.clone(),
-            length,
-            height,
-            _s: Default::default(),
-            _h: Default::default(),
-            _l: Default::default(),
-        })
+        Ok(Self::new_unchecked(bottom_node, path, length, height))
     }
 
-    pub fn new_unchecked(bottom_nodes: Vec<u8>, path: NodePath, length: Length, height: Height) -> Self {
+    pub fn new_unchecked(bottom_node: Vec<u8>, path: NodePath, length: Length, height: Height) -> Self {
         debug_assert!(verify_path_value(&path, length).is_ok());
-        Self {
-            bottom_node: bottom_nodes,
-            path: path.clone(),
-            length,
-            height,
-            _s: Default::default(),
-            _h: Default::default(),
-            _l: Default::default(),
-        }
+        Self { bottom_node, path: path.clone(), length, height, _phantom: Default::default() }
     }
 
     fn empty_node(height: Height) -> Self {
@@ -75,9 +57,7 @@ where
             path: NodePath(0u64.into()),
             length: Length(0),
             height,
-            _s: Default::default(),
-            _h: Default::default(),
-            _l: Default::default(),
+            _phantom: Default::default(),
         }
     }
 
@@ -200,9 +180,7 @@ where
             path: self.path.clone(),
             length: self.length,
             height: self.height,
-            _s: Default::default(),
-            _h: Default::default(),
-            _l: Default::default(),
+            _phantom: Default::default(),
         }
     }
 }

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -1,0 +1,693 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+
+use futures::future::FutureExt;
+use num_bigint::BigUint;
+
+use crate::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath, TreeIndex};
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
+use crate::starkware_utils::commitment_tree::binary_fact_tree_node::{
+    read_node_fact, write_node_fact, BinaryFactTreeNode,
+};
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::nodes::{
+    verify_path_value, EdgeNodeFact, PatriciaNodeFact,
+};
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
+
+#[derive(Debug)]
+pub struct VirtualPatriciaNode<S, H, L>
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    pub bottom_node: Vec<u8>,
+    pub path: NodePath,
+    pub length: Length,
+    /// The height of the subtree rooted at this node.
+    /// In other words, this is the length of the path from this node to the leaves.
+    pub height: Height,
+
+    _s: PhantomData<S>,
+    _h: PhantomData<H>,
+    _l: PhantomData<L>,
+}
+
+impl<S, H, L> VirtualPatriciaNode<S, H, L>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    L: LeafFact<S, H> + Send,
+{
+    #[allow(unused)]
+    pub fn new(bottom_nodes: Vec<u8>, path: NodePath, length: Length, height: Height) -> Result<Self, TreeError> {
+        verify_path_value(&path, length)?;
+        Ok(Self {
+            bottom_node: bottom_nodes,
+            path: path.clone(),
+            length,
+            height,
+            _s: Default::default(),
+            _h: Default::default(),
+            _l: Default::default(),
+        })
+    }
+
+    pub fn new_unchecked(bottom_nodes: Vec<u8>, path: NodePath, length: Length, height: Height) -> Self {
+        debug_assert!(verify_path_value(&path, length).is_ok());
+        Self {
+            bottom_node: bottom_nodes,
+            path: path.clone(),
+            length,
+            height,
+            _s: Default::default(),
+            _h: Default::default(),
+            _l: Default::default(),
+        }
+    }
+
+    fn empty_node(height: Height) -> Self {
+        Self {
+            bottom_node: EMPTY_NODE_HASH.to_vec(),
+            path: NodePath(0u64.into()),
+            length: Length(0),
+            height,
+            _s: Default::default(),
+            _h: Default::default(),
+            _l: Default::default(),
+        }
+    }
+
+    pub fn from_hash(hash_value: Vec<u8>, height: Height) -> Self {
+        Self::new_unchecked(hash_value, NodePath(0u64.into()), Length(0), height)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bottom_node == EMPTY_NODE_HASH
+    }
+
+    fn is_virtual_edge(&self) -> bool {
+        self.length.0 != 0
+    }
+
+    /// Calculates and returns the hash of self.
+    /// If this is a virtual edge node, an edge node fact is written to the DB.
+    pub async fn commit(
+        &self,
+        ffc: &mut FactFetchingContext<S, H>,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<Vec<u8>, TreeError> {
+        if !self.is_virtual_edge() {
+            // Node is already of form (hash, 0, 0); no work to be done.
+            return Ok(self.bottom_node.clone());
+        }
+
+        let edge_node_fact = EdgeNodeFact::new(self.bottom_node.clone(), self.path.clone(), self.length)?;
+
+        let hash = write_node_fact(ffc, edge_node_fact, facts).await?;
+        Ok(hash)
+    }
+
+    /// Returns the children of a virtual edge node: an empty node and a shorter-by-one virtual
+    /// edge node, according to the direction embedded in the edge path.
+    fn get_virtual_edge_node_children(&self) -> Result<(Self, Self), TreeError> {
+        let children_height = self.height - 1;
+        let children_length = self.length - 1;
+
+        // Turn the MSB off.
+        let path = NodePath(self.path.0.clone() & ((BigUint::from(1u64) << children_length.0) - BigUint::from(1u64)));
+        let non_empty_child =
+            VirtualPatriciaNode::new_unchecked(self.bottom_node.clone(), path, children_length, children_height);
+
+        let edge_child_direction = self.path.0.clone() >> children_length.0;
+        let empty_child = Self::empty_node(children_height);
+        if edge_child_direction == BigUint::from(0u64) {
+            // Non-empty on the left
+            Ok((non_empty_child, empty_child))
+        } else {
+            // Non-empty on the right
+            Ok((empty_child, non_empty_child))
+        }
+    }
+
+    async fn read_bottom_node_fact(
+        &self,
+        ffc: &mut FactFetchingContext<S, H>,
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<PatriciaNodeFact, TreeError> {
+        let node_fact = read_node_fact::<S, H, PatriciaNodeFact>(ffc, &self.bottom_node, facts).await?;
+        Ok(node_fact)
+    }
+
+    /// Returns the values of the leaves whose indices are given.
+    async fn get_edge_node_leaves(
+        &self,
+        ffc: &mut FactFetchingContext<S, H>,
+        indices: &[TreeIndex],
+        facts: &mut Option<BinaryFactDict>,
+    ) -> Result<HashMap<TreeIndex, L>, TreeError> {
+        // Partition indices.
+        let path_suffix_width = self.height.0 - self.length.0;
+        let path_prefix = self.path.0.clone() << path_suffix_width;
+        let (bottom_subtree_indices, empty_indices) = {
+            let mut bottom_indices = vec![];
+            let mut empty_indices = vec![];
+            for index in indices.iter().cloned().map(BigUint::from) {
+                if index.clone() >> path_suffix_width == self.path.0 {
+                    bottom_indices.push(index - &path_prefix);
+                } else {
+                    empty_indices.push(index);
+                }
+            }
+            (bottom_indices, empty_indices)
+        };
+
+        // Get bottom subtree root.
+        let bottom_subtree_root = Self::from_hash(self.bottom_node.clone(), Height(path_suffix_width));
+        let bottom_subtree_leaves = bottom_subtree_root._get_leaves(ffc, &bottom_subtree_indices, facts).await?;
+        let empty_leaves = get_empty_leaves(ffc, &empty_indices).await?;
+
+        Ok(unify_edge_leaves(path_prefix, empty_leaves, bottom_subtree_leaves))
+    }
+}
+
+impl<S, H, L> PartialEq for VirtualPatriciaNode<S, H, L>
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.bottom_node == other.bottom_node
+            && self.path == other.path
+            && self.length == other.length
+            && self.height == other.height
+    }
+}
+
+impl<S, H, L> Clone for VirtualPatriciaNode<S, H, L>
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            bottom_node: self.bottom_node.clone(),
+            path: self.path.clone(),
+            length: self.length,
+            height: self.height,
+            _s: Default::default(),
+            _h: Default::default(),
+            _l: Default::default(),
+        }
+    }
+}
+
+impl<S, H, L> BinaryFactTreeNode<S, H, L> for VirtualPatriciaNode<S, H, L>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    L: LeafFact<S, H> + Send,
+{
+    fn _leaf_hash(&self) -> Vec<u8> {
+        self.bottom_node.clone()
+    }
+
+    fn get_height_in_tree(&self) -> Height {
+        self.height
+    }
+
+    fn create_leaf(hash_value: Vec<u8>) -> Self {
+        Self::from_hash(hash_value, Height(0))
+    }
+
+    /// Returns the two VirtualPatriciaNode objects which are the subtrees of the current
+    /// VirtualPatriciaNode.
+    ///
+    /// If facts argument is not None, this dictionary is filled with facts read from the DB.
+    fn get_children<'a>(
+        &'a self,
+        ffc: &'a mut FactFetchingContext<S, H>,
+        facts: &'a mut Option<BinaryFactDict>,
+    ) -> impl std::future::Future<Output = Result<(Self, Self), TreeError>> + Send {
+        async move {
+            if self.is_leaf() {
+                return Err(TreeError::IsLeaf);
+            }
+            let children_height = self.height - 1;
+            if self.is_empty() {
+                let empty_child = Self::empty_node(children_height);
+                return Ok((empty_child.clone(), empty_child));
+            }
+
+            if self.is_virtual_edge() {
+                return self.get_virtual_edge_node_children();
+            }
+
+            // At this point the preimage of self.bottom_node must be read from the storage, to know
+            // what kind of node it represents - a committed edge node, or a binary node.
+            let fact = self.read_bottom_node_fact(ffc, facts).await?;
+
+            match fact {
+                PatriciaNodeFact::Edge(edge_node_fact) => {
+                    // A previously committed edge node.
+                    let edge_node = Self::new_unchecked(
+                        edge_node_fact.bottom_node,
+                        edge_node_fact.edge_path,
+                        edge_node_fact.edge_length,
+                        self.height,
+                    );
+                    edge_node.get_virtual_edge_node_children()
+                }
+                PatriciaNodeFact::Binary(binary_node_fact) => Ok((
+                    Self::from_hash(binary_node_fact.left_node, children_height),
+                    Self::from_hash(binary_node_fact.right_node, children_height),
+                )),
+                PatriciaNodeFact::Empty(_) => Err(TreeError::IsEmpty),
+            }
+        }
+        .boxed()
+    }
+
+    fn _get_leaves<'a>(
+        &'a self,
+        ffc: &'a mut FactFetchingContext<S, H>,
+        indices: &'a [TreeIndex],
+        facts: &'a mut Option<BinaryFactDict>,
+    ) -> impl std::future::Future<Output = Result<HashMap<TreeIndex, L>, TreeError>> + std::marker::Send {
+        async move {
+            if indices.is_empty() {
+                return Ok(HashMap::new());
+            }
+
+            if self.is_empty() {
+                return get_empty_leaves(ffc, indices).await;
+            }
+
+            if self.is_leaf() {
+                return self._get_leaf(ffc, indices).await;
+            }
+
+            if self.is_virtual_edge() {
+                return self.get_edge_node_leaves(ffc, indices, facts).await;
+            }
+
+            self._get_binary_node_leaves(ffc, indices, facts).await
+        }
+        .boxed()
+    }
+}
+
+async fn get_empty_leaves<S, H, L>(
+    ffc: &mut FactFetchingContext<S, H>,
+    indices: &[TreeIndex],
+) -> Result<HashMap<TreeIndex, L>, TreeError>
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    if indices.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let empty_leaf = L::get_or_fail(&ffc.storage, EMPTY_NODE_HASH.as_ref()).await?;
+    let result: HashMap<_, L> = indices.iter().map(|index| (index.clone(), empty_leaf.clone())).collect();
+    Ok(result)
+}
+
+fn unify_edge_leaves<S, H, L>(
+    path_prefix: BigUint,
+    empty_leaves: HashMap<TreeIndex, L>,
+    bottom_subtree_leaves: HashMap<TreeIndex, L>,
+) -> HashMap<TreeIndex, L>
+where
+    S: Storage,
+    H: HashFunctionType,
+    L: LeafFact<S, H>,
+{
+    let mut edge_leaves = empty_leaves;
+    for (index, leaf_fact) in bottom_subtree_leaves.into_iter() {
+        edge_leaves.insert(index + &path_prefix, leaf_fact);
+    }
+
+    edge_leaves
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use cairo_vm::Felt252;
+    use rand::seq::SliceRandom;
+    use rand::Rng;
+    use rstest::{fixture, rstest};
+
+    use super::*;
+    use crate::crypto::pedersen::PedersenHash;
+    use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
+    use crate::starkware_utils::commitment_tree::binary_fact_tree_node::BinaryFactTreeNodeDiff;
+    use crate::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
+    use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
+    use crate::starkware_utils::commitment_tree::patricia_tree::patricia_utils::compute_patricia_from_leaves_for_test;
+    use crate::starkware_utils::commitment_tree::patricia_tree::virtual_calculation_node::VirtualCalculationNode;
+    use crate::starkware_utils::commitment_tree::update_tree::update_tree;
+    use crate::storage::dict_storage::DictStorage;
+    use crate::storage::storage::{Fact, FactFetchingContext};
+    use crate::storage::storage_utils::SimpleLeafFact;
+
+    type StorageType = DictStorage;
+    type HashFunction = PedersenHash;
+    type LeafFactType = SimpleLeafFact;
+    type FFC = FactFetchingContext<StorageType, HashFunction>;
+    type VPN = VirtualPatriciaNode<DictStorage, HashFunction, LeafFactType>;
+    type VCN = VirtualCalculationNode<StorageType, HashFunction, LeafFactType>;
+
+    #[fixture]
+    fn ffc() -> FFC {
+        FactFetchingContext::<_, HashFunction>::new(DictStorage::default())
+    }
+
+    /// Returns the non-canonical form (hash, 0, 0) of a virtual edge node.
+    async fn make_virtual_edge_non_canonical(ffc: &mut FFC, node: &VPN) -> VPN {
+        assert!(node.is_virtual_edge(), "Node should be of canonical form.");
+
+        let mut facts = None;
+        let node_hash = node.commit(ffc, &mut facts).await.unwrap();
+        VPN::from_hash(node_hash, node.height)
+    }
+
+    fn verify_root(leaves: &[Felt252], expected_root_hash: &[u8]) -> Result<(), ()> {
+        let (root_hash, _preimage, _node_at_path) = compute_patricia_from_leaves_for_test::<HashFunction>(leaves);
+        let root_hash_bytes = root_hash.to_bytes_be();
+
+        println!("{}", root_hash.to_biguint());
+
+        if root_hash_bytes == expected_root_hash { Ok(()) } else { Err(()) }
+    }
+
+    async fn build_empty_patricia_virtual_node(ffc: &mut FFC, height: Height) -> VPN {
+        // Done manually, since PatriciaTree.empty() is in charge of that and is not used here.
+        SimpleLeafFact::empty().set_fact(ffc).await.unwrap();
+
+        // Build empty tree.
+        VirtualPatriciaNode::empty_node(height)
+    }
+
+    async fn build_patricia_virtual_node(
+        ffc: &mut FFC,
+        height: Height,
+        leaves: HashMap<TreeIndex, SimpleLeafFact>,
+    ) -> VPN {
+        let tree = build_empty_patricia_virtual_node(ffc, height).await;
+        let modifications: Vec<_> = leaves.into_iter().collect();
+
+        let mut facts = None;
+        update_tree::<StorageType, HashFunction, LeafFactType, VPN, VCN>(tree, ffc, modifications, &mut facts)
+            .await
+            .unwrap()
+    }
+
+    async fn sample_and_verify_leaf_values(
+        ffc: &mut FFC,
+        tree: &VPN,
+        expected_leaves: &HashMap<TreeIndex, LeafFactType>,
+    ) {
+        let sampled_indices: Vec<_> = expected_leaves.keys().cloned().collect();
+        let mut facts = None;
+        let actual_leaves = tree._get_leaves(ffc, &sampled_indices, &mut facts).await.unwrap();
+
+        println!("Expected:");
+        for (i, lf) in expected_leaves {
+            println!("{i}: {}", lf.value.to_biguint());
+        }
+
+        println!("Actual:");
+        for (i, lf) in &actual_leaves {
+            println!("{i}: {}", lf.value.to_biguint());
+        }
+        assert_eq!(&actual_leaves, expected_leaves);
+    }
+
+    /// Builds a Patricia tree of length 3 with the following values in the leaves:
+    /// 1 -> 12, 6 -> 30. This is done using only "low-level" VirtualPatriciaNode methods,
+    /// without _update().
+    ///            0
+    ///      0           0
+    ///   0     0     0     0
+    /// 0  12 0   0 0   0 30  0
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_children(mut ffc: FFC) {
+        let empty_tree_0 = build_empty_patricia_virtual_node(&mut ffc, Height(0)).await;
+        let empty_tree_1 = build_empty_patricia_virtual_node(&mut ffc, Height(1)).await;
+
+        let mut facts = None;
+        let empty_tree_1_children = empty_tree_1.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(empty_tree_1_children, (empty_tree_0.clone(), empty_tree_0.clone()));
+
+        // Create leaves and write their facts to DB.
+        let leaf_hash_12 = SimpleLeafFact::new(Felt252::from(12)).set_fact(&mut ffc).await.unwrap();
+        let leaf_hash_30 = SimpleLeafFact::new(Felt252::from(30)).set_fact(&mut ffc).await.unwrap();
+
+        let leaf_12 = VPN::new(leaf_hash_12.clone(), NodePath(0u64.into()), Length(0), Height(0)).unwrap();
+        let leaf_30 = VPN::new(leaf_hash_30.clone(), NodePath(0u64.into()), Length(0), Height(0)).unwrap();
+
+        // Build left subtree and write its fact to DB.
+        EdgeNodeFact::new(leaf_hash_12.clone(), NodePath(1u64.into()), Length(1))
+            .unwrap()
+            .set_fact(&mut ffc)
+            .await
+            .unwrap();
+        let left_tree_1 = VPN::new(leaf_hash_12.clone(), NodePath(1u64.into()), Length(1), Height(1)).unwrap();
+
+        let expected_children = (empty_tree_0.clone(), leaf_12.clone());
+        let left_tree_1_children = left_tree_1.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(left_tree_1_children, expected_children);
+
+        let non_canonical_node = make_virtual_edge_non_canonical(&mut ffc, &left_tree_1).await;
+        let non_canonical_node_children = non_canonical_node.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(non_canonical_node_children, expected_children);
+
+        // Combine left edge node and right empty tree. Write the result's fact to DB.
+        EdgeNodeFact::new(leaf_hash_12.clone(), NodePath(0b01u64.into()), Length(2))
+            .unwrap()
+            .set_fact(&mut ffc)
+            .await
+            .unwrap();
+        let left_tree_2 = VPN::new(leaf_hash_12.clone(), NodePath(0b01u64.into()), Length(2), Height(2)).unwrap();
+        // Get children on both forms.
+        let expected_children = (left_tree_1.clone(), empty_tree_1.clone());
+        let left_tree_2_children = left_tree_2.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(left_tree_2_children, expected_children);
+        let non_canonical_node = make_virtual_edge_non_canonical(&mut ffc, &left_tree_2).await;
+        let non_canonical_node_children = non_canonical_node.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(non_canonical_node_children, expected_children);
+
+        // Build right subtree.
+        // Combine left leaf and right empty tree. Write the result's fact to DB.
+        EdgeNodeFact::new(leaf_hash_30.clone(), NodePath(0u64.into()), Length(1))
+            .unwrap()
+            .set_fact(&mut ffc)
+            .await
+            .unwrap();
+        let right_tree_1 = VPN::new(leaf_hash_30.clone(), NodePath(0u64.into()), Length(1), Height(1)).unwrap();
+        // Get children on both forms.
+        let expected_children = (leaf_30.clone(), empty_tree_0.clone());
+        let right_tree_1_children = right_tree_1.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(right_tree_1_children, expected_children);
+        let non_canonical_node = make_virtual_edge_non_canonical(&mut ffc, &right_tree_1).await;
+        let non_canonical_node_children = non_canonical_node.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(non_canonical_node_children, expected_children);
+
+        EdgeNodeFact::new(leaf_hash_30.clone(), NodePath(0b10u64.into()), Length(2))
+            .unwrap()
+            .set_fact(&mut ffc)
+            .await
+            .unwrap();
+        let right_tree_2 = VPN::new(leaf_hash_30.clone(), NodePath(0b10u64.into()), Length(2), Height(2)).unwrap();
+        // Get children on both forms.
+        let expected_children = (empty_tree_1.clone(), right_tree_1.clone());
+        let right_tree_2_children = right_tree_2.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(right_tree_2_children, expected_children);
+        let non_canonical_node = make_virtual_edge_non_canonical(&mut ffc, &right_tree_2).await;
+        let non_canonical_node_children = non_canonical_node.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(non_canonical_node_children, expected_children);
+
+        // Build whole tree and write its fact to DB.
+        let left_node = left_tree_2.commit(&mut ffc, &mut facts).await.unwrap();
+        let right_node = right_tree_2.commit(&mut ffc, &mut facts).await.unwrap();
+        let root_hash =
+            BinaryNodeFact::new(left_node.clone(), right_node.clone()).unwrap().set_fact(&mut ffc).await.unwrap();
+
+        let tree = VPN::new(root_hash, NodePath(0u64.into()), Length(0), Height(3)).unwrap();
+        let (left_edge_child, right_edge_child) = tree.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(left_edge_child, VPN::new(left_node.clone(), NodePath(0u64.into()), Length(0), Height(2)).unwrap());
+        assert_eq!(
+            right_edge_child,
+            VPN::new(right_node.clone(), NodePath(0u64.into()), Length(0), Height(2)).unwrap()
+        );
+
+        // Test operations on the committed left tree.
+        // Getting its children should return another edge with length shorter-by-one.
+        let left_edge_child_children = left_edge_child.get_children(&mut ffc, &mut facts).await.unwrap();
+        assert_eq!(left_edge_child_children, (left_tree_1, empty_tree_1));
+    }
+
+    /// Builds a Patricia tree of length 3 with the following values in the leaves:
+    /// 1 -> 12, 6 -> 30. This is the same tree as in the test above,
+    /// but in this test built using _update().
+    #[rstest]
+    #[tokio::test]
+    async fn test_update_and_get_leaves(mut ffc: FFC) {
+        // Build empty tree.
+        let tree = build_empty_patricia_virtual_node(&mut ffc, Height(3)).await;
+
+        // Compare empty root to test util result.
+        let n_leaves = 8 as u64;
+        let leaves = vec![Felt252::ZERO; n_leaves as usize];
+        verify_root(&leaves, &tree.bottom_node).unwrap();
+
+        // Update leaf values.
+        let leaves = HashMap::from([
+            (BigUint::from(1u64), SimpleLeafFact::new(Felt252::from(12))),
+            (BigUint::from(1u64), SimpleLeafFact::new(Felt252::from(1000))),
+            (BigUint::from(6u64), SimpleLeafFact::new(Felt252::from(30))),
+        ]);
+
+        let mut facts = None;
+        let modifications: Vec<_> = leaves.clone().into_iter().collect();
+        let tree =
+            update_tree::<StorageType, HashFunction, LeafFactType, VPN, VCN>(tree, &mut ffc, modifications, &mut facts)
+                .await
+                .unwrap();
+
+        // Check get_leaves().
+        let expected_leaves: HashMap<_, _> = (0..n_leaves)
+            .map(BigUint::from)
+            .map(|leaf_id| (leaf_id.clone(), leaves.get(&leaf_id).cloned().unwrap_or(SimpleLeafFact::empty())))
+            .collect();
+
+        sample_and_verify_leaf_values(&mut ffc, &tree, &expected_leaves).await;
+
+        // Compare to test util result.
+        let verify_root_leaves: Vec<_> =
+            (0..n_leaves).map(|key| expected_leaves.get(&BigUint::from(key)).unwrap().value).collect();
+        verify_root(&verify_root_leaves, &tree.bottom_node).unwrap();
+
+        // Update leaf values again: new leaves contain addition, deletion and updating a key.
+        let updated_leaves = HashMap::from([
+            (BigUint::from(0u64), SimpleLeafFact::new(Felt252::from(2))),
+            (BigUint::from(1u64), SimpleLeafFact::new(Felt252::from(20))),
+            (BigUint::from(3u64), SimpleLeafFact::new(Felt252::from(6))),
+            (BigUint::from(6u64), SimpleLeafFact::empty()),
+        ]);
+
+        let modifications: Vec<_> = updated_leaves.clone().into_iter().collect();
+        let tree =
+            update_tree::<StorageType, HashFunction, LeafFactType, VPN, VCN>(tree, &mut ffc, modifications, &mut facts)
+                .await
+                .unwrap();
+
+        let updated_leaves = {
+            let mut expected_leaves = expected_leaves;
+            expected_leaves.extend(updated_leaves);
+            expected_leaves
+        };
+
+        sample_and_verify_leaf_values(&mut ffc, &tree, &updated_leaves).await;
+
+        let sorted_by_index_leaf_values: Vec<_> =
+            (0..n_leaves).map(BigUint::from).map(|key| updated_leaves[&key].value).collect();
+        let expected_root_hash = tree.commit(&mut ffc, &mut facts).await.unwrap();
+        verify_root(&sorted_by_index_leaf_values, &expected_root_hash).unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_binary_fact_tree_node_create_diff(mut ffc: FFC) {
+        let mut facts = None;
+        let mut empty_tree = PatriciaTree::empty_tree(&mut ffc, Height(251), SimpleLeafFact::empty()).await.unwrap();
+        let virtual_empty_tree_node = VPN::from_hash(empty_tree.root.clone(), empty_tree.height);
+
+        // All tree values are zero except for the fifth leaf, which has a value of 8.
+        let modifications = vec![(BigUint::from(5u64), SimpleLeafFact::new(Felt252::from(8)))];
+        let mut one_change_tree = empty_tree.update(&mut ffc, modifications, &mut facts).await.unwrap();
+        let virtual_one_change_node = VPN::from_hash(one_change_tree.root.clone(), empty_tree.height);
+
+        // All tree values are zero except for the fifth leaf, which has a value of 8.
+        // and the 58th leaf, which is 81.
+        let modifications = vec![(BigUint::from(58u64), SimpleLeafFact::new(Felt252::from(81)))];
+        let two_change_tree = one_change_tree.update(&mut ffc, modifications, &mut facts).await.unwrap();
+        let virtual_two_change_node = VPN::from_hash(two_change_tree.root.clone(), empty_tree.height);
+
+        // The difference between the tree whose values are all zero and the tree that has
+        // all values zero except two values is exactly the 2 values.
+        let expected_diff = vec![
+            BinaryFactTreeNodeDiff::new(5, SimpleLeafFact::empty(), SimpleLeafFact::new(Felt252::from(8))),
+            BinaryFactTreeNodeDiff::new(58, SimpleLeafFact::empty(), SimpleLeafFact::new(Felt252::from(81))),
+        ];
+        let diff_result = {
+            let mut diff = virtual_empty_tree_node
+                .get_diff_between_trees(virtual_two_change_node.clone(), &mut ffc, &mut facts)
+                .await
+                .unwrap();
+            // The diff order is unpredictable given the way the tree is traversed.
+            // Sort it before comparing it to the expected result.
+            diff.sort_by(|a, b| a.path.cmp(&b.path));
+            diff
+        };
+        assert_eq!(diff_result, expected_diff);
+
+        // The difference between the tree whose values are zero except for the fifth leaf
+        // and the tree whose values are all zero except for the fifth leaf (there they are equal)
+        // and for the 58th leaf is exactly the 58th leaf.    # The difference between the tree whose values
+        // are zero except for the fifth leaf and the tree whose values are all zero except for the
+        // fifth leaf (there they are equal) and for the 58th leaf is exactly the 58th leaf.
+        let expected_diff =
+            vec![BinaryFactTreeNodeDiff::new(58, SimpleLeafFact::empty(), SimpleLeafFact::new(Felt252::from(81)))];
+        let diff_result = virtual_one_change_node
+            .get_diff_between_trees(virtual_two_change_node, &mut ffc, &mut facts)
+            .await
+            .unwrap();
+        assert_eq!(diff_result, expected_diff);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_leaves(mut ffc: FFC) {
+        let mut rng = rand::thread_rng();
+
+        let height = Height(100);
+        let n_leaves: u64 = rng.gen_range(1..=5) * 100;
+        let leaf_values: Vec<u64> = (0..n_leaves).map(|_| rng.gen_range(1..1000)).collect();
+        let leaf_indices: Vec<BigUint> =
+            (0..n_leaves).map(|_| BigUint::from(rng.gen::<u64>()) % (BigUint::from(1u64) << height.0)).collect();
+        let leaves: HashMap<_, _> = leaf_indices
+            .iter()
+            .cloned()
+            .zip(leaf_values.iter().map(|x| SimpleLeafFact::new(Felt252::from(*x))))
+            .collect();
+        let tree = build_patricia_virtual_node(&mut ffc, height, leaves.clone()).await;
+
+        // Sample random subset of initialized leaves.
+        let n_sampled_leaves = rng.gen_range(1..=n_leaves) as usize;
+        let sampled_indices: HashSet<_> = leaf_indices.choose_multiple(&mut rng, n_sampled_leaves).collect();
+        let expected_leaves: HashMap<_, _> =
+            leaves.into_iter().filter(|(index, _)| sampled_indices.contains(index)).collect();
+        sample_and_verify_leaf_values(&mut ffc, &tree, &expected_leaves).await;
+
+        // Sample random subset of empty leaves
+        // (almost zero prob. they will land on initialized ones).
+        let empty_leaf = SimpleLeafFact::empty();
+        let sampled_indices: Vec<_> =
+            (0..10).map(|_| BigUint::from(rng.gen::<u64>()) % (BigUint::from(1u64) << height.0)).collect();
+        let expected_leaves: HashMap<_, _> =
+            sampled_indices.into_iter().map(BigUint::from).map(|index| (index, empty_leaf.clone())).collect();
+        sample_and_verify_leaf_values(&mut ffc, &tree, &expected_leaves).await;
+    }
+}

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -632,13 +632,10 @@ mod tests {
             BinaryFactTreeNodeDiff::new(58, SimpleLeafFact::empty(), SimpleLeafFact::new(Felt252::from(81))),
         ];
         let diff_result = {
-            let mut diff = virtual_empty_tree_node
+            let diff = virtual_empty_tree_node
                 .get_diff_between_trees(virtual_two_change_node.clone(), &mut ffc, &mut facts)
                 .await
                 .unwrap();
-            // The diff order is unpredictable given the way the tree is traversed.
-            // Sort it before comparing it to the expected result.
-            diff.sort_by(|a, b| a.path.cmp(&b.path));
             diff
         };
         assert_eq!(diff_result, expected_diff);

--- a/src/starkware_utils/commitment_tree/update_tree.rs
+++ b/src/starkware_utils/commitment_tree/update_tree.rs
@@ -43,7 +43,8 @@ where
 
     // Xoring by 1 switch between 2k <-> 2k + 1, which are siblings in the tree.
     // The parent of these siblings is k = floor(n/2) for n = 2k, 2k+1.
-    while updated_nodes.contains_key(&(cur_node_index.clone() ^ BigUint::from(1u64))) {
+    let one = BigUint::from(1u64);
+    while updated_nodes.contains_key(&(cur_node_index.clone() ^ &one)) {
         cur_node_index /= 2u64;
         // Unwrapping is safe, guaranteed by construction
         let (left_index, right_index) = (&cur_node_index * 2u64, &cur_node_index * 2u64 + 1u64);

--- a/src/starkware_utils/commitment_tree/update_tree.rs
+++ b/src/starkware_utils/commitment_tree/update_tree.rs
@@ -1,0 +1,395 @@
+use std::collections::{HashMap, HashSet};
+use std::marker::PhantomData;
+
+use num_bigint::BigUint;
+
+use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
+use crate::starkware_utils::commitment_tree::binary_fact_tree_node::BinaryFactTreeNode;
+use crate::starkware_utils::commitment_tree::calculation::{Calculation, CalculationNode, NodeFactDict};
+use crate::starkware_utils::commitment_tree::errors::{TreeError, UpdateTreeError};
+use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::merkle_tree::traverse_tree::{traverse_tree, TreeTraverser};
+use crate::starkware_utils::commitment_tree::patricia_tree::nodes::PatriciaNodeFact;
+use crate::storage::storage::{DbObject, FactFetchingContext, HashFunctionType, Storage, StorageError};
+
+#[derive(Clone, Debug)]
+enum UpdateTree<LF>
+where
+    LF: Clone,
+{
+    Tuple(Box<Option<UpdateTree<LF>>>, Box<Option<UpdateTree<LF>>>),
+    Leaf(Option<LF>),
+}
+
+/// Checks if there are merkle nodes that are not updated, but all of its children are.
+/// Starts at node_index, and goes up to the root.
+async fn update_necessary<S, H, LF, CN>(
+    node_index: TreeIndex,
+    updated_nodes: &mut HashMap<TreeIndex, CN>,
+    ffc: &mut FactFetchingContext<S, H>,
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<(), UpdateTreeError>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H>,
+    CN: CalculationNode<S, H, LF>,
+{
+    let mut cur_node_index = node_index;
+
+    // Xoring by 1 switch between 2k <-> 2k + 1, which are siblings in the tree.
+    // The parent of these siblings is k = floor(n/2) for n = 2k, 2k+1.
+    while updated_nodes.contains_key(&(cur_node_index.clone() ^ BigUint::from(1u64))) {
+        cur_node_index /= 2u64;
+        // Unwrapping is safe, guaranteed by construction
+        let (left_index, right_index) = (&cur_node_index * 2u64, &cur_node_index * 2u64 + 1u64);
+        let left = updated_nodes.get(&(left_index)).unwrap().clone();
+        let right = updated_nodes.get(&(right_index)).unwrap().clone();
+
+        let calculation_node = CN::combine(ffc, left, right, facts).await?;
+        updated_nodes.insert(cur_node_index.clone(), calculation_node);
+
+        updated_nodes.remove(&left_index);
+        updated_nodes.remove(&right_index);
+    }
+
+    Ok(())
+}
+
+async fn update_if_possible<S, H, LF, BFTN, CN>(
+    node_index: TreeIndex,
+    binary_fact_tree_node: &BFTN,
+    updated_nodes: &mut HashMap<TreeIndex, CN>,
+    ffc: &mut FactFetchingContext<S, H>,
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<(), UpdateTreeError>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    BFTN: BinaryFactTreeNode<S, H, LF>,
+    CN: CalculationNode<S, H, LF, BinaryFactTreeNodeType = BFTN>,
+{
+    let calculation_node = CN::create_from_node(binary_fact_tree_node);
+    updated_nodes.insert(node_index.clone(), calculation_node);
+
+    update_necessary(node_index, updated_nodes, ffc, facts).await
+}
+
+async fn set_fact<S, H, LF, CN>(
+    new_fact: LF,
+    node_index: TreeIndex,
+    updated_nodes: &mut HashMap<TreeIndex, CN>,
+    ffc: &mut FactFetchingContext<S, H>,
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<(), UpdateTreeError>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    CN: CalculationNode<S, H, LF>,
+{
+    let calculation_node = CN::create_from_fact(new_fact);
+    updated_nodes.insert(node_index.clone(), calculation_node);
+
+    update_necessary(node_index, updated_nodes, ffc, facts).await
+}
+
+struct NodeType<LF, BFTN>
+where
+    LF: Clone,
+{
+    index: TreeIndex,
+    tree: BFTN,
+    update: UpdateTree<LF>,
+}
+
+struct TreeUpdateTraverser<'trav, S, H, LF, BFTN, CN>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    BFTN: BinaryFactTreeNode<S, H, LF> + Send,
+    CN: CalculationNode<S, H, LF, BinaryFactTreeNodeType = BFTN>,
+{
+    pub ffc: &'trav mut FactFetchingContext<S, H>,
+    pub facts: &'trav mut Option<BinaryFactDict>,
+    pub updated_nodes: HashMap<TreeIndex, CN>,
+    _lf: PhantomData<LF>,
+}
+
+impl<'trav, S, H, LF, BFTN, CN> TreeUpdateTraverser<'trav, S, H, LF, BFTN, CN>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    BFTN: BinaryFactTreeNode<S, H, LF> + Send,
+    CN: CalculationNode<S, H, LF, BinaryFactTreeNodeType = BFTN>,
+{
+    pub fn new(ffc: &'trav mut FactFetchingContext<S, H>, facts: &'trav mut Option<BinaryFactDict>) -> Self {
+        Self { ffc, facts, updated_nodes: Default::default(), _lf: Default::default() }
+    }
+}
+
+impl<'trav, S, H, LF, BFTN, CN> TreeTraverser<'trav, S, H, LF> for TreeUpdateTraverser<'trav, S, H, LF, BFTN, CN>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    BFTN: BinaryFactTreeNode<S, H, LF> + Send,
+    CN: CalculationNode<S, H, LF, BinaryFactTreeNodeType = BFTN>,
+{
+    type NodeType = NodeType<LF, BFTN>;
+
+    async fn get_children(&mut self, node: &Self::NodeType) -> Result<Vec<Self::NodeType>, TreeError> {
+        let node_index = node.index.clone();
+        let binary_fact_tree_node = &node.tree;
+        let subtree_update = &node.update;
+
+        let children = match subtree_update {
+            UpdateTree::Leaf(leaf_update) => match leaf_update {
+                None => {
+                    update_if_possible(
+                        node_index,
+                        binary_fact_tree_node,
+                        &mut self.updated_nodes,
+                        self.ffc,
+                        self.facts,
+                    )
+                    .await?;
+                    vec![]
+                }
+                Some(leaf_fact) => {
+                    debug_assert!(binary_fact_tree_node.is_leaf());
+                    set_fact::<S, H, LF, CN>(
+                        leaf_fact.clone(),
+                        node_index,
+                        &mut self.updated_nodes,
+                        self.ffc,
+                        self.facts,
+                    )
+                    .await?;
+                    vec![]
+                }
+            },
+            UpdateTree::Tuple(left_update, right_update) => {
+                let (left, right) = binary_fact_tree_node.get_children(self.ffc, self.facts).await?;
+
+                vec![
+                    NodeType {
+                        index: 2u64 * &node_index,
+                        tree: left,
+                        update: (*left_update.clone()).unwrap_or(UpdateTree::Leaf(None)),
+                    },
+                    NodeType {
+                        index: 2u64 * &node_index + 1u64,
+                        tree: right,
+                        update: (*right_update.clone()).unwrap_or(UpdateTree::Leaf(None)),
+                    },
+                ]
+            }
+        };
+
+        Ok(children)
+    }
+}
+
+async fn build_updated_calculation<S, H, LF, BFTN, CN>(
+    tree: BFTN,
+    modifications: Vec<(TreeIndex, LF)>,
+    ffc: &mut FactFetchingContext<S, H>,
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<CN, TreeError>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    BFTN: BinaryFactTreeNode<S, H, LF> + Send,
+    CN: CalculationNode<S, H, LF, BinaryFactTreeNodeType = BFTN> + Send,
+{
+    let update_tree = build_update_tree(tree.get_height_in_tree(), modifications);
+    let first_node = NodeType { index: 1u64.into(), tree, update: update_tree };
+
+    let mut tree_update_traverser = TreeUpdateTraverser::<S, H, LF, BFTN, CN>::new(ffc, facts);
+    traverse_tree(&mut tree_update_traverser, first_node).await?;
+
+    let mut updated_nodes = tree_update_traverser.updated_nodes;
+    // Since the updated_nodes dictionary cleans itself, we expect only the new root to be
+    // present, at node index 1.
+    debug_assert_eq!(updated_nodes.len(), 1);
+    debug_assert!(updated_nodes.contains_key(&1u64.into()));
+
+    Ok(updated_nodes.remove(&1u64.into()).unwrap())
+}
+
+/// Updates the tree with the given list of modifications, writes all the new facts to the
+/// storage and returns a new BinaryFactTree representing the fact of the root of the new tree.
+///
+/// If facts argument is not None, this dictionary is filled during building the new tree
+/// by the facts of the modified nodes (the modified leaves won't enter to this dict as they are
+/// already known to the function caller).
+///
+/// This method is to be called by a update() method of a specific tree implementation
+/// (derived class of BinaryFactTree).
+///
+/// For efficiency, the function does not compute and store the new facts while traversing the
+/// tree. Instead, it first traverses the tree to fetch the needed facts for the update. It then
+/// computes the new facts. Once all facts are computed, it finally stores them.
+pub async fn update_tree<S, H, LF, BFTN, CN>(
+    tree: BFTN,
+    ffc: &mut FactFetchingContext<S, H>,
+    modifications: Vec<(TreeIndex, LF)>,
+    facts: &mut Option<BinaryFactDict>,
+) -> Result<BFTN, TreeError>
+where
+    S: Storage + Sync + Send,
+    H: HashFunctionType + Sync + Send,
+    LF: LeafFact<S, H> + Send,
+    BFTN: BinaryFactTreeNode<S, H, LF> + Send,
+    CN: CalculationNode<S, H, LF, BinaryFactTreeNodeType = BFTN> + Calculation<BFTN, LF> + Send,
+{
+    // A map from node index to the updated subtree, in which inner nodes are not hashed yet, but
+    // rather consist of their children.
+    // This map is populated when we traverse a node and know its value in the updated tree.
+    // This happens when either of these happens:
+    // 1. The node has no updates => value remains the same.
+    // 2. Node is a leaf update, and we just updated the leaf value.
+    // 3. When its two children are already updated (happens in update_necessary()).
+    let mut new_facts = NodeFactDict::<LF>::default();
+
+    let updated_calc_node: CN =
+        build_updated_calculation::<S, H, LF, BFTN, CN>(tree, modifications, ffc, facts).await?;
+
+    let root_node = updated_calc_node.full_calculate(&mut new_facts);
+
+    write_fact_nodes(ffc, &new_facts).await?;
+
+    if let Some(facts) = facts {
+        // The leaves aren't stored in `facts`. Only nodes are stored there.
+        for (fact_hash, node_fact) in new_facts.inner_nodes.iter() {
+            facts.insert(
+                BigUint::from_bytes_be(fact_hash),
+                <PatriciaNodeFact as InnerNodeFact<S, H>>::to_tuple(node_fact),
+            );
+        }
+    }
+
+    Ok(root_node)
+}
+
+type Layer<LF> = HashMap<TreeIndex, UpdateTree<LF>>;
+
+/// Constructs a tree from leaf updates. This is not a full binary tree. It is just the subtree
+/// induced by the modification leaves.
+/// Returns a tree. A tree is either:
+///  * None (if no modifications exist in its subtree).
+///  * A leaf (if a single modification is given at height 0; i.e., a leaf).
+///  * A pair of trees.
+fn build_update_tree<LF>(height: Height, modifications: Vec<(TreeIndex, LF)>) -> UpdateTree<LF>
+where
+    LF: Clone,
+{
+    // Bottom layer. This will prefer the last modification to an index.
+    if modifications.is_empty() {
+        return UpdateTree::Leaf(None);
+    }
+
+    // A layer is a dictionary from index in current merkle layer [0, 2**layer_height) to a tree.
+    // A tree is either None, a leaf, or a pair of trees.
+    let mut layer: Layer<LF> =
+        modifications.into_iter().map(|(index, leaf_fact)| (index, UpdateTree::Leaf(Some(leaf_fact)))).collect();
+
+    for _ in 0..height.0 {
+        let parents: HashSet<TreeIndex> = layer.keys().map(|key| key / 2u64).collect();
+        let mut new_layer: Layer<LF> = Layer::new();
+
+        for index in parents.into_iter() {
+            let left_update = layer.get(&(&index * 2u64)).cloned();
+            let right_update = layer.get(&(&index * 2u64 + 1u64)).cloned();
+
+            new_layer.insert(index, UpdateTree::Tuple(Box::new(left_update), Box::new(right_update)));
+        }
+
+        layer = new_layer;
+    }
+
+    // We reached layer_height=0, the top layer with only the root (with index 0).
+    debug_assert!(layer.len() == 1);
+
+    // unwrap() is safe here, 0 should always be in `layer` by construction
+    layer.remove(&0u64.into()).unwrap()
+}
+
+async fn write_fact_nodes<S, H, LF>(
+    ffc: &mut FactFetchingContext<S, H>,
+    fact_nodes: &NodeFactDict<LF>,
+) -> Result<(), StorageError>
+where
+    S: Storage,
+    H: HashFunctionType,
+    LF: DbObject,
+{
+    // TODO: this implementation is sync and simplistic for now.
+    //       Determine if it is necessary to improve it.
+    for (root_hash, root_node) in fact_nodes.inner_nodes.iter() {
+        root_node.set(&mut ffc.storage, root_hash).await?;
+    }
+    for (root_hash, root_node) in fact_nodes.leaves.iter() {
+        root_node.set(&mut ffc.storage, root_hash).await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use cairo_vm::Felt252;
+
+    use super::*;
+    use crate::storage::storage_utils::SimpleLeafFact;
+
+    type LeafFactType = SimpleLeafFact;
+
+    #[test]
+    fn test_build_update_tree_empty() {
+        let update_tree = build_update_tree::<LeafFactType>(Height(3), vec![]);
+        assert_matches!(update_tree, UpdateTree::Leaf(None));
+    }
+
+    fn print_update_tree(index: u64, update_tree: &UpdateTree<LeafFactType>) {
+        match update_tree {
+            UpdateTree::Tuple(left, right) => {
+                if let Some(left) = left.as_ref() {
+                    print_update_tree(index * 2, left);
+                }
+                if let Some(right) = right.as_ref() {
+                    print_update_tree(index * 2 + 1, right);
+                }
+            }
+            UpdateTree::Leaf(leaf_fact) => match leaf_fact {
+                Some(leaf_fact) => {
+                    println!("{index}: {}", leaf_fact.value.to_biguint())
+                }
+                None => {
+                    return;
+                }
+            },
+        }
+    }
+
+    #[test]
+    fn test_build_update_tree() {
+        let modifications = vec![
+            (BigUint::from(1u64), SimpleLeafFact::new(Felt252::from(12))),
+            (BigUint::from(4u64), SimpleLeafFact::new(Felt252::from(1000))),
+            (BigUint::from(6u64), SimpleLeafFact::new(Felt252::from(30))),
+        ];
+        let update_tree = build_update_tree::<LeafFactType>(Height(3), modifications);
+        print_update_tree(0, &update_tree);
+
+        // TODO finish this test
+    }
+}

--- a/src/starkware_utils/mod.rs
+++ b/src/starkware_utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod commitment_tree;
+pub mod serializable;

--- a/src/starkware_utils/serializable.rs
+++ b/src/starkware_utils/serializable.rs
@@ -1,0 +1,80 @@
+use heck::ToSnakeCase;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SerializeError {
+    // Right now we keep the raw serde error available for easier debugging.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error("Expected value to be at most {0} bytes once serialized")]
+    ValueTooLong(usize),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DeserializeError {
+    // Right now we keep the raw serde error available for easier debugging.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error("Could not find a deserialization method that takes this number of bytes: {0}")]
+    NoVariantWithLength(usize),
+
+    #[error("Expected {0} bytes but got {1}")]
+    LengthMismatch(usize, usize),
+}
+
+pub trait Serializable: Sized {
+    fn class_name_prefix() -> Vec<u8> {
+        let type_name = std::any::type_name::<Self>().to_string();
+        // unwrap() is safe here, there is always at least one element
+        let struct_name = type_name.split("::").last().unwrap().to_snake_case();
+        struct_name.into_bytes()
+    }
+
+    /// Converts the class name to a lower case name with '_' as separators and returns the
+    /// bytes version of this name. For example HelloWorldAB -> b'hello_world_a_b'.
+    fn prefix() -> Vec<u8> {
+        Self::class_name_prefix()
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError>;
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError>;
+}
+
+impl<T> Serializable for T
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        let serialized = serde_json::to_string(self)?;
+        Ok(serialized.into_bytes())
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        let value: Self = serde_json::from_reader(data)?;
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MySerializable;
+
+    impl Serializable for MySerializable {
+        fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+            panic!("Not implemented, on purpose");
+        }
+
+        fn deserialize(_data: &[u8]) -> Result<Self, DeserializeError> {
+            panic!("Not implemented, on purpose");
+        }
+    }
+
+    #[test]
+    fn test_class_name_prefix() {
+        assert_eq!(MySerializable::class_name_prefix(), "my_serializable".as_bytes());
+    }
+}

--- a/src/state/node.rs
+++ b/src/state/node.rs
@@ -134,7 +134,7 @@ impl BinaryNode {
         }
     }
 
-    pub(crate) fn calculate_hash<H: StarkHasher>(left: &StarkFelt, right: &StarkFelt) -> StarkHash {
+    pub fn calculate_hash<H: StarkHasher>(left: &StarkFelt, right: &StarkFelt) -> StarkHash {
         H::hash(left, right)
     }
 }
@@ -179,7 +179,7 @@ impl EdgeNode {
         &self.path[..common_length]
     }
 
-    pub(crate) fn calculate_hash<H: StarkHasher>(child: &StarkFelt, path: &BitSlice<u8, Msb0>) -> StarkHash {
+    pub fn calculate_hash<H: StarkHasher>(child: &StarkFelt, path: &BitSlice<u8, Msb0>) -> StarkHash {
         let mut length = [0; 32];
         // Safe as len() is guaranteed to be <= 251
         length[31] = path.len() as u8;

--- a/src/storage/dict_storage.rs
+++ b/src/storage/dict_storage.rs
@@ -1,0 +1,161 @@
+use std::collections::HashMap;
+
+use async_stream::stream;
+use futures_util::{FutureExt, Stream};
+
+use crate::storage::storage::{Storage, StorageError};
+
+/// A dictionary-based storage, for testing.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DictStorage {
+    db: HashMap<Vec<u8>, Vec<u8>>,
+}
+
+impl Storage for DictStorage {
+    async fn set_value(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StorageError> {
+        self.db.insert(key.to_vec(), value.to_vec());
+        Ok(())
+    }
+
+    fn get_value<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+    ) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send {
+        let result = Ok(self.db.get(key.as_ref()).cloned());
+        async move { result }.boxed()
+    }
+
+    async fn has_key<K: AsRef<[u8]>>(&self, key: K) -> bool {
+        self.db.contains_key(key.as_ref())
+    }
+
+    async fn del_value<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), StorageError> {
+        self.db.remove(key.as_ref());
+        Ok(())
+    }
+
+    async fn mset(&mut self, updates: HashMap<Vec<u8>, Vec<u8>>) -> Result<(), StorageError> {
+        for (key, value) in updates {
+            self.db.insert(key, value);
+        }
+        Ok(())
+    }
+    fn mget<K, I>(&self, keys: I) -> impl Stream<Item = Result<Option<Vec<u8>>, StorageError>>
+    where
+        K: AsRef<[u8]>,
+        I: Iterator<Item = K>,
+    {
+        stream! {
+            for key in keys {
+                yield Ok(self.db.get(key.as_ref()).cloned())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::{fixture, rstest};
+    use tokio_stream::StreamExt;
+
+    use super::*;
+
+    #[fixture]
+    fn storage_with_values() -> DictStorage {
+        let db =
+            HashMap::from([(vec![0], vec![0, 0, 1, 1, 0]), (vec![1], vec![1, 1, 1]), (vec![2], vec![255, 254, 253])]);
+        let storage = DictStorage { db };
+
+        storage
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_has_key(#[from(storage_with_values)] storage: DictStorage) {
+        assert!(storage.has_key(vec![0]).await);
+        assert!(storage.has_key(vec![1]).await);
+        assert!(storage.has_key(vec![2]).await);
+
+        assert!(!storage.has_key(vec![3]).await);
+        assert!(!storage.has_key(vec![0, 1, 2]).await);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_get_value(#[from(storage_with_values)] storage: DictStorage) {
+        assert_eq!(Some(vec![0, 0, 1, 1, 0]), storage.get_value(vec![0]).await.unwrap());
+        assert_eq!(Some(vec![1, 1, 1]), storage.get_value(vec![1]).await.unwrap());
+        assert_eq!(Some(vec![255, 254, 253]), storage.get_value(vec![2]).await.unwrap());
+
+        assert_eq!(None, storage.get_value(vec![3]).await.unwrap());
+        assert_eq!(None, storage.get_value(vec![0, 1, 2]).await.unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_set_value(#[from(storage_with_values)] mut storage: DictStorage) {
+        let key = vec![1, 2, 3, 4];
+        let value = vec![7; 7];
+
+        storage.set_value(key.clone(), value.clone()).await.unwrap();
+        assert_eq!(Some(value), storage.get_value(key).await.unwrap());
+
+        // Overwrite an existing value
+        let key = vec![2];
+        let value = vec![8; 8];
+        storage.set_value(key.clone(), value.clone()).await.unwrap();
+        assert_eq!(Some(value), storage.get_value(key).await.unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_del_value(#[from(storage_with_values)] mut storage: DictStorage) {
+        // Delete existing key
+        let key = vec![2];
+        storage.del_value(&key).await.unwrap();
+        assert_eq!(None, storage.get_value(&key).await.unwrap());
+
+        // Delete nonexistent key
+        let key = vec![1, 2, 3, 4];
+        storage.del_value(&key).await.unwrap();
+        assert_eq!(None, storage.get_value(&key).await.unwrap());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_mset(#[from(storage_with_values)] mut storage: DictStorage) {
+        let mut old_values = storage.db.clone();
+        let new_values = HashMap::from([(vec![1, 2, 3, 4], vec![3; 3]), (vec![3], vec![32]), (vec![0], vec![0; 100])]);
+        storage.mset(new_values.clone()).await.unwrap();
+
+        for (key, value) in new_values.iter() {
+            assert_eq!(Some(value), storage.get_value(key).await.unwrap().as_ref());
+        }
+
+        // Check that the previous values (minus the ones that were replaced) are still present
+        let remaining_values = {
+            for key in new_values.keys() {
+                old_values.remove(key);
+            }
+            old_values
+        };
+        for (key, value) in remaining_values {
+            assert_eq!(Some(value), storage.get_value(key).await.unwrap());
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_mget(#[from(storage_with_values)] storage: DictStorage) {
+        let storage_content = storage.db.clone();
+
+        let keys = storage_content.keys();
+        let values: Vec<_> = storage.mget(keys.clone()).collect().await;
+
+        assert_eq!(keys.len(), values.len());
+        for (key, value) in keys.zip(values) {
+            let value = value.unwrap();
+            assert_eq!(value, storage_content.get(key).cloned());
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,4 @@
+pub mod dict_storage;
+#[allow(clippy::module_inception)] // Use the same name as the parent module
+pub mod storage;
+pub mod storage_utils;

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -1,0 +1,173 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+
+use async_stream::try_stream;
+use cairo_vm::Felt252;
+use tokio_stream::Stream;
+
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+
+pub const HASH_BYTES: usize = 32;
+
+#[derive(thiserror::Error, Debug)]
+pub enum StorageError {
+    #[error("Content not found in storage")]
+    ContentNotFound,
+
+    #[error(transparent)]
+    Deserialize(#[from] DeserializeError),
+
+    #[error(transparent)]
+    Serialize(#[from] SerializeError),
+}
+
+#[allow(async_fn_in_trait)]
+pub trait Storage: Sync + Send {
+    async fn set_value(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StorageError>;
+
+    async fn setnx_value(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StorageError> {
+        // TODO: it is unclear what this function does differently from `set_value`.
+        //       we'll keep it around for now until this is clarified.
+        self.set_value(key, value).await
+    }
+
+    fn get_value<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+    ) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send;
+
+    async fn has_key<K: AsRef<[u8]>>(&self, key: K) -> bool;
+
+    async fn del_value<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), StorageError>;
+
+    /// Writes the given updates to storage.
+    /// Raises an exception when one or more of the operations failed;
+    /// in this case, the write might not be atomic.
+    async fn mset(&mut self, updates: HashMap<Vec<u8>, Vec<u8>>) -> Result<(), StorageError>;
+
+    /// Reads and returns the values of the given keys.
+    ///
+    /// Returns None for each nonexistent key.
+    fn mget<K, I>(&self, keys: I) -> impl Stream<Item = Result<Option<Vec<u8>>, StorageError>>
+    where
+        K: AsRef<[u8]>,
+        I: Iterator<Item = K>;
+
+    fn mget_or_fail<K, I>(&self, keys: I) -> impl Stream<Item = Result<Vec<u8>, StorageError>>
+    where
+        K: AsRef<[u8]>,
+        I: Iterator<Item = K>,
+    {
+        let stream = self.mget(keys);
+        try_stream! {
+            for await value in stream {
+                let value = value?;
+                match value {
+                    Some(content) => yield content,
+                    None => {return;},
+                }
+            }
+        }
+    }
+    async fn get_or_fail<K: AsRef<[u8]>>(&self, key: K) -> Result<Vec<u8>, StorageError> {
+        match self.get_value(key).await? {
+            Some(content) => Ok(content),
+            None => Err(StorageError::ContentNotFound),
+        }
+    }
+}
+
+pub trait HashFunctionType {
+    fn hash(x: &[u8], y: &[u8]) -> Vec<u8>;
+
+    fn hash_felts(x: Felt252, y: Felt252) -> Felt252 {
+        let hash = Self::hash(x.to_bytes_be().as_ref(), y.to_bytes_be().as_ref());
+        Felt252::from_bytes_be_slice(&hash)
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait DbObject: Serializable {
+    fn db_key(suffix: &[u8]) -> Vec<u8> {
+        let prefix = Self::prefix();
+        let elements = vec![&prefix, ":".as_bytes(), suffix];
+        elements.into_iter().flat_map(|v| v.iter().cloned()).collect()
+    }
+
+    fn get<S: Storage>(
+        storage: &S,
+        suffix: &[u8],
+    ) -> impl futures::Future<Output = Result<Option<Self>, StorageError>> + Send {
+        async move {
+            let key = Self::db_key(suffix);
+            match storage.get_value(key).await {
+                Ok(Some(data)) => {
+                    let value = Self::deserialize(&data)?;
+                    Ok(Some(value))
+                }
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    fn get_or_fail<S: Storage>(
+        storage: &S,
+        suffix: &[u8],
+    ) -> impl futures::Future<Output = Result<Self, StorageError>> + Send {
+        async move {
+            match Self::get(storage, suffix).await {
+                Ok(Some(content)) => Ok(content),
+                Ok(None) => Err(StorageError::ContentNotFound),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    async fn set<S: Storage>(&self, storage: &mut S, suffix: &[u8]) -> Result<(), StorageError> {
+        let key = Self::db_key(suffix);
+        let value = self.serialize()?;
+        storage.set_value(key, value).await?;
+        Ok(())
+    }
+
+    async fn setnx<S: Storage>(&self, storage: &mut S, suffix: &[u8]) -> Result<(), StorageError> {
+        let key = Self::db_key(suffix);
+        let value = self.serialize()?;
+        storage.setnx_value(key, value).await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FactFetchingContext<S, H>
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    pub storage: S,
+    _h: PhantomData<H>,
+}
+
+impl<S, H> FactFetchingContext<S, H>
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    #[allow(unused)]
+    pub fn new(storage: S) -> Self {
+        Self { storage, _h: Default::default() }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait Fact<S: Storage, H: HashFunctionType>: DbObject {
+    fn hash(&self) -> Vec<u8>;
+
+    async fn set_fact(&self, ffc: &mut FactFetchingContext<S, H>) -> Result<Vec<u8>, StorageError> {
+        let hash_val = self.hash();
+        self.set(&mut ffc.storage, &hash_val).await?;
+
+        Ok(hash_val)
+    }
+}

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -1,0 +1,53 @@
+use cairo_vm::Felt252;
+
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SimpleLeafFact {
+    pub value: Felt252,
+}
+
+impl SimpleLeafFact {
+    pub fn new(value: Felt252) -> Self {
+        Self { value }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(Felt252::ZERO)
+    }
+}
+
+impl<S, H> Fact<S, H> for SimpleLeafFact
+where
+    H: HashFunctionType,
+    S: Storage,
+{
+    fn hash(&self) -> Vec<u8> {
+        self.serialize().unwrap()
+    }
+}
+
+impl DbObject for SimpleLeafFact {}
+
+impl Serializable for SimpleLeafFact {
+    fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
+        Ok(self.value.to_bytes_be().to_vec())
+    }
+
+    fn deserialize(data: &[u8]) -> Result<Self, DeserializeError> {
+        let value = Felt252::from_bytes_be_slice(data);
+        Ok(Self { value })
+    }
+}
+
+impl<S, H> LeafFact<S, H> for SimpleLeafFact
+where
+    S: Storage,
+    H: HashFunctionType,
+{
+    fn is_empty(&self) -> bool {
+        self.value == Felt252::ZERO
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -205,6 +205,33 @@ impl SerializeAs<ChainId> for ChainIdNum {
     }
 }
 
+pub fn u64_from_byte_slice_le(bytes: &[u8]) -> u64 {
+    let mut x: u64 = 0;
+    for (i, byte) in bytes.iter().enumerate() {
+        x += (*byte as u64) << (i * 8);
+    }
+    x
+}
+
+pub fn u64_from_byte_slice_be(bytes: &[u8]) -> u64 {
+    let mut x: u64 = 0;
+    for (i, byte) in bytes.iter().enumerate() {
+        if *byte != 0 {
+            let offset = 8 * (bytes.len() - i - 1);
+            x += (*byte as u64) << offset;
+        }
+    }
+    x
+}
+
+pub fn i64_from_byte_slice_le(bytes: &[u8]) -> i64 {
+    u64_from_byte_slice_le(bytes) as i64
+}
+
+pub fn i64_from_byte_slice_be(bytes: &[u8]) -> i64 {
+    u64_from_byte_slice_be(bytes) as i64
+}
+
 #[cfg(test)]
 mod tests {
     use bitvec::prelude::*;


### PR DESCRIPTION
This port brings over the PatriciaTree, BinaryTreeNodeFact,
Calculation, LeafFact, etc logic from cairo-lang.

In short, this PR allows to compute state tree roots, state tree
updates, state tree diffs, etc while staying as close as possible to the
Python implementation.

Known limitations/differences:
* Tree traversal (`traverse_tree`) is single threaded. The Python VM
  spawns worker tasks for traversal but this approach proved to be too
  complex to implement in Rust for a first go.
* Error handling is not perfectly defined, lots of functions resort to
  TreeError but the definition of errors inside this enum could be
  improved.

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
