### PR TITLE
Feature: support skipping validation of hashes

### DIFF
--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -17,7 +17,7 @@ use num_traits::ToPrimitive;
 
 use crate::cairo_types::builtins::HashBuiltin;
 use crate::cairo_types::trie::NodeEdge;
-use crate::hints::types::{DescentMap, Preimage};
+use crate::hints::types::{skip_verification_if_configured, DescentMap, Preimage};
 use crate::hints::vars;
 use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, TreeUpdate};
@@ -233,7 +233,8 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
     // memory[hash_ptr + ids.HashBuiltin.y] = right_hash
     vm.insert_value((hash_ptr + HashBuiltin::y_offset())?, right_hash)?;
 
-    // TODO: __patricia_skip_validation_runner
+    let hash_result_address = (hash_ptr + HashBuiltin::result_offset())?;
+    skip_verification_if_configured(exec_scopes, hash_result_address)?;
 
     // memory[ap] = int(case != 'both')"#
     let ap = match case {

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -17,7 +17,7 @@ use crate::cairo_types::builtins::{HashBuiltin, SpongeHashBuiltin};
 use crate::cairo_types::traits::CairoType;
 use crate::cairo_types::trie::NodeEdge;
 use crate::execution::helper::ExecutionHelperWrapper;
-use crate::hints::types::Preimage;
+use crate::hints::types::{skip_verification_if_configured, Preimage};
 use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, CommitmentInfo, StorageLeaf};
@@ -195,7 +195,8 @@ pub fn load_edge(
     let hash_result_ptr: Relocatable = (hash_ptr + SpongeHashBuiltin::result_offset())?;
     vm.insert_value(hash_result_ptr, res)?;
 
-    // TODO: __patricia_skip_validation_runner
+    let hash_result_address = (hash_ptr + HashBuiltin::result_offset())?;
+    skip_verification_if_configured(exec_scopes, hash_result_address)?;
 
     Ok(())
 }
@@ -231,7 +232,8 @@ pub fn load_bottom(
     vm.insert_value((hash_ptr + HashBuiltin::x_offset())?, x)?;
     vm.insert_value((hash_ptr + HashBuiltin::y_offset())?, y)?;
 
-    // TODO: __patricia_skip_validation_runner
+    let hash_result_address = (hash_ptr + HashBuiltin::result_offset())?;
+    skip_verification_if_configured(exec_scopes, hash_result_address)?;
 
     Ok(())
 }
@@ -309,6 +311,7 @@ mod tests {
 
     use super::*;
     use crate::crypto::pedersen::PedersenHash;
+    use crate::hints::types::PatriciaSkipValidationRunner;
     use crate::starknet::starknet_storage::{OsSingleStarknetStorage, StorageLeaf};
     use crate::starkware_utils::commitment_tree::base_types::Height;
     use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
@@ -513,6 +516,8 @@ mod tests {
         let mut preimage: HashMap<Felt252, Vec<Felt252>> = Default::default();
         preimage.insert(1_usize.into(), vec![2_usize.into(), 3_usize.into(), 4_usize.into()]);
         exec_scopes.insert_value(vars::scopes::PREIMAGE, preimage);
+        exec_scopes
+            .insert_value::<Option<PatriciaSkipValidationRunner>>(vars::scopes::PATRICIA_SKIP_VALIDATION_RUNNER, None);
 
         load_edge(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
 

--- a/src/hints/types.rs
+++ b/src/hints/types.rs
@@ -1,7 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
+use cairo_vm::types::exec_scope::ExecutionScopes;
 use cairo_vm::types::relocatable::Relocatable;
+use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::Felt252;
+
+use crate::hints::vars;
 
 pub type Preimage = HashMap<Felt252, Vec<Felt252>>;
 
@@ -12,3 +16,20 @@ pub struct PatriciaSkipValidationRunner {
 
 // TODO: define correctly when implementing the descend functionality
 pub type DescentMap = HashMap<(Felt252, Felt252), Vec<Felt252>>;
+
+/// Inserts a hash result address in `__patricia_skip_validation_runner` if it exists.
+///
+/// This skips validation of the preimage dict to speed up the VM. When this flag is set,
+/// mistakes in the preimage dict will be discovered only in the prover.
+pub fn skip_verification_if_configured(
+    exec_scopes: &mut ExecutionScopes,
+    address: Relocatable,
+) -> Result<(), HintError> {
+    let patricia_skip_validation_runner: &mut Option<PatriciaSkipValidationRunner> =
+        exec_scopes.get_mut_ref(vars::scopes::PATRICIA_SKIP_VALIDATION_RUNNER)?;
+    if let Some(skipped) = patricia_skip_validation_runner {
+        skipped.verified_addresses.insert(address);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Problem: the `__patricia_skip_validation_runner` part in several hints has been ignored so far and left as TODOs.

Solution: Now that the `PatriciaSkipValidationRunner` struct is upstreamed, added a utility function that checks if this option is configured and inserts the addresses to skip in the runner.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
