### PR TITLE
Cleanup: GEN_CALLDATA_ARG is already implemented

### DIFF
--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -50,9 +50,6 @@ const DECODE_NODE: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-const GEN_CALLDATA_ARG: &str = "memory[ap] = to_felt_or_relocatable(segments.gen_arg(tx.calldata))";
-
-#[allow(unused)]
 const SET_AP_TO_ENTRY_POINT_SELECTOR: &str = "memory[ap] = to_felt_or_relocatable(tx.entry_point_selector)";
 
 #[allow(unused)]


### PR DESCRIPTION
This hint is already implemented as `TX_CALLDATA`.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
