### PR TITLE
Fix: support nested structures for `FieldOffsetGetters`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
 name = "cairo-type-derive"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.48",
 ]

--- a/cairo-type-derive/Cargo.toml
+++ b/cairo-type-derive/Cargo.toml
@@ -9,3 +9,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0.35"
 syn = "2.0.48"
+proc-macro2 = "1.0.78"

--- a/src/cairo_types/traits.rs
+++ b/src/cairo_types/traits.rs
@@ -25,6 +25,16 @@ mod tests {
         pub c: Felt252,
     }
 
+    #[derive(FieldOffsetGetters)]
+    struct MyNestedType {
+        #[allow(unused)]
+        pub x: Felt252,
+        #[allow(unused)]
+        pub y: MyType,
+        #[allow(unused)]
+        pub z: Felt252,
+    }
+
     #[test]
     fn write_cairo_type() {
         let mut vm = VirtualMachine::new(false);
@@ -71,5 +81,13 @@ mod tests {
         assert_eq!(MyType::a_offset(), 0);
         assert_eq!(MyType::b_offset(), 1);
         assert_eq!(MyType::c_offset(), 2);
+
+        assert_eq!(MyType::cairo_size(), 3);
+
+        assert_eq!(MyNestedType::x_offset(), 0);
+        assert_eq!(MyNestedType::y_offset(), 1);
+        assert_eq!(MyNestedType::z_offset(), 4);
+
+        assert_eq!(MyNestedType::cairo_size(), 5);
     }
 }


### PR DESCRIPTION
Problem: the derive macro for `FieldOffsetGetters` assumes a size of 1 for each field of a struct, even if they are structures that span multiple felts.

Solution: take this into account in the offset computation. Deriving `FieldOffsetGetters` now adds a `cairo_size() -> usize` method that computes the size of the struct in terms of felts. This method is called for each struct encountered in the derive macro.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
