### PR TITLE
Syscall handler infra

### DIFF
--- a/src/execution/gas_constants.rs
+++ b/src/execution/gas_constants.rs
@@ -1,0 +1,107 @@
+// Gas Cost.
+// See documentation in core/os/constants.cairo.
+#[allow(unused)]
+pub const STEP_GAS_COST: u64 = 100;
+#[allow(unused)]
+pub const RANGE_CHECK_GAS_COST: u64 = 70;
+
+#[allow(unused)]
+pub const MEMORY_HOLE_GAS_COST: u64 = 10;
+
+// An estimation of the initial gas for a transaction to run with. This solution is temporary and
+// this value will become a field of the transaction.
+#[allow(unused)]
+pub const INITIAL_GAS_COST: u64 = 10_u64.pow(8) * blockifier::abi::constants::STEP_GAS_COST;
+// Compiler gas costs.
+#[allow(unused)]
+pub const ENTRY_POINT_INITIAL_BUDGET: u64 = 100 * blockifier::abi::constants::STEP_GAS_COST;
+// The initial gas budget for a system call (this value is hard-coded by the compiler).
+// This needs to be high enough to cover OS costs in the case of failure due to out of gas.
+#[allow(unused)]
+pub const SYSCALL_BASE_GAS_COST: u64 = 100 * blockifier::abi::constants::STEP_GAS_COST;
+// OS gas costs.
+#[allow(unused)]
+pub const ENTRY_POINT_GAS_COST: u64 =
+    blockifier::abi::constants::ENTRY_POINT_INITIAL_BUDGET + 500 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const FEE_TRANSFER_GAS_COST: u64 =
+    blockifier::abi::constants::ENTRY_POINT_GAS_COST + 100 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const TRANSACTION_GAS_COST: u64 = (2 * blockifier::abi::constants::ENTRY_POINT_GAS_COST)
+    + blockifier::abi::constants::FEE_TRANSFER_GAS_COST
+    + (100 * blockifier::abi::constants::STEP_GAS_COST);
+// The required gas for each syscall.
+#[allow(unused)]
+pub const CALL_CONTRACT_GAS_COST: u64 = blockifier::abi::constants::SYSCALL_BASE_GAS_COST
+    + 10 * blockifier::abi::constants::STEP_GAS_COST
+    + blockifier::abi::constants::ENTRY_POINT_GAS_COST;
+#[allow(unused)]
+pub const DEPLOY_GAS_COST: u64 = blockifier::abi::constants::SYSCALL_BASE_GAS_COST
+    + 200 * blockifier::abi::constants::STEP_GAS_COST
+    + blockifier::abi::constants::ENTRY_POINT_GAS_COST;
+#[allow(unused)]
+pub const EMIT_EVENT_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 10 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const GET_BLOCK_HASH_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 50 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const GET_EXECUTION_INFO_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 10 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const KECCAK_GAS_COST: u64 = blockifier::abi::constants::SYSCALL_BASE_GAS_COST;
+#[allow(unused)]
+pub const KECCAK_ROUND_COST_GAS_COST: u64 = 180000;
+#[allow(unused)]
+pub const LIBRARY_CALL_GAS_COST: u64 = blockifier::abi::constants::CALL_CONTRACT_GAS_COST;
+#[allow(unused)]
+pub const REPLACE_CLASS_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 50 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const SECP256K1_ADD_GAS_COST: u64 =
+    406 * blockifier::abi::constants::STEP_GAS_COST + 29 * blockifier::abi::constants::RANGE_CHECK_GAS_COST;
+#[allow(unused)]
+pub const SECP256K1_GET_POINT_FROM_X_GAS_COST: u64 = 391 * blockifier::abi::constants::STEP_GAS_COST
+    + 30 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 20 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256K1_GET_XY_GAS_COST: u64 = 239 * blockifier::abi::constants::STEP_GAS_COST
+    + 11 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 40 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256K1_MUL_GAS_COST: u64 = 76501 * blockifier::abi::constants::STEP_GAS_COST
+    + 7045 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 2 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256K1_NEW_GAS_COST: u64 = 475 * blockifier::abi::constants::STEP_GAS_COST
+    + 35 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 40 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256R1_ADD_GAS_COST: u64 =
+    589 * blockifier::abi::constants::STEP_GAS_COST + 57 * blockifier::abi::constants::RANGE_CHECK_GAS_COST;
+#[allow(unused)]
+pub const SECP256R1_GET_POINT_FROM_X_GAS_COST: u64 = 510 * blockifier::abi::constants::STEP_GAS_COST
+    + 44 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 20 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256R1_GET_XY_GAS_COST: u64 = 241 * blockifier::abi::constants::STEP_GAS_COST
+    + 11 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 40 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256R1_MUL_GAS_COST: u64 = 125340 * blockifier::abi::constants::STEP_GAS_COST
+    + 13961 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 2 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+#[allow(unused)]
+pub const SECP256R1_NEW_GAS_COST: u64 = 594 * blockifier::abi::constants::STEP_GAS_COST
+    + 49 * blockifier::abi::constants::RANGE_CHECK_GAS_COST
+    + 40 * blockifier::abi::constants::MEMORY_HOLE_GAS_COST;
+
+#[allow(unused)]
+pub const SEND_MESSAGE_TO_L1_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 50 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const STORAGE_READ_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 50 * blockifier::abi::constants::STEP_GAS_COST;
+#[allow(unused)]
+pub const STORAGE_WRITE_GAS_COST: u64 =
+    blockifier::abi::constants::SYSCALL_BASE_GAS_COST + 50 * blockifier::abi::constants::STEP_GAS_COST;

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,2 +1,3 @@
 pub mod deprecated_syscall_handler;
+pub mod syscall_handler;
 pub mod helper;

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,4 +1,5 @@
 pub mod deprecated_syscall_handler;
+mod gas_constants;
 pub mod helper;
 pub mod syscall_handler;
 mod syscall_utils;

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -1,3 +1,5 @@
 pub mod deprecated_syscall_handler;
-pub mod syscall_handler;
 pub mod helper;
+pub mod syscall_handler;
+mod syscall_utils;
+mod syscalls;

--- a/src/execution/syscall_handler.rs
+++ b/src/execution/syscall_handler.rs
@@ -3,15 +3,14 @@ use std::rc::Rc;
 
 use blockifier::execution::execution_utils::ReadOnlySegments;
 use cairo_vm::Felt252;
-use cairo_vm::types::exec_scope::ExecutionScopes;
 use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::vm_core::VirtualMachine;
-use num_traits::Zero;
+
+use crate::execution::syscall_utils::{execute_syscall, felt_from_ptr, SyscallSelector};
+use crate::execution::syscalls::get_execution_info;
 
 use super::helper::ExecutionHelperWrapper;
-use crate::execution::syscall_utils::{execute_syscall, SyscallSelector};
-use crate::execution::syscalls::get_execution_info;
 
 /// DeprecatedSyscallHandlerimplementation for execution of system calls in the StarkNet OS
 #[derive(Debug)]
