### PR TITLE
Cleanup: map second CONTRACT_ADDRESS hint declaration

### DIFF
--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -471,6 +471,13 @@ pub const CONTRACT_ADDRESS: &str = indoc! {r#"
     )"#
 };
 
+pub const CONTRACT_ADDRESS_2: &str = indoc! {r#"
+	from starkware.starknet.business_logic.transaction.objects import InternalL1Handler
+	ids.contract_address = (
+	    tx.contract_address if isinstance(tx, InternalL1Handler) else tx.sender_address
+	)"#
+};
+
 pub fn contract_address(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -46,7 +46,7 @@ type HintImpl = fn(
     &HashMap<String, Felt252>,
 ) -> Result<(), HintError>;
 
-static HINTS: [(&str, HintImpl); 112] = [
+static HINTS: [(&str, HintImpl); 113] = [
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
     (IS_N_GE_TWO, is_n_ge_two),
@@ -87,6 +87,7 @@ static HINTS: [(&str, HintImpl); 112] = [
         execution::cache_contract_storage_syscall_request_address,
     ),
     (execution::CONTRACT_ADDRESS, execution::contract_address),
+    (execution::CONTRACT_ADDRESS_2, execution::contract_address),
     (execution::END_TX, execution::end_tx),
     (execution::ENTER_CALL, execution::enter_call),
     (execution::ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER, execution::enter_scope_deprecated_syscall_handler),

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -59,14 +59,6 @@ const PREPARE_PREIMAGE_VALIDATION_BOTTOM: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-const SET_CONTRACT_ADDRESS: &str = indoc! {r#"
-	from starkware.starknet.business_logic.transaction.objects import InternalL1Handler
-	ids.contract_address = (
-	    tx.contract_address if isinstance(tx, InternalL1Handler) else tx.sender_address
-	)"#
-};
-
-#[allow(unused)]
 const SET_AP_TO_NONCE_ARG_SEGMENT: &str = "memory[ap] = to_felt_or_relocatable(segments.gen_arg([tx.nonce]))";
 
 #[allow(unused)]


### PR DESCRIPTION
The CONTRACT_ADDRESS hint is declared in two places in the OS with a slightly different format.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
