### PR TITLE
Cleanup: SET_AP_TO_ENTRY_POINT_SELECTOR is already implemented

### DIFF
--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -50,9 +50,6 @@ const DECODE_NODE: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-const SET_AP_TO_ENTRY_POINT_SELECTOR: &str = "memory[ap] = to_felt_or_relocatable(tx.entry_point_selector)";
-
-#[allow(unused)]
 const SET_TREE_STRUCTURE: &str = indoc! {r#"
 	from starkware.python.math_utils import div_ceil
 	onchain_data_start = ids.da_start


### PR DESCRIPTION
This hint is already implemented as `TX_ENTRY_POINT_SELECTOR`.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
