### PR TITLE
Fix: use correct initial/final state roots for commitment info hint

### DIFF
--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -139,8 +139,20 @@ pub fn set_preimage_for_current_commitment_info(
 ) -> Result<(), HintError> {
     // TODO: CommitmentInfo should not be obtained through exec_scopes
     let commitment_info = exec_scopes.get::<CommitmentInfo>(vars::scopes::COMMITMENT_INFO)?;
-    insert_value_from_var_name(vars::ids::INITIAL_ROOT, commitment_info.previous_root, vm, ids_data, ap_tracking)?;
-    insert_value_from_var_name(vars::ids::FINAL_ROOT, commitment_info.updated_root, vm, ids_data, ap_tracking)?;
+    insert_value_from_var_name(
+        vars::ids::INITIAL_CONTRACT_STATE_ROOT,
+        commitment_info.previous_root,
+        vm,
+        ids_data,
+        ap_tracking,
+    )?;
+    insert_value_from_var_name(
+        vars::ids::FINAL_CONTRACT_STATE_ROOT,
+        commitment_info.updated_root,
+        vm,
+        ids_data,
+        ap_tracking,
+    )?;
 
     let preimage = commitment_info.commitment_facts;
     exec_scopes.insert_value(vars::scopes::PREIMAGE, preimage);
@@ -478,8 +490,8 @@ mod tests {
         let constants = HashMap::new();
 
         let ids_data = HashMap::from([
-            (vars::ids::INITIAL_ROOT.to_string(), HintReference::new_simple(-3)),
-            (vars::ids::FINAL_ROOT.to_string(), HintReference::new_simple(-2)),
+            (vars::ids::INITIAL_CONTRACT_STATE_ROOT.to_string(), HintReference::new_simple(-3)),
+            (vars::ids::FINAL_CONTRACT_STATE_ROOT.to_string(), HintReference::new_simple(-2)),
             (vars::ids::MERKLE_HEIGHT.to_string(), HintReference::new_simple(-1)),
         ]);
         insert_value_from_var_name(vars::ids::MERKLE_HEIGHT, 251_usize, &mut vm, &ids_data, &ap_tracking)
@@ -492,11 +504,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            get_integer_from_var_name(vars::ids::INITIAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
+            get_integer_from_var_name(vars::ids::INITIAL_CONTRACT_STATE_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             1_usize.into()
         );
         assert_eq!(
-            get_integer_from_var_name(vars::ids::FINAL_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
+            get_integer_from_var_name(vars::ids::FINAL_CONTRACT_STATE_ROOT, &vm, &ids_data, &ap_tracking).unwrap(),
             2_usize.into()
         );
         // TODO: test preimage more thoroughly

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -41,10 +41,12 @@ pub mod ids {
     pub const EDGE: &str = "edge";
     pub const ENTRY_POINT_RETURN_VALUES: &str = "entry_point_return_values";
     pub const EXECUTION_CONTEXT: &str = "execution_context";
+    pub const FINAL_CONTRACT_STATE_ROOT: &str = "final_contract_state_root";
     pub const FINAL_ROOT: &str = "final_root";
     pub const HASH_PTR: &str = "hash_ptr";
     pub const INITIAL_GAS: &str = "initial_gas";
     pub const HEIGHT: &str = "height";
+    pub const INITIAL_CONTRACT_STATE_ROOT: &str = "initial_contract_state_root";
     pub const INITIAL_ROOT: &str = "initial_root";
     pub const IS_ON_CURVE: &str = "is_on_curve";
     pub const LENGTH: &str = "length";


### PR DESCRIPTION
Fixed an error likely caused by a hasty copy-paste. The SET_PREIMAGE_FOR_CURRENT_COMMITMENT_INFO hint manipulates the initial/final contract state root variables and not `initial_root`/`final_root`.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
