### PR TITLE
Fix: restore CHECK_* hints that were deleted

### DIFF
--- a/src/cairo_types/syscalls.rs
+++ b/src/cairo_types/syscalls.rs
@@ -1,4 +1,5 @@
 use cairo_type_derive::FieldOffsetGetters;
+use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::Felt252;
 
 #[allow(unused)]
@@ -42,4 +43,23 @@ pub struct NewStorageWriteRequest {
     pub reserved: Felt252,
     pub key: Felt252,
     pub value: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct SyscallContractResponse {
+    pub retdata_size: Felt252,
+    pub retdata: Relocatable,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct NewSyscallContractResponse {
+    pub retdata_start: Relocatable,
+    pub retdata_end: Relocatable,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct NewDeployResponse {
+    pub contract_address: Felt252,
+    pub constructor_retdata_start: Relocatable,
+    pub constructor_retdata_end: Relocatable,
 }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -48,7 +48,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 156] = [
+static HINTS: [(&str, HintImpl); 157] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -86,8 +86,9 @@ static HINTS: [(&str, HintImpl); 156] = [
     (execution::CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS, execution::cache_contract_storage_syscall_request_address),
     (execution::CHECK_EXECUTION, execution::check_execution),
     (execution::CHECK_IS_DEPRECATED, execution::check_is_deprecated),
-    (execution::CHECK_RESPONSE_RETURN_VALUE, execution::check_response_return_value),
-    (execution::COMPARE_RETURN_VALUE, execution::compare_return_value),
+    (execution::CHECK_NEW_DEPLOY_RESPONSE, execution::check_new_deploy_response),
+    (execution::CHECK_NEW_SYSCALL_RESPONSE, execution::check_new_syscall_response),
+    (execution::CHECK_SYSCALL_RESPONSE, execution::check_syscall_response),
     (execution::CONTRACT_ADDRESS, execution::contract_address),
     (execution::END_TX, execution::end_tx),
     (execution::ENTER_CALL, execution::enter_call),

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -57,18 +57,6 @@ pub const CALCULATE_VALUE: &str = indoc! {r#"
         value = (-y) % SECP256R1.prime"#
 };
 
-// TODO: similar to execution::COMPARE_RETURN_VALUE
-#[allow(unused)]
-pub const COMPARE_RETURN_VALUE_2: &str = indoc! {r#"
-    # Check that the actual return value matches the expected one.
-    expected = memory.get_range(
-        addr=ids.response.constructor_retdata_start,
-        size=ids.response.constructor_retdata_end - ids.response.constructor_retdata_start,
-    )
-    actual = memory.get_range(addr=ids.retdata, size=ids.retdata_size)
-    assert expected == actual, f'Return value mismatch; expected={expected}, actual={actual}.'"#
-};
-
 #[allow(unused)]
 pub const SET_AP_TO_SEGMENT_HASH: &str = indoc! {r#"
     memory[ap] = to_felt_or_relocatable(bytecode_segment_structure.hash())"#


### PR DESCRIPTION
Hints introduced in #128 were deleted inadvertently. Reverted the change.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
