### PR TITLE
Cleanup: SET_AP_TO_CALLDATA_LEN is already implemented

### DIFF
--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -34,9 +34,6 @@ const ENTER_SCOPE_NEW_NODE: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-const SET_AP_TO_CALLDATA_LEN: &str = "memory[ap] = to_felt_or_relocatable(len(tx.calldata))";
-
-#[allow(unused)]
 const ADD_RELOCATION_RULE: &str = "memory.add_relocation_rule(src_ptr=ids.src_ptr, dest_ptr=ids.dest_ptr)";
 
 #[allow(unused)]


### PR DESCRIPTION
This hint is already implemented as TX_CALLDATA_LEN. Removed the hint code from `unimplemented.rs`.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
