### PR TITLE
Convert to Cargo workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2444,9 +2444,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -3098,9 +3098,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -3111,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
-workspace = { members = ["cairo-type-derive", "bin/hint_tool"] }
+[workspace]
+members = ["cairo-type-derive", "bin/hint_tool"]
+resolver = "2"
+
 [package]
 edition = "2021"
 name = "snos"
 version = "0.1.0"
 
-[dependencies]
+[workspace.dependencies]
 anyhow = "1.0.75"
 assert_matches = "1.5.0"
 async-stream = "0.3.5"
@@ -48,6 +51,51 @@ cairo-lang-filesystem = { version = "~2.5.4" }
 cairo-lang-semantic = { version = "~2.5.4" }
 cairo-lang-sierra = { version = "~2.5.4" }
 cairo-lang-syntax = { version = "~2.5.4" }
+
+[dependencies]
+anyhow = { workspace = true }
+assert_matches = { workspace = true }
+async-stream = { workspace = true }
+base64 = { workspace = true }
+bitvec = { workspace = true }
+blockifier = { workspace = true }
+cairo-type-derive = { workspace = true }
+cairo-vm = { workspace = true }
+futures = { workspace = true }
+futures-util = { workspace = true }
+getset = { workspace = true }
+heck = { workspace = true }
+hex = { workspace = true }
+indexmap = { workspace = true }
+indoc = { workspace = true }
+lazy_static = { workspace = true }
+log = { workspace = true }
+num-bigint = { workspace = true }
+num-integer = { workspace = true }
+num-traits = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+serde_yaml = { workspace = true }
+starknet-crypto = { workspace = true }
+starknet_api = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+uuid = { workspace = true }
+zip = { workspace = true }
+
+# These dependencies pin cairo-lang requirement versions because cairo-vm does not do it
+cairo-lang-starknet = { workspace = true }
+cairo-lang-casm = { workspace = true }
+cairo-lang-defs = { workspace = true }
+cairo-lang-diagnostics = { workspace = true }
+cairo-lang-filesystem = { workspace = true }
+cairo-lang-semantic = { workspace = true }
+cairo-lang-sierra = { workspace = true }
+cairo-lang-syntax = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/bin/hint_tool/Cargo.toml
+++ b/bin/hint_tool/Cargo.toml
@@ -4,12 +4,13 @@ name = "examples"
 version = "0.1.0"
 
 [dependencies]
-blockifier = { git = "https://github.com/keep-starknet-strange/blockifier", branch = "snos/callinfo-clone", features = ["clone", "testing"] }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", features = ["extensive_hints", "cairo-1-hints"] }
-clap = { version = "4.5.4", features = ["derive"] }
-serde = { version = "1.0.188", features = ["derive"] }
-serde_json = { version = "1.0.105", features = ["arbitrary_precision"] }
+blockifier = { workspace = true }
+cairo-vm = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
 snos = { path = "../../" }
+clap = { version = "4.5.4", features = ["derive"] }
 
 [[bin]]
 name = "hint_tool"


### PR DESCRIPTION
This PR converts the project to a Cargo workspace structure.

The root `Cargo.toml` is a bit messy as each dependency is duplicated (this isn't exactly obvious from the diff); I think this is a consequence of having a crate in the root directory itself. This could be fixed by moving the `snos` crate to a subdir but that would be very disruptive.