@@ -55,7 +54,7 @@ impl OsSyscallHandlerWrapper {
         let mut syscall_handler = self.syscall_handler.as_ref().borrow_mut();
         assert_eq!(syscall_handler.syscall_ptr, syscall_ptr);
 
-        let selector = SyscallSelector::try_from(vm.get_integer(syscall_ptr)?.into_owned())?;
+        let selector = SyscallSelector::try_from(felt_from_ptr(vm, &mut syscall_handler.syscall_ptr)?)?;
 
         println!("about to execute syscall: {:?}", selector);
 

--- a/src/execution/syscall_handler.rs
+++ b/src/execution/syscall_handler.rs
@@ -5,9 +5,9 @@ use blockifier::execution::execution_utils::ReadOnlySegments;
 use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::vm_core::VirtualMachine;
-use cairo_vm::Felt252;
 
 use super::helper::ExecutionHelperWrapper;
+use crate::execution::gas_constants::GET_EXECUTION_INFO_GAS_COST;
 use crate::execution::syscall_utils::{execute_syscall, felt_from_ptr, SyscallSelector};
 use crate::execution::syscalls::get_execution_info;
 
@@ -56,9 +56,13 @@ impl OsSyscallHandlerWrapper {
         let ehw = syscall_handler.exec_wrapper.clone();
 
         match selector {
-            SyscallSelector::GetExecutionInfo => {
-                execute_syscall(&mut syscall_handler.syscall_ptr, vm, ehw, get_execution_info, Felt252::ZERO)
-            }
+            SyscallSelector::GetExecutionInfo => execute_syscall(
+                &mut syscall_handler.syscall_ptr,
+                vm,
+                ehw,
+                get_execution_info,
+                GET_EXECUTION_INFO_GAS_COST,
+            ),
             _ => Err(HintError::CustomHint(format!("Unknown syscall selector: {:?}", selector).into())),
         }
     }

--- a/src/execution/syscall_handler.rs
+++ b/src/execution/syscall_handler.rs
@@ -1,0 +1,55 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use blockifier::execution::execution_utils::ReadOnlySegments;
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+
+use super::helper::ExecutionHelperWrapper;
+
+/// DeprecatedSyscallHandlerimplementation for execution of system calls in the StarkNet OS
+#[derive(Debug)]
+pub struct OsSyscallHandler {
+    pub exec_wrapper: ExecutionHelperWrapper,
+    pub syscall_ptr: Relocatable,
+    pub segments: ReadOnlySegments,
+}
+
+/// OsSyscallHandler is wrapped in Rc<RefCell<_>> in order
+/// to clone the refrence when entering and exiting vm scopes
+#[derive(Clone, Debug)]
+pub struct OsSyscallHandlerWrapper {
+    pub syscall_handler: Rc<RefCell<OsSyscallHandler>>,
+}
+
+impl OsSyscallHandlerWrapper {
+    pub fn new(exec_wrapper: ExecutionHelperWrapper, syscall_ptr: Relocatable) -> Self {
+        Self {
+            syscall_handler: Rc::new(RefCell::new(OsSyscallHandler {
+                exec_wrapper,
+                syscall_ptr,
+                segments: ReadOnlySegments::default(),
+            })),
+        }
+    }
+    pub fn set_syscall_ptr(&self, syscall_ptr: Relocatable) {
+        let mut syscall_handler = self.syscall_handler.as_ref().borrow_mut();
+        syscall_handler.syscall_ptr = syscall_ptr;
+    }
+
+    pub fn syscall_ptr(&self) -> Relocatable {
+        self.syscall_handler.as_ref().borrow().syscall_ptr
+    }
+
+    pub fn syscall(&self,
+                   vm: &mut VirtualMachine,
+                   _exec_scopes: &mut ExecutionScopes,
+                   syscall_ptr: Relocatable
+    ) -> Result<(), HintError> {
+        let selector = vm.get_integer(syscall_ptr)?;
+        println!("syscall selector: {}", selector);
+        Ok(())
+    }
+}

--- a/src/execution/syscall_handler.rs
+++ b/src/execution/syscall_handler.rs
@@ -2,15 +2,14 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use blockifier::execution::execution_utils::ReadOnlySegments;
-use cairo_vm::Felt252;
 use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::vm_core::VirtualMachine;
-
-use crate::execution::syscall_utils::{execute_syscall, felt_from_ptr, SyscallSelector};
-use crate::execution::syscalls::get_execution_info;
+use cairo_vm::Felt252;
 
 use super::helper::ExecutionHelperWrapper;
+use crate::execution::syscall_utils::{execute_syscall, felt_from_ptr, SyscallSelector};
+use crate::execution::syscalls::get_execution_info;
 
 /// DeprecatedSyscallHandlerimplementation for execution of system calls in the StarkNet OS
 #[derive(Debug)]
@@ -46,11 +45,7 @@ impl OsSyscallHandlerWrapper {
         self.syscall_handler.as_ref().borrow().syscall_ptr
     }
 
-    pub fn syscall(
-        &self,
-        vm: &mut VirtualMachine,
-        syscall_ptr: Relocatable,
-    ) -> Result<(), HintError> {
+    pub fn syscall(&self, vm: &mut VirtualMachine, syscall_ptr: Relocatable) -> Result<(), HintError> {
         let mut syscall_handler = self.syscall_handler.as_ref().borrow_mut();
         assert_eq!(syscall_handler.syscall_ptr, syscall_ptr);
 

--- a/src/execution/syscall_utils.rs
+++ b/src/execution/syscall_utils.rs
@@ -1,12 +1,10 @@
-use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::Felt252;
 use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::errors::memory_errors::MemoryError;
-use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use cairo_vm::vm::vm_core::VirtualMachine;
-use cairo_vm::Felt252;
-use starknet_api::StarknetApiError;
 use thiserror::Error;
+
 use crate::execution::helper::ExecutionHelperWrapper;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -90,6 +88,7 @@ impl TryFrom<Felt252> for SyscallSelector {
 
 pub fn felt_from_ptr(vm: &VirtualMachine, ptr: &mut Relocatable) -> Result<Felt252, MemoryError> {
     let felt = vm.get_integer(*ptr)?.into_owned();
+    println!("reading syscall_ptr: {}", ptr);
     *ptr = (*ptr + 1)?;
     Ok(felt)
 }
@@ -103,7 +102,9 @@ pub fn write_maybe_relocatable<T: Into<MaybeRelocatable>>(
     ptr: &mut Relocatable,
     value: T,
 ) -> Result<(), MemoryError> {
-    vm.insert_value(*ptr, value)?;
+    let r: MaybeRelocatable = value.into();
+    println!("writing: {} to syscall_ptr: {}", r, ptr);
+    vm.insert_value(*ptr, r)?;
     *ptr = (*ptr + 1)?;
     Ok(())
 }

--- a/src/execution/syscall_utils.rs
+++ b/src/execution/syscall_utils.rs
@@ -1,0 +1,262 @@
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::vm::errors::memory_errors::MemoryError;
+use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use cairo_vm::Felt252;
+use starknet_api::StarknetApiError;
+use thiserror::Error;
+use crate::execution::helper::ExecutionHelperWrapper;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SyscallSelector {
+    CallContract,
+    DelegateCall,
+    DelegateL1Handler,
+    Deploy,
+    EmitEvent,
+    GetBlockHash,
+    GetBlockNumber,
+    GetBlockTimestamp,
+    GetCallerAddress,
+    GetContractAddress,
+    GetExecutionInfo,
+    GetSequencerAddress,
+    GetTxInfo,
+    GetTxSignature,
+    Keccak,
+    LibraryCall,
+    LibraryCallL1Handler,
+    ReplaceClass,
+    Secp256k1Add,
+    Secp256k1GetPointFromX,
+    Secp256k1GetXy,
+    Secp256k1Mul,
+    Secp256k1New,
+    Secp256r1Add,
+    Secp256r1GetPointFromX,
+    Secp256r1GetXy,
+    Secp256r1Mul,
+    Secp256r1New,
+    SendMessageToL1,
+    StorageRead,
+    StorageWrite,
+}
+
+impl TryFrom<Felt252> for SyscallSelector {
+    type Error = HintError;
+    fn try_from(raw_selector: Felt252) -> Result<Self, Self::Error> {
+        // Remove leading zero bytes from selector.
+        let selector_bytes = raw_selector.to_bytes_be();
+        let first_non_zero = selector_bytes.iter().position(|&byte| byte != b'\0').unwrap_or(32);
+
+        match &selector_bytes[first_non_zero..] {
+            b"CallContract" => Ok(Self::CallContract),
+            b"DelegateCall" => Ok(Self::DelegateCall),
+            b"DelegateL1Handler" => Ok(Self::DelegateL1Handler),
+            b"Deploy" => Ok(Self::Deploy),
+            b"EmitEvent" => Ok(Self::EmitEvent),
+            b"GetBlockHash" => Ok(Self::GetBlockHash),
+            b"GetBlockNumber" => Ok(Self::GetBlockNumber),
+            b"GetBlockTimestamp" => Ok(Self::GetBlockTimestamp),
+            b"GetCallerAddress" => Ok(Self::GetCallerAddress),
+            b"GetContractAddress" => Ok(Self::GetContractAddress),
+            b"GetExecutionInfo" => Ok(Self::GetExecutionInfo),
+            b"GetSequencerAddress" => Ok(Self::GetSequencerAddress),
+            b"GetTxInfo" => Ok(Self::GetTxInfo),
+            b"GetTxSignature" => Ok(Self::GetTxSignature),
+            b"Keccak" => Ok(Self::Keccak),
+            b"LibraryCall" => Ok(Self::LibraryCall),
+            b"LibraryCallL1Handler" => Ok(Self::LibraryCallL1Handler),
+            b"ReplaceClass" => Ok(Self::ReplaceClass),
+            b"Secp256k1Add" => Ok(Self::Secp256k1Add),
+            b"Secp256k1GetPointFromX" => Ok(Self::Secp256k1GetPointFromX),
+            b"Secp256k1GetXy" => Ok(Self::Secp256k1GetXy),
+            b"Secp256k1Mul" => Ok(Self::Secp256k1Mul),
+            b"Secp256k1New" => Ok(Self::Secp256k1New),
+            b"Secp256r1Add" => Ok(Self::Secp256r1Add),
+            b"Secp256r1GetPointFromX" => Ok(Self::Secp256r1GetPointFromX),
+            b"Secp256r1GetXy" => Ok(Self::Secp256r1GetXy),
+            b"Secp256r1Mul" => Ok(Self::Secp256r1Mul),
+            b"Secp256r1New" => Ok(Self::Secp256r1New),
+            b"SendMessageToL1" => Ok(Self::SendMessageToL1),
+            b"StorageRead" => Ok(Self::StorageRead),
+            b"StorageWrite" => Ok(Self::StorageWrite),
+            _ => Err(HintError::CustomHint(format!("Unknown syscall selector: {}", raw_selector).into())),
+        }
+    }
+}
+
+pub fn felt_from_ptr(vm: &VirtualMachine, ptr: &mut Relocatable) -> Result<Felt252, MemoryError> {
+    let felt = vm.get_integer(*ptr)?.into_owned();
+    *ptr = (*ptr + 1)?;
+    Ok(felt)
+}
+
+pub fn write_felt(vm: &mut VirtualMachine, ptr: &mut Relocatable, felt: Felt252) -> Result<(), MemoryError> {
+    write_maybe_relocatable(vm, ptr, felt)
+}
+
+pub fn write_maybe_relocatable<T: Into<MaybeRelocatable>>(
+    vm: &mut VirtualMachine,
+    ptr: &mut Relocatable,
+    value: T,
+) -> Result<(), MemoryError> {
+    vm.insert_value(*ptr, value)?;
+    *ptr = (*ptr + 1)?;
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum SyscallExecutionError {
+    #[error("Internal Error: {0}")]
+    InternalError(Box<str>),
+    #[error("Syscall error.")]
+    SyscallError { error_data: Vec<Felt252> },
+}
+
+impl From<MemoryError> for SyscallExecutionError {
+    fn from(error: MemoryError) -> Self {
+        Self::InternalError(format!("Memory error: {}", error).into())
+    }
+}
+
+impl From<SyscallExecutionError> for HintError {
+    fn from(error: SyscallExecutionError) -> Self {
+        HintError::CustomHint(format!("Memory error: {}", error).into())
+    }
+}
+
+impl From<HintError> for SyscallExecutionError {
+    fn from(error: HintError) -> Self {
+        Self::InternalError(format!("Memory error: {}", error).into())
+    }
+}
+
+
+pub type SyscallResult<T> = Result<T, SyscallExecutionError>;
+pub type WriteResponseResult = SyscallResult<()>;
+
+// type SyscallSelector = DeprecatedSyscallSelector;
+
+pub trait SyscallRequest: Sized {
+    fn read(_vm: &VirtualMachine, _ptr: &mut Relocatable) -> SyscallResult<Self> where Self: Sized;
+}
+
+pub trait SyscallResponse {
+    fn write(self, _vm: &mut VirtualMachine, _ptr: &mut Relocatable) -> WriteResponseResult;
+}
+
+// Syscall header structs.
+pub struct SyscallRequestWrapper<T: SyscallRequest> {
+    pub gas_counter: Felt252,
+    pub request: T,
+}
+impl<T: SyscallRequest> SyscallRequest for SyscallRequestWrapper<T> {
+    fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<Self> {
+        let gas_counter = felt_from_ptr(vm, ptr)?;
+        let request = T::read(vm, ptr)?;
+        Ok(Self { gas_counter, request })
+    }
+}
+
+pub enum SyscallResponseWrapper<T: SyscallResponse> {
+    Success { gas_counter: Felt252, response: T },
+    Failure { gas_counter: Felt252, error_data: Vec<Felt252> },
+}
+impl<T: SyscallResponse> SyscallResponse for SyscallResponseWrapper<T> {
+    fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+        match self {
+            Self::Success { gas_counter, response } => {
+                write_felt(vm, ptr, Felt252::from(gas_counter))?;
+                // 0 to indicate success.
+                write_felt(vm, ptr, Felt252::ZERO)?;
+                response.write(vm, ptr)
+            }
+            Self::Failure { gas_counter, error_data } => {
+                write_felt(vm, ptr, Felt252::from(gas_counter))?;
+                // 1 to indicate failure.
+                write_felt(vm, ptr, Felt252::ONE)?;
+
+                // Write the error data to a new memory segment.
+                let revert_reason_start = vm.add_memory_segment();
+                let revert_reason_end =
+                    vm.load_data(revert_reason_start, &error_data.into_iter().map(Into::into).collect())?;
+
+                // Write the start and end pointers of the error data.
+                write_maybe_relocatable(vm, ptr, revert_reason_start)?;
+                write_maybe_relocatable(vm, ptr, revert_reason_end)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+// Common structs.
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct EmptyRequest;
+
+impl SyscallRequest for EmptyRequest {
+    fn read(_vm: &VirtualMachine, _ptr: &mut Relocatable) -> SyscallResult<EmptyRequest> {
+        Ok(EmptyRequest)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct EmptyResponse;
+
+impl SyscallResponse for EmptyResponse {
+    fn write(self, _vm: &mut VirtualMachine, _ptr: &mut Relocatable) -> WriteResponseResult {
+        Ok(())
+    }
+}
+
+pub fn execute_syscall<Request, Response, ExecuteCallback>(
+    syscall_ptr: &mut Relocatable,
+    vm: &mut VirtualMachine,
+    exec_wrapper: ExecutionHelperWrapper,
+    execute_callback: ExecuteCallback,
+    _syscall_gas_cost: Felt252,
+) -> Result<(), HintError>
+where
+    Request: SyscallRequest + std::fmt::Debug,
+    Response: SyscallResponse + std::fmt::Debug,
+    ExecuteCallback:
+        FnOnce(Request, &mut VirtualMachine, ExecutionHelperWrapper, &mut Felt252) -> SyscallResult<Response>,
+{
+    // Refund `SYSCALL_BASE_GAS_COST` as it was pre-charged.
+    // TODO: Uncomment once we we know what to do
+    // let required_gas = syscall_gas_cost - self.context.get_gas_cost("syscall_base_gas_cost");
+
+    let SyscallRequestWrapper { gas_counter, request } = SyscallRequestWrapper::<Request>::read(vm, syscall_ptr)?;
+
+    // TODO: Uncomment once we we know what to do
+    // if gas_counter < required_gas {
+    //     //  Out of gas failure.
+    //     let out_of_gas_error =
+    //         StarkFelt::try_from(OUT_OF_GAS_ERROR).map_err(SyscallExecutionError::from)?;
+    //     let response: SyscallResponseWrapper<Response> =
+    //         SyscallResponseWrapper::Failure { gas_counter, error_data: vec![out_of_gas_error] };
+    //     response.write(vm, &mut self.syscall_ptr)?;
+    //
+    //     return Ok(());
+    // }
+
+    // Execute.
+    // let mut remaining_gas = gas_counter - required_gas;
+    let mut remaining_gas = gas_counter;
+    let original_response = execute_callback(request, vm, exec_wrapper, &mut remaining_gas);
+    let response = match original_response {
+        Ok(response) => SyscallResponseWrapper::Success { gas_counter: remaining_gas, response },
+        Err(SyscallExecutionError::SyscallError { error_data: data }) => {
+            SyscallResponseWrapper::Failure { gas_counter: remaining_gas, error_data: data }
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    response.write(vm, syscall_ptr)?;
+
+    Ok(())
+}

--- a/src/execution/syscalls.rs
+++ b/src/execution/syscalls.rs
@@ -1,10 +1,10 @@
-use cairo_vm::Felt252;
 use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::vm_core::VirtualMachine;
+use cairo_vm::Felt252;
 
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_utils::{
-    EmptyRequest, SyscallResponse, SyscallResult, write_maybe_relocatable, WriteResponseResult,
+    write_maybe_relocatable, EmptyRequest, SyscallResponse, SyscallResult, WriteResponseResult,
 };
 
 // TODO: what is this for?

--- a/src/execution/syscalls.rs
+++ b/src/execution/syscalls.rs
@@ -1,6 +1,5 @@
 use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::vm_core::VirtualMachine;
-use cairo_vm::Felt252;
 
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_utils::{
@@ -192,7 +191,7 @@ pub fn get_execution_info(
     _request: GetExecutionInfoRequest,
     _vm: &mut VirtualMachine,
     exec_wrapper: ExecutionHelperWrapper,
-    _remaining_gas: &mut Felt252,
+    _remaining_gas: &mut u64,
 ) -> SyscallResult<GetExecutionInfoResponse> {
     let eh_ref = exec_wrapper.execution_helper.as_ref().borrow();
     let execution_info_ptr = eh_ref.call_execution_info_ptr.unwrap();

--- a/src/execution/syscalls.rs
+++ b/src/execution/syscalls.rs
@@ -1,0 +1,586 @@
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use cairo_vm::Felt252;
+use num_traits::ToPrimitive;
+
+use crate::execution::helper::ExecutionHelperWrapper;
+use crate::execution::syscall_utils::{
+    write_maybe_relocatable, EmptyRequest, SyscallResponse, SyscallResult, WriteResponseResult,
+};
+
+// TODO: what is this for?
+// #[derive(Debug)]
+// pub struct SingleSegmentResponse {
+//     segment: ReadOnlySegment,
+// }
+//
+// impl SyscallResponse for SingleSegmentResponse {
+//     fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+//         write_segment(vm, ptr, self.segment)
+//     }
+// }
+
+// TODO: CallContract syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct CallContractRequest {
+//     pub contract_address: ContractAddress,
+//     pub function_selector: EntryPointSelector,
+//     pub calldata: Calldata,
+// }
+//
+// impl SyscallRequest for CallContractRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<CallContractRequest> {
+//         let contract_address = ContractAddress::try_from(stark_felt_from_ptr(vm, ptr)?)?;
+//         let (function_selector, calldata) = read_call_params(vm, ptr)?;
+//
+//         Ok(CallContractRequest { contract_address, function_selector, calldata })
+//     }
+// }
+//
+// pub type CallContractResponse = SingleSegmentResponse;
+//
+// pub fn call_contract(
+//     request: CallContractRequest,
+//     vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     remaining_gas: &mut u64,
+// ) -> SyscallResult<CallContractResponse> {
+//     Ok(CallContractResponse { segment: retdata_segment })
+// }
+
+// TODO: Deploy syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct DeployRequest {
+//     pub class_hash: ClassHash,
+//     pub contract_address_salt: ContractAddressSalt,
+//     pub constructor_calldata: Calldata,
+//     pub deploy_from_zero: bool,
+// }
+//
+// impl SyscallRequest for DeployRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<DeployRequest> {
+//         let class_hash = ClassHash(stark_felt_from_ptr(vm, ptr)?);
+//         let contract_address_salt = ContractAddressSalt(stark_felt_from_ptr(vm, ptr)?);
+//         let constructor_calldata = read_calldata(vm, ptr)?;
+//         let deploy_from_zero = stark_felt_from_ptr(vm, ptr)?;
+//
+//         Ok(DeployRequest {
+//             class_hash,
+//             contract_address_salt,
+//             constructor_calldata,
+//             deploy_from_zero: felt_to_bool(
+//                 deploy_from_zero,
+//                 "The deploy_from_zero field in the deploy system call must be 0 or 1.",
+//             )?,
+//         })
+//     }
+// }
+//
+// #[derive(Debug)]
+// pub struct DeployResponse {
+//     pub contract_address: ContractAddress,
+//     pub constructor_retdata: ReadOnlySegment,
+// }
+//
+// impl SyscallResponse for DeployResponse {
+//     fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+//         write_stark_felt(vm, ptr, *self.contract_address.0.key())?;
+//         write_segment(vm, ptr, self.constructor_retdata)
+//     }
+// }
+//
+// pub fn deploy(
+//     request: DeployRequest,
+//     vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     remaining_gas: &mut u64,
+// ) -> SyscallResult<DeployResponse> {
+//
+//     Ok(DeployResponse { contract_address: deployed_contract_address, constructor_retdata })
+// }
+
+// TODO: EmitEvent syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct EmitEventRequest {
+//     pub content: EventContent,
+// }
+//
+// impl SyscallRequest for EmitEventRequest {
+//     // The Cairo struct contains: `keys_len`, `keys`, `data_len`, `data`·
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<EmitEventRequest> {
+//         let keys =
+//             read_felt_array::<SyscallExecutionError>(vm,
+// ptr)?.into_iter().map(EventKey).collect();         let data =
+// EventData(read_felt_array::<SyscallExecutionError>(vm, ptr)?);
+//
+//         Ok(EmitEventRequest { content: EventContent { keys, data } })
+//     }
+// }
+//
+// type EmitEventResponse = EmptyResponse;
+//
+// pub fn emit_event(
+//     request: EmitEventRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> SyscallResult<EmitEventResponse> {
+//     Ok(EmitEventResponse {})
+// }
+
+// TODO: GetBlockHash syscall.
+//
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct GetBlockHashRequest {
+//     pub block_number: BlockNumber,
+// }
+//
+// impl SyscallRequest for GetBlockHashRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<GetBlockHashRequest> {
+//         let felt = felt_from_ptr(vm, ptr)?;
+//         let block_number = BlockNumber(felt.to_u64().ok_or_else(|| {
+//             SyscallExecutionError::InvalidSyscallInput {
+//                 input: felt_to_stark_felt(&felt),
+//                 info: String::from("Block number must fit within 64 bits."),
+//             }
+//         })?);
+//
+//         Ok(GetBlockHashRequest { block_number })
+//     }
+// }
+//
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct GetBlockHashResponse {
+//     pub block_hash: BlockHash,
+// }
+//
+// impl SyscallResponse for GetBlockHashResponse {
+//     fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+//         write_stark_felt(vm, ptr, self.block_hash.0)?;
+//         Ok(())
+//     }
+// }
+//
+// /// Returns the block hash of a given block_number.
+// /// Returns the expected block hash if the given block was created at least
+// /// [constants::STORED_BLOCK_HASH_BUFFER] blocks before the current block. Otherwise, returns an
+// /// error.
+// pub fn get_block_hash(
+//     request: GetBlockHashRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> SyscallResult<GetBlockHashResponse> {
+//     Ok(GetBlockHashResponse { block_hash })
+// }
+
+// GetExecutionInfo syscall.
+type GetExecutionInfoRequest = EmptyRequest;
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct GetExecutionInfoResponse {
+    pub execution_info_ptr: Relocatable,
+}
+
+impl SyscallResponse for GetExecutionInfoResponse {
+    fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+        write_maybe_relocatable(vm, ptr, self.execution_info_ptr)?;
+        Ok(())
+    }
+}
+
+pub fn get_execution_info(
+    _request: GetExecutionInfoRequest,
+    _vm: &mut VirtualMachine,
+    exec_wrapper: ExecutionHelperWrapper,
+    _remaining_gas: &mut Felt252,
+) -> SyscallResult<GetExecutionInfoResponse> {
+    let eh_ref = exec_wrapper.execution_helper.as_ref().borrow();
+    let execution_info_ptr = eh_ref.call_execution_info_ptr.unwrap();
+    Ok(GetExecutionInfoResponse { execution_info_ptr })
+}
+
+// TODO: LibraryCall syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct LibraryCallRequest {
+//     pub class_hash: ClassHash,
+//     pub function_selector: EntryPointSelector,
+//     pub calldata: Calldata,
+// }
+//
+// impl SyscallRequest for LibraryCallRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<LibraryCallRequest> {
+//         let class_hash = ClassHash(stark_felt_from_ptr(vm, ptr)?);
+//         let (function_selector, calldata) = read_call_params(vm, ptr)?;
+//
+//         Ok(LibraryCallRequest { class_hash, function_selector, calldata })
+//     }
+// }
+//
+// type LibraryCallResponse = CallContractResponse;
+//
+// pub fn library_call(
+//     request: LibraryCallRequest,
+//     vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     remaining_gas: &mut u64,
+// ) -> SyscallResult<LibraryCallResponse> {
+//     Ok(LibraryCallResponse { segment: retdata_segment })
+// }
+
+// TODO: LibraryCallL1Handler syscall.
+// pub fn library_call_l1_handler(
+//     request: LibraryCallRequest,
+//     vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     remaining_gas: &mut u64,
+// ) -> SyscallResult<LibraryCallResponse> {
+//     let call_to_external = false;
+//     let retdata_segment = execute_library_call(
+//         syscall_handler,
+//         vm,
+//         request.class_hash,
+//         call_to_external,
+//         request.function_selector,
+//         request.calldata,
+//         remaining_gas,
+//     )?;
+//
+//     Ok(LibraryCallResponse { segment: retdata_segment })
+// }
+
+// TODO: ReplaceClass syscall.
+//
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct ReplaceClassRequest {
+//     pub class_hash: ClassHash,
+// }
+//
+// impl SyscallRequest for ReplaceClassRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<ReplaceClassRequest> {
+//         let class_hash = ClassHash(stark_felt_from_ptr(vm, ptr)?);
+//
+//         Ok(ReplaceClassRequest { class_hash })
+//     }
+// }
+//
+// pub type ReplaceClassResponse = EmptyResponse;
+//
+// pub fn replace_class(
+//     request: ReplaceClassRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> SyscallResult<ReplaceClassResponse> {
+// }
+
+// TODO: SendMessageToL1 syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct SendMessageToL1Request {
+//     pub message: MessageToL1,
+// }
+//
+// impl SyscallRequest for SendMessageToL1Request {
+//     // The Cairo struct contains: `to_address`, `payload_size`, `payload`.
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<SendMessageToL1Request>
+// {         let to_address = EthAddress::try_from(stark_felt_from_ptr(vm, ptr)?)?;
+//         let payload = L2ToL1Payload(read_felt_array::<SyscallExecutionError>(vm, ptr)?);
+//
+//         Ok(SendMessageToL1Request { message: MessageToL1 { to_address, payload } })
+//     }
+// }
+//
+// type SendMessageToL1Response = EmptyResponse;
+//
+// pub fn send_message_to_l1(
+//     request: SendMessageToL1Request,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> SyscallResult<SendMessageToL1Response> {
+//     Ok(SendMessageToL1Response {})
+// }
+
+// TODO: StorageRead syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct StorageReadRequest {
+//     pub address_domain: StarkFelt,
+//     pub address: StorageKey,
+// }
+//
+// impl SyscallRequest for StorageReadRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<StorageReadRequest> {
+//         let address_domain = stark_felt_from_ptr(vm, ptr)?;
+//         if address_domain != StarkFelt::from(0_u8) {
+//             return Err(SyscallExecutionError::InvalidAddressDomain { address_domain });
+//         }
+//         let address = StorageKey::try_from(stark_felt_from_ptr(vm, ptr)?)?;
+//         Ok(StorageReadRequest { address_domain, address })
+//     }
+// }
+//
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct StorageReadResponse {
+//     pub value: StarkFelt,
+// }
+//
+// impl SyscallResponse for StorageReadResponse {
+//     fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+//         write_stark_felt(vm, ptr, self.value)?;
+//         Ok(())
+//     }
+// }
+//
+// pub fn storage_read(
+//     request: StorageReadRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> SyscallResult<StorageReadResponse> {
+// }
+
+// TODO: StorageWrite syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct StorageWriteRequest {
+//     pub address_domain: StarkFelt,
+//     pub address: StorageKey,
+//     pub value: StarkFelt,
+// }
+//
+// impl SyscallRequest for StorageWriteRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<StorageWriteRequest> {
+//         let address_domain = stark_felt_from_ptr(vm, ptr)?;
+//         if address_domain != StarkFelt::from(0_u8) {
+//             return Err(SyscallExecutionError::InvalidAddressDomain { address_domain });
+//         }
+//         let address = StorageKey::try_from(stark_felt_from_ptr(vm, ptr)?)?;
+//         let value = stark_felt_from_ptr(vm, ptr)?;
+//         Ok(StorageWriteRequest { address_domain, address, value })
+//     }
+// }
+//
+// pub type StorageWriteResponse = EmptyResponse;
+//
+// pub fn storage_write(
+//     request: StorageWriteRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> SyscallResult<StorageWriteResponse> {
+// }
+
+// TODO: Keccak syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct KeccakRequest {
+//     pub input_start: Relocatable,
+//     pub input_end: Relocatable,
+// }
+//
+// impl SyscallRequest for KeccakRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<KeccakRequest> {
+//         let input_start = vm.get_relocatable(*ptr)?;
+//         *ptr = (*ptr + 1)?;
+//         let input_end = vm.get_relocatable(*ptr)?;
+//         *ptr = (*ptr + 1)?;
+//         Ok(KeccakRequest { input_start, input_end })
+//     }
+// }
+//
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct KeccakResponse {
+//     pub result_low: Felt252,
+//     pub result_high: Felt252,
+// }
+//
+// impl SyscallResponse for KeccakResponse {
+//     fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult {
+//         write_felt(vm, ptr, self.result_low)?;
+//         write_felt(vm, ptr, self.result_high)?;
+//         Ok(())
+//     }
+// }
+//
+// pub fn keccak(
+//     request: KeccakRequest,
+//     vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     remaining_gas: &mut u64,
+// ) -> SyscallResult<KeccakResponse> {
+// }
+
+// TODO: SecpAdd syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct SecpAddRequest {
+//     pub lhs_id: Felt252,
+//     pub rhs_id: Felt252,
+// }
+//
+// impl SyscallRequest for SecpAddRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) ->
+// blockifier::execution::syscalls::SyscallResult<SecpAddRequest> {         Ok(SecpAddRequest {
+// lhs_id: felt_from_ptr(vm, ptr)?, rhs_id: felt_from_ptr(vm, ptr)? })     }
+// }
+//
+// type SecpAddResponse = SecpOpRespone;
+//
+// pub fn secp256k1_add(
+//     request: SecpAddRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpOpRespone> {
+//     syscall_handler.secp256k1_hint_processor.secp_add(request)
+// }
+//
+// pub fn secp256r1_add(
+//     request: SecpAddRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpOpRespone> {
+//     syscall_handler.secp256r1_hint_processor.secp_add(request)
+// }
+
+// TODO: SecpGetPointFromXRequest syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct SecpGetPointFromXRequest {
+//     x: BigUint,
+//     // The parity of the y coordinate, assuming a point with the given x coordinate exists.
+//     // True means the y coordinate is odd.
+//     y_parity: bool,
+// }
+//
+// impl SyscallRequest for SecpGetPointFromXRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) ->
+// blockifier::execution::syscalls::SyscallResult<SecpGetPointFromXRequest> {         let x =
+// SierraU256::from_memory(vm, ptr)?.to_biguint();
+//
+//         let y_parity = felt_to_bool(stark_felt_from_ptr(vm, ptr)?, "Invalid y parity")?;
+//         Ok(SecpGetPointFromXRequest { x, y_parity })
+//     }
+// }
+//
+// type SecpGetPointFromXResponse = SecpOptionalEcPointResponse;
+//
+// pub fn secp256k1_get_point_from_x(
+//     request: SecpGetPointFromXRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpGetPointFromXResponse> {
+//     syscall_handler.secp256k1_hint_processor.secp_get_point_from_x(request)
+// }
+//
+// pub fn secp256r1_get_point_from_x(
+//     request: SecpGetPointFromXRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpGetPointFromXResponse> {
+//     syscall_handler.secp256r1_hint_processor.secp_get_point_from_x(request)
+// }
+
+// TODO: SecpGetXy syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct SecpGetXyRequest {
+//     pub ec_point_id: Felt252,
+// }
+//
+// impl SyscallRequest for SecpGetXyRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) ->
+// blockifier::execution::syscalls::SyscallResult<SecpGetXyRequest> {         Ok(SecpGetXyRequest {
+// ec_point_id: felt_from_ptr(vm, ptr)? })     }
+// }
+//
+// type SecpGetXyResponse = EcPointCoordinates;
+//
+// impl SyscallResponse for SecpGetXyResponse {
+//     fn write(self, vm: &mut VirtualMachine, ptr: &mut Relocatable) ->
+// blockifier::execution::syscalls::WriteResponseResult {         write_u256(vm, ptr, self.x)?;
+//         write_u256(vm, ptr, self.y)?;
+//         Ok(())
+//     }
+// }
+//
+// pub fn secp256k1_get_xy(
+//     request: SecpGetXyRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpGetXyResponse> {
+// }
+//
+// pub fn secp256r1_get_xy(
+//     request: SecpGetXyRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpGetXyResponse> {
+// }
+
+// TODO: SecpMul syscall.
+// #[derive(Debug, Eq, PartialEq)]
+// pub struct SecpMulRequest {
+//     pub ec_point_id: Felt252,
+//     pub multiplier: BigUint,
+// }
+//
+// impl blockifier::execution::syscalls::SyscallRequest for SecpMulRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) ->
+// blockifier::execution::syscalls::SyscallResult<SecpMulRequest> {         let ec_point_id =
+// felt_from_ptr(vm, ptr)?;         let multiplier = SierraU256::from_memory(vm, ptr)?.to_biguint();
+//         Ok(SecpMulRequest { ec_point_id, multiplier })
+//     }
+// }
+//
+// type SecpMulResponse = SecpOpRespone;
+//
+// pub fn secp256k1_mul(
+//     request: SecpMulRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpMulResponse> {
+// }
+//
+// pub fn secp256r1_mul(
+//     request: SecpMulRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpMulResponse> {
+// }
+
+// TODO: SecpNew syscall.
+// type SecpNewRequest = EcPointCoordinates;
+//
+// impl blockifier::execution::syscalls::SyscallRequest for SecpNewRequest {
+//     fn read(vm: &VirtualMachine, ptr: &mut Relocatable) ->
+// blockifier::execution::syscalls::SyscallResult<SecpNewRequest> {         let x =
+// SierraU256::from_memory(vm, ptr)?.to_biguint();         let y = SierraU256::from_memory(vm,
+// ptr)?.to_biguint();         Ok(SecpNewRequest { x, y })
+//     }
+// }
+//
+// type SecpNewResponse = SecpOptionalEcPointResponse;
+//
+// pub fn secp256k1_new(
+//     request: SecpNewRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<SecpNewResponse> {
+// }
+//
+// type Secp256r1NewRequest = EcPointCoordinates;
+// type Secp256r1NewResponse = SecpOptionalEcPointResponse;
+//
+// pub fn secp256r1_new(
+//     request: Secp256r1NewRequest,
+//     _vm: &mut VirtualMachine,
+//     syscall_handler: &mut SyscallHintProcessor<'_>,
+//     _remaining_gas: &mut u64,
+// ) -> blockifier::execution::syscalls::SyscallResult<Secp256r1NewResponse> {
+// }

--- a/src/execution/syscalls.rs
+++ b/src/execution/syscalls.rs
@@ -1,13 +1,10 @@
-use cairo_vm::types::exec_scope::ExecutionScopes;
-use cairo_vm::types::relocatable::Relocatable;
-use cairo_vm::vm::errors::hint_errors::HintError;
-use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_vm::Felt252;
-use num_traits::ToPrimitive;
+use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::vm_core::VirtualMachine;
 
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_utils::{
-    write_maybe_relocatable, EmptyRequest, SyscallResponse, SyscallResult, WriteResponseResult,
+    EmptyRequest, SyscallResponse, SyscallResult, write_maybe_relocatable, WriteResponseResult,
 };
 
 // TODO: what is this for?

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -284,8 +284,7 @@ pub fn enter_syscall_scopes(
     let execution_helper: Box<dyn Any> = Box::new(exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?);
     let deprecated_syscall_handler: Box<dyn Any> =
         Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>("deprecated_syscall_handler")?);
-    let syscall_handler: Box<dyn Any> =
-        Box::new(exec_scopes.get::<OsSyscallHandlerWrapper>("syscall_handler")?);
+    let syscall_handler: Box<dyn Any> = Box::new(exec_scopes.get::<OsSyscallHandlerWrapper>("syscall_handler")?);
     let dict_manager: Box<dyn Any> = Box::new(exec_scopes.get_dict_manager()?);
     exec_scopes.enter_scope(HashMap::from_iter([
         (String::from("__deprecated_class_hashes"), deprecated_class_hashes),

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -19,6 +19,7 @@ use indoc::indoc;
 use crate::cairo_types::structs::ExecutionContext;
 use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
 use crate::execution::helper::ExecutionHelperWrapper;
+use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::vars::ids::{SIGNATURE_LEN, SIGNATURE_START};
 use crate::io::input::StarknetOsInput;
 use crate::io::InternalTransaction;
@@ -166,9 +167,9 @@ pub fn enter_scope_syscall_handler(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let dep_sys = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>("syscall_handler")?;
-    let deprecated_syscall_handler: Box<dyn Any> = Box::new(dep_sys);
-    exec_scopes.enter_scope(HashMap::from_iter([(String::from("syscall_handler"), deprecated_syscall_handler)]));
+    let sys = exec_scopes.get::<OsSyscallHandlerWrapper>("syscall_handler")?;
+    let syscall_handler: Box<dyn Any> = Box::new(sys);
+    exec_scopes.enter_scope(HashMap::from_iter([(String::from("syscall_handler"), syscall_handler)]));
     Ok(())
 }
 
@@ -284,7 +285,7 @@ pub fn enter_syscall_scopes(
     let deprecated_syscall_handler: Box<dyn Any> =
         Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>("deprecated_syscall_handler")?);
     let syscall_handler: Box<dyn Any> =
-        Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>("syscall_handler")?);
+        Box::new(exec_scopes.get::<OsSyscallHandlerWrapper>("syscall_handler")?);
     let dict_manager: Box<dyn Any> = Box::new(exec_scopes.get_dict_manager()?);
     exec_scopes.enter_scope(HashMap::from_iter([
         (String::from("__deprecated_class_hashes"), deprecated_class_hashes),

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use cairo_lang_casm::hints::{Hint, StarknetHint};
+use cairo_lang_casm::operand::{BinOpOperand, DerefOrImmediate, Operation, Register, ResOperand};
+use cairo_vm::Felt252;
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
     BuiltinHintProcessor, HintProcessorData,
 };
@@ -11,15 +13,15 @@ use cairo_vm::hint_processor::hint_processor_definition::{
 };
 use cairo_vm::serde::deserialize_program::ApTracking;
 use cairo_vm::types::exec_scope::ExecutionScopes;
-use cairo_vm::types::relocatable::MaybeRelocatable;
+use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::runners::cairo_runner::{ResourceTracker, RunResources};
 use cairo_vm::vm::vm_core::VirtualMachine;
-use cairo_vm::Felt252;
 use indoc::indoc;
 use num_bigint::BigInt;
 
 use crate::execution::helper::ExecutionHelperWrapper;
+use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::block_context::is_leaf;
 use crate::io::input::StarknetOsInput;
 
@@ -178,12 +180,33 @@ impl Default for SnosHintProcessor {
         let extensive_hints = EXTENSIVE_HINTS.into_iter().map(|(h, i)| (h.to_string(), i)).collect();
         Self {
             builtin_hint_proc: BuiltinHintProcessor::new_empty(),
-            cairo1_builtin_hint_proc: Cairo1HintProcessor::new(Default::default(), RunResources::default()),
+            cairo1_builtin_hint_proc: Cairo1HintProcessor::new(Default::default(), Default::default()),
             hints,
             extensive_hints,
             run_resources: Default::default(),
         }
     }
+}
+
+// from blockifier/cairo-vm:
+fn get_ptr_from_res_operand(vm: &mut VirtualMachine, res: &ResOperand) -> Result<Relocatable, HintError> {
+    let (cell, base_offset) = match res {
+        ResOperand::Deref(cell) => (cell, Felt252::ZERO),
+        ResOperand::BinOp(BinOpOperand {
+                              op: Operation::Add,
+                              a,
+                              b: DerefOrImmediate::Immediate(b),
+                          }) => (a, Felt252::from(&b.value)),
+        _ => return Err(HintError::CustomHint(
+            "Failed to extract buffer, expected ResOperand of BinOp type to have Inmediate b value".to_owned().into_boxed_str()
+        ))
+    };
+    let base = match cell.register {
+        Register::AP => vm.get_ap(),
+        Register::FP => vm.get_fp(),
+    };
+    let cell_reloc = (base + (i32::from(cell.offset)))?;
+    (vm.get_relocatable(cell_reloc)? + &base_offset).map_err(|e| e.into())
 }
 
 impl SnosHintProcessor {
@@ -195,14 +218,6 @@ impl SnosHintProcessor {
             .union(&self.extensive_hints.keys().cloned().collect::<HashSet<_>>())
             .cloned()
             .collect::<HashSet<_>>()
-    }
-    fn execute_syscall_hint(
-        &mut self,
-        _vm: &mut VirtualMachine,
-        hint: &StarknetHint,
-    ) -> Result<HintExtension, HintError> {
-        println!("TODO: execute syscall hint: {:?}", hint);
-        Ok(HintExtension::default())
     }
 }
 
@@ -243,8 +258,11 @@ impl HintProcessorLogic for SnosHintProcessor {
         }
 
         if let Some(hint) = hint_data.downcast_ref::<Hint>() {
-            if let Hint::Starknet(starknet_hint) = hint {
-                return self.execute_syscall_hint(vm, starknet_hint);
+            if let Hint::Starknet(StarknetHint::SystemCall { system }) = hint {
+                let syscall_ptr = get_ptr_from_res_operand(vm, system)?;
+                let syscall_handler =
+                    exec_scopes.get::<OsSyscallHandlerWrapper>("syscall_handler")?;
+                return syscall_handler.syscall(vm, exec_scopes, syscall_ptr).map(|_| HintExtension::default());
             } else {
                 return self.cairo1_builtin_hint_proc.execute(vm, exec_scopes, hint).map(|_| HintExtension::default());
             }

--- a/src/hints/syscalls.rs
+++ b/src/hints/syscalls.rs
@@ -367,7 +367,7 @@ mod tests {
         let syscall_ptr = Relocatable::from((0, 0));
         let execution_infos = vec![];
         let exec_helper = ExecutionHelperWrapper::new(execution_infos, &block_context);
-        let syscall_handler = DeprecatedOsSyscallHandlerWrapper::new(exec_helper, syscall_ptr);
+        let syscall_handler = OsSyscallHandlerWrapper::new(exec_helper, syscall_ptr);
 
         let mut exec_scopes = ExecutionScopes::new();
         exec_scopes.insert_value(vars::scopes::SYSCALL_HANDLER, syscall_handler);
@@ -398,8 +398,7 @@ mod tests {
         assert_eq!(os_context, Relocatable::from((2, 0)));
         assert_eq!(syscall_ptr, Relocatable::from((3, 0)));
 
-        let syscall_handler: DeprecatedOsSyscallHandlerWrapper =
-            exec_scopes.get(vars::scopes::SYSCALL_HANDLER).unwrap();
+        let syscall_handler: OsSyscallHandlerWrapper = exec_scopes.get(vars::scopes::SYSCALL_HANDLER).unwrap();
         assert_eq!(syscall_handler.syscall_ptr(), syscall_ptr);
     }
 }

--- a/src/hints/syscalls.rs
+++ b/src/hints/syscalls.rs
@@ -10,6 +10,7 @@ use cairo_vm::Felt252;
 use indoc::indoc;
 
 use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
+use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::vars;
 
 pub const CALL_CONTRACT: &str = "syscall_handler.call_contract(segments=segments, syscall_ptr=ids.syscall_ptr)";
@@ -345,8 +346,7 @@ pub fn set_syscall_ptr(
     insert_value_from_var_name(vars::ids::OS_CONTEXT, os_context, vm, ids_data, ap_tracking)?;
     insert_value_from_var_name(vars::ids::SYSCALL_PTR, syscall_ptr, vm, ids_data, ap_tracking)?;
 
-    // TODO: it should not be a deprecated syscall handler!
-    let syscall_handler: DeprecatedOsSyscallHandlerWrapper = exec_scopes.get(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler: OsSyscallHandlerWrapper = exec_scopes.get(vars::scopes::SYSCALL_HANDLER)?;
     syscall_handler.set_syscall_ptr(syscall_ptr);
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use error::SnOsError;
 use execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
 use execution::helper::ExecutionHelperWrapper;
 use io::output::StarknetOsOutput;
+use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 
 use crate::io::input::StarknetOsInput;
 
@@ -52,7 +53,7 @@ pub fn run_os(
     let deprecated_syscall_handler =
         DeprecatedOsSyscallHandlerWrapper::new(execution_helper.clone(), vm.add_memory_segment());
 
-    let syscall_handler = DeprecatedOsSyscallHandlerWrapper::new(execution_helper.clone(), vm.add_memory_segment());
+    let syscall_handler = OsSyscallHandlerWrapper::new(execution_helper.clone(), vm.add_memory_segment());
 
     // Setup Globals
     cairo_runner.exec_scopes.insert_value("os_input", os_input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ use error::SnOsError;
 use execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
 use execution::helper::ExecutionHelperWrapper;
 use io::output::StarknetOsOutput;
-use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 
+use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::io::input::StarknetOsInput;
 
 mod cairo_types;


### PR DESCRIPTION
Infrastructure for executing Cairo1 syscalls. Executes first `GetExecutionInfo` syscall, fails on next `CallContract` syscall:
```
...
about to call contract_address: 3221225984, class_hash: 2147484160, is_deprecated: 0
about to execute syscall: GetExecutionInfo
about to execute syscall: CallContract
...
```

A lot of code borrowed from Blockifier. @odesenfans there are a lot of TODOs in syscalls.cairo. This code is adapted from blockifier. I prefer to move it in one go, put not ready parts in comments with todos, then uncomment one by one in subsequent prs.