### PR TITLE
Chore: update cairo-vm to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.0-rc1"
-source = "git+https://github.com/lambdaclass/cairo-vm#42e04161de82d7e5381258def4b65087c8944660"
+source = "git+https://github.com/lambdaclass/cairo-vm#ec00e31ec5ed412d520957edef8b3441db82d133"
 dependencies = [
  "anyhow",
  "ark-ff",


### PR DESCRIPTION
This version includes the `vm.get_output_builtin_mut()` and the `output_builtin.add_attribute()` methods. Fixed the workarounds for the absence of these methods.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
