### PR TITLE
Feature: CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS hint

### DIFF
--- a/src/cairo_types/syscalls.rs
+++ b/src/cairo_types/syscalls.rs
@@ -2,6 +2,23 @@ use cairo_type_derive::FieldOffsetGetters;
 use cairo_vm::Felt252;
 
 #[derive(FieldOffsetGetters)]
+pub struct StorageReadRequest {
+    pub selector: Felt252,
+    pub address: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct StorageReadResponse {
+    pub value: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct StorageRead {
+    pub request: StorageReadRequest,
+    pub response: StorageReadResponse,
+}
+
+#[derive(FieldOffsetGetters)]
 pub struct StorageWrite {
     pub selector: Felt252,
     pub address: Felt252,

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -46,7 +46,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 102] = [
+static HINTS: [(&str, HintImpl); 103] = [
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
     (IS_N_GE_TWO, is_n_ge_two),
@@ -81,7 +81,11 @@ static HINTS: [(&str, HintImpl); 102] = [
     (execution::ASSERT_TRANSACTION_HASH, execution::assert_transaction_hash),
     (execution::ASSERT_TRANSACTION_HASH, execution::assert_transaction_hash),
     (execution::CHECK_IS_DEPRECATED, execution::check_is_deprecated),
-    (execution::CACHE_CONTRACT_STORAGE, execution::cache_contract_storage),
+    (execution::CACHE_CONTRACT_STORAGE_REQUEST_KEY, execution::cache_contract_storage_request_key),
+    (
+        execution::CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS,
+        execution::cache_contract_storage_syscall_request_address,
+    ),
     (execution::CONTRACT_ADDRESS, execution::contract_address),
     (execution::END_TX, execution::end_tx),
     (execution::ENTER_CALL, execution::enter_call),

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -1,14 +1,6 @@
 use indoc::indoc;
 
 #[allow(unused)]
-const CACHE_CONTRACT_STORAGE: &str = indoc! {r#"
-	# Make sure the value is cached (by reading it), to be used later on for the
-	# commitment computation.
-	value = execution_helper.storage_by_address[ids.contract_address].read(key=ids.request.key)
-	assert ids.value == value, "Inconsistent storage value.""#
-};
-
-#[allow(unused)]
 const ENTER_SCOPE_SYSCALL_HANDLER: &str = "vm_enter_scope({'syscall_handler': syscall_handler})";
 
 #[allow(unused)]


### PR DESCRIPTION
This hint shares most of its implementation with the hint previously tagged as CACHE_CONTRACT_STORAGE. Renamed this hint to CACHE_CONTRACT_STORAGE_REQUEST_KEY and moved most of the code to a common implementation.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
