### PR TITLE
Chore: update cairo-vm to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.0-rc1"
-source = "git+https://github.com/lambdaclass/cairo-vm#c692b7594a74ee3245cf7affc7c8cfc296b0398c"
+source = "git+https://github.com/lambdaclass/cairo-vm#6de8f56fcb28f5e5c0669c747cc76ce34cfef6aa"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1027,7 +1027,6 @@ dependencies = [
  "hex",
  "keccak",
  "lazy_static",
- "mimalloc",
  "nom",
  "num-bigint",
  "num-integer",

--- a/src/execution/execute_syscalls.rs
+++ b/src/execution/execute_syscalls.rs
@@ -43,7 +43,7 @@ pub fn is_block_number_in_block_hash_buffer(
         .get(STORED_BLOCK_HASH_BUFFER)
         .ok_or_else(|| HintError::MissingConstant(Box::new(STORED_BLOCK_HASH_BUFFER)))?;
 
-    let result = *request_block_number > *current_block_number - *stored_block_hash_buffer;
+    let result = request_block_number > *current_block_number - *stored_block_hash_buffer;
 
     insert_value_into_ap(vm, if result { Felt252::ONE } else { Felt252::ZERO })?;
 

--- a/src/hints/builtins.rs
+++ b/src/hints/builtins.rs
@@ -1,11 +1,12 @@
 use std::any::Any;
 use std::collections::HashMap;
-use std::ops::{AddAssign, Deref};
+use std::ops::AddAssign;
 
 use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
     get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
 };
 use cairo_vm::hint_processor::hint_processor_definition::HintReference;
+use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
 use cairo_vm::serde::deserialize_program::ApTracking;
 use cairo_vm::types::exec_scope::ExecutionScopes;
 use cairo_vm::types::relocatable::MaybeRelocatable;
@@ -13,7 +14,7 @@ use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_vm::Felt252;
 use indoc::indoc;
-use num_traits::{ToPrimitive, Zero};
+use num_traits::Zero;
 
 use crate::cairo_types::structs::BuiltinParams;
 
@@ -26,7 +27,7 @@ pub fn selected_builtins(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let n_selected_builtins: Box<dyn Any> =
-        Box::new(get_integer_from_var_name("n_selected_builtins", vm, ids_data, ap_tracking)?.into_owned());
+        Box::new(get_integer_from_var_name("n_selected_builtins", vm, ids_data, ap_tracking)?);
     exec_scopes.enter_scope(HashMap::from_iter([(String::from("n_selected_builtins"), n_selected_builtins)]));
     Ok(())
 }
@@ -104,13 +105,9 @@ pub fn update_builtin_ptrs(
 
     let selected_ptrs = get_ptr_from_var_name("selected_ptrs", vm, ids_data, ap_tracking)?;
 
-    let all_builtins = vm
-        .get_continuous_range(builtins_encoding_addr, n_builtins.deref().to_usize().ok_or(HintError::WrongHintData)?)?;
+    let all_builtins = vm.get_continuous_range(builtins_encoding_addr, felt_to_usize(&n_builtins)?)?;
 
-    let selected_builtins = vm.get_continuous_range(
-        selected_encodings,
-        n_selected_builtins.deref().to_usize().ok_or(HintError::WrongHintData)?,
-    )?;
+    let selected_builtins = vm.get_continuous_range(selected_encodings, felt_to_usize(&n_selected_builtins)?)?;
 
     let mut returned_builtins: Vec<MaybeRelocatable> = Vec::new();
     let mut selected_builtin_offset: usize = 0;

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -159,7 +159,7 @@ pub fn assert_transaction_hash(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let tx = exec_scopes.get::<InternalTransaction>("tx")?;
-    let transaction_hash = get_integer_from_var_name("transaction_hash", vm, ids_data, ap_tracking)?.into_owned();
+    let transaction_hash = get_integer_from_var_name("transaction_hash", vm, ids_data, ap_tracking)?;
 
     assert_eq!(
         tx.hash_value,
@@ -294,7 +294,7 @@ pub fn get_contract_address_state_entry_and_set_new_state_entry(
     let dict_ptr = get_ptr_from_var_name(vars::ids::CONTRACT_STATE_CHANGES, vm, ids_data, ap_tracking)?;
     let key = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
 
-    get_state_entry_and_set_new_state_entry(dict_ptr, key.into_owned(), vm, exec_scopes, ids_data, ap_tracking)?;
+    get_state_entry_and_set_new_state_entry(dict_ptr, key, vm, exec_scopes, ids_data, ap_tracking)?;
 
     Ok(())
 }
@@ -959,8 +959,7 @@ pub fn compare_return_value(
     let expected = vm.get_range(expected_retdata_ptr, size);
 
     let ids_retdata = get_ptr_from_var_name("retdata", vm, ids_data, ap_tracking)?;
-    let ids_retdata_size =
-        get_integer_from_var_name("retdata_size", vm, ids_data, ap_tracking)?.into_owned().to_usize().unwrap();
+    let ids_retdata_size = get_integer_from_var_name("retdata_size", vm, ids_data, ap_tracking)?.to_usize().unwrap();
 
     let actual = vm.get_range(ids_retdata, ids_retdata_size);
 
@@ -1001,7 +1000,7 @@ pub fn log_enter_syscall(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let selector = get_integer_from_var_name(SELECTOR, _vm, ids_data, _ap_tracking)?;
-    println!("entering syscall: {:?} execution", SyscallSelector::try_from(*selector)?);
+    println!("entering syscall: {:?} execution", SyscallSelector::try_from(selector)?);
     // TODO: implement logging
     Ok(())
 }
@@ -1159,14 +1158,13 @@ fn cache_contract_storage(
 ) -> Result<(), HintError> {
     let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
 
-    let contract_address =
-        get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?.into_owned();
+    let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
 
     let value = execution_helper.read_storage_for_address(contract_address, key).map_err(|_| {
         HintError::CustomHint(format!("No storage found for contract {}", contract_address).into_boxed_str())
     })?;
 
-    let ids_value = get_integer_from_var_name(vars::ids::VALUE, vm, ids_data, ap_tracking)?.into_owned();
+    let ids_value = get_integer_from_var_name(vars::ids::VALUE, vm, ids_data, ap_tracking)?;
     if ids_value != value {
         return Err(HintError::AssertionFailed(
             format!("Inconsistent storage value (expected {}, got {})", ids_value, value).into_boxed_str(),
@@ -1366,7 +1364,7 @@ pub fn enter_scope_descend_edge(
     let mut new_node: UpdateTree<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
     let length = {
         let length = get_integer_from_var_name(vars::ids::LENGTH, vm, ids_data, ap_tracking)?;
-        length.to_u64().ok_or(MathError::Felt252ToU64Conversion(Box::new(length.into_owned())))?
+        length.to_u64().ok_or(MathError::Felt252ToU64Conversion(Box::new(length)))?
     };
     let word = get_integer_from_var_name(vars::ids::WORD, vm, ids_data, ap_tracking)?.to_biguint();
 
@@ -1414,8 +1412,7 @@ pub fn write_syscall_result_deprecated(
 ) -> Result<(), HintError> {
     let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
-    let contract_address =
-        get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?.into_owned();
+    let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     // ids.prev_value = storage.read(key=ids.syscall_ptr.address)
@@ -1463,8 +1460,7 @@ pub fn write_syscall_result(
 ) -> Result<(), HintError> {
     let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
-    let contract_address =
-        get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?.into_owned();
+    let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let request = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
 
     // ids.prev_value = storage.read(key=ids.request.key)
@@ -1566,9 +1562,8 @@ pub fn write_old_block_to_storage(
     let block_hash_contract_address = constants
         .get(BLOCK_HASH_CONTRACT_ADDRESS)
         .ok_or_else(|| HintError::MissingConstant(Box::new(BLOCK_HASH_CONTRACT_ADDRESS)))?;
-    let old_block_number =
-        get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?.into_owned();
-    let old_block_hash = get_integer_from_var_name(vars::ids::OLD_BLOCK_HASH, vm, ids_data, ap_tracking)?.into_owned();
+    let old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
+    let old_block_hash = get_integer_from_var_name(vars::ids::OLD_BLOCK_HASH, vm, ids_data, ap_tracking)?;
 
     println!("writing block number: {} -> block hash: {}", old_block_number, old_block_hash);
     execution_helper
@@ -1645,8 +1640,7 @@ pub fn get_old_block_number_and_hash(
     let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let (old_block_number, old_block_hash) = execution_helper.get_old_block_number_and_hash()?;
 
-    let ids_old_block_number =
-        get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?.into_owned();
+    let ids_old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
     if old_block_number != ids_old_block_number {
         return Err(HintError::AssertionFailed(
             "Inconsistent block number. The constant STORED_BLOCK_HASH_BUFFER is probably out of sync."
@@ -1816,7 +1810,7 @@ mod tests {
         assert_eq!(exec_scopes.get::<UpdateTree<StorageLeaf>>(vars::scopes::NODE).unwrap(), left_child);
 
         let child_bit = get_integer_from_var_name(vars::ids::CHILD_BIT, &mut vm, &ids_data, &ap_tracking).unwrap();
-        assert_eq!(*child_bit, Felt252::ZERO);
+        assert_eq!(child_bit, Felt252::ZERO);
     }
 
     #[rstest]
@@ -1876,15 +1870,13 @@ mod tests {
             .expect("Hint should not fail");
 
         // Check that the storage was updated
-        let prev_value =
-            get_integer_from_var_name(vars::ids::PREV_VALUE, &mut vm, &ids_data, &ap_tracking).unwrap().into_owned();
+        let prev_value = get_integer_from_var_name(vars::ids::PREV_VALUE, &mut vm, &ids_data, &ap_tracking).unwrap();
         assert_eq!(prev_value, Felt252::from(8000));
         let stored_value = execution_helper_with_storage.read_storage_for_address(contract_address, key).unwrap();
         assert_eq!(stored_value, Felt252::from(777));
 
         // Check the state entry
-        let state_entry =
-            get_integer_from_var_name(vars::ids::STATE_ENTRY, &mut vm, &ids_data, &ap_tracking).unwrap().into_owned();
+        let state_entry = get_integer_from_var_name(vars::ids::STATE_ENTRY, &mut vm, &ids_data, &ap_tracking).unwrap();
         assert_eq!(state_entry, Felt252::from(123));
     }
 }

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -53,7 +53,7 @@ pub fn is_case_right(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let case: DecodeNodeCase = exec_scopes.get(vars::scopes::CASE)?;
-    let bit = get_integer_from_var_name(vars::ids::BIT, vm, ids_data, ap_tracking)?.into_owned();
+    let bit = get_integer_from_var_name(vars::ids::BIT, vm, ids_data, ap_tracking)?;
 
     let case_felt = match case {
         DecodeNodeCase::Right => Felt252::ONE,
@@ -80,7 +80,7 @@ pub fn set_bit(
     let edge_ptr = get_ptr_from_var_name(vars::ids::EDGE, vm, ids_data, ap_tracking)?;
     let edge_path = vm.get_integer((edge_ptr + NodeEdge::path_offset())?)?.into_owned();
     let new_length = {
-        let new_length = get_integer_from_var_name(vars::ids::NEW_LENGTH, vm, ids_data, ap_tracking)?.into_owned();
+        let new_length = get_integer_from_var_name(vars::ids::NEW_LENGTH, vm, ids_data, ap_tracking)?;
         new_length.to_u64().ok_or(MathError::Felt252ToU64Conversion(Box::new(new_length)))?
     };
 
@@ -105,8 +105,8 @@ pub fn set_ap_to_descend(
 ) -> Result<(), HintError> {
     let descent_map: DescentMap = exec_scopes.get(vars::scopes::DESCENT_MAP)?;
 
-    let height = get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?.into_owned();
-    let path = get_integer_from_var_name(vars::ids::PATH, vm, ids_data, ap_tracking)?.into_owned();
+    let height = get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?;
+    let path = get_integer_from_var_name(vars::ids::PATH, vm, ids_data, ap_tracking)?;
 
     let ap = match descent_map.get(&(height, path)) {
         None => Felt252::ZERO,
@@ -170,7 +170,7 @@ pub fn height_is_zero_or_len_node_preimage_is_two(
     let height = get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?;
     let node = get_integer_from_var_name(vars::ids::NODE, vm, ids_data, ap_tracking)?;
 
-    let ap = if *height == Felt252::ZERO {
+    let ap = if height == Felt252::ZERO {
         Felt252::ONE
     } else {
         let preimage: Preimage = exec_scopes.get(vars::scopes::PREIMAGE)?;
@@ -322,7 +322,7 @@ mod tests {
         // in the implementation of the hint
         set_bit(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).expect("Hint should succeed");
 
-        let bit = get_integer_from_var_name(vars::ids::BIT, &mut vm, &ids_data, &ap_tracking).unwrap().into_owned();
+        let bit = get_integer_from_var_name(vars::ids::BIT, &mut vm, &ids_data, &ap_tracking).unwrap();
         assert_eq!(bit, Felt252::from(1));
     }
 }

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -69,7 +69,7 @@ pub fn set_preimage_for_state_commitments(
     let preimage = os_input.contract_state_commitment_info.commitment_facts;
     exec_scopes.insert_value(vars::scopes::PREIMAGE, preimage);
 
-    let merkle_height = get_integer_from_var_name(vars::ids::MERKLE_HEIGHT, vm, ids_data, ap_tracking)?.into_owned();
+    let merkle_height = get_integer_from_var_name(vars::ids::MERKLE_HEIGHT, vm, ids_data, ap_tracking)?;
     let tree_height: Felt252 = os_input.contract_state_commitment_info.tree_height.into();
     assert_tree_height_eq_merkle_height(tree_height, merkle_height)?;
 
@@ -112,7 +112,7 @@ pub fn set_preimage_for_class_commitments(
     let preimage = os_input.contract_class_commitment_info.commitment_facts;
     exec_scopes.insert_value(vars::scopes::PREIMAGE, preimage);
 
-    let merkle_height = get_integer_from_var_name(vars::ids::MERKLE_HEIGHT, vm, ids_data, ap_tracking)?.into_owned();
+    let merkle_height = get_integer_from_var_name(vars::ids::MERKLE_HEIGHT, vm, ids_data, ap_tracking)?;
     let tree_height: Felt252 = os_input.contract_class_commitment_info.tree_height.into();
     assert_tree_height_eq_merkle_height(tree_height, merkle_height)?;
 
@@ -145,7 +145,7 @@ pub fn set_preimage_for_current_commitment_info(
     let preimage = commitment_info.commitment_facts;
     exec_scopes.insert_value(vars::scopes::PREIMAGE, preimage);
 
-    let merkle_height = get_integer_from_var_name(vars::ids::MERKLE_HEIGHT, vm, ids_data, ap_tracking)?.into_owned();
+    let merkle_height = get_integer_from_var_name(vars::ids::MERKLE_HEIGHT, vm, ids_data, ap_tracking)?;
     let tree_height: Felt252 = commitment_info.tree_height.into();
     assert_tree_height_eq_merkle_height(tree_height, merkle_height)?;
 
@@ -174,7 +174,7 @@ pub fn load_edge(
     insert_value_from_var_name(vars::ids::EDGE, new_segment_base, vm, ids_data, ap_tracking)?;
 
     let preimage: HashMap<Felt252, Vec<Felt252>> = exec_scopes.get(vars::scopes::PREIMAGE)?;
-    let node = get_integer_from_var_name(vars::ids::NODE, vm, ids_data, ap_tracking)?.into_owned();
+    let node = get_integer_from_var_name(vars::ids::NODE, vm, ids_data, ap_tracking)?;
     let node_values = preimage
         .get(&node)
         .ok_or(HintError::CustomHint("preimage does not contain expected edge".to_string().into_boxed_str()))?;
@@ -421,11 +421,11 @@ mod tests {
         set_preimage_for_state_commitments(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
 
         assert_eq!(
-            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap().into_owned(),
+            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             1_usize.into()
         );
         assert_eq!(
-            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap().into_owned(),
+            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             2_usize.into()
         );
         // TODO: test preimage more thoroughly
@@ -456,11 +456,11 @@ mod tests {
         set_preimage_for_class_commitments(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
 
         assert_eq!(
-            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap().into_owned(),
+            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             11_usize.into()
         );
         assert_eq!(
-            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap().into_owned(),
+            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             12_usize.into()
         );
         // TODO: test preimage more thoroughly
@@ -492,11 +492,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap().into_owned(),
+            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             1_usize.into()
         );
         assert_eq!(
-            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap().into_owned(),
+            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             2_usize.into()
         );
         // TODO: test preimage more thoroughly

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -143,8 +143,7 @@ pub mod tests {
             .expect("is_on_curve() failed");
 
         let is_on_curve: Felt252 = get_integer_from_var_name(vars::ids::IS_ON_CURVE, &vm, &ids_data, &ap_tracking)
-            .expect("is_on_curve should be put in ids_data")
-            .into_owned();
+            .expect("is_on_curve should be put in ids_data");
         assert_eq!(is_on_curve, 1.into());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn run_os(
     println!("{:?}", _os_output);
 
     vm.verify_auto_deductions().map_err(|e| SnOsError::Runner(e.into()))?;
-    cairo_runner.read_return_values(&mut vm).map_err(|e| SnOsError::Runner(e.into()))?;
+    cairo_runner.read_return_values(&mut vm, false).map_err(|e| SnOsError::Runner(e.into()))?;
     cairo_runner.relocate(&mut vm, cairo_run_config.relocate_mem).map_err(|e| SnOsError::Runner(e.into()))?;
 
     // Parse the Cairo VM output


### PR DESCRIPTION
Fixed breaking changes:
* reading VM memory now returns a `Felt252` instead of a `Cow<Felt252>`
* `cairo_runner.read_return_values` now takes two arguments.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [x] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
