### PR TITLE
Improve descent map typing

### DIFF
--- a/src/cairo_types/dict_access.rs
+++ b/src/cairo_types/dict_access.rs
@@ -1,0 +1,9 @@
+use cairo_type_derive::FieldOffsetGetters;
+use cairo_vm::Felt252;
+
+#[derive(FieldOffsetGetters)]
+pub struct DictAccess {
+    pub key: Felt252,
+    pub prev_value: Felt252,
+    pub new_value: Felt252,
+}

--- a/src/cairo_types/mod.rs
+++ b/src/cairo_types/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod builtins;
+pub(crate) mod dict_access;
 pub(crate) mod structs;
 pub(crate) mod syscalls;
 pub(crate) mod traits;

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -30,7 +30,7 @@ use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrap
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::execution::syscall_utils::SyscallSelector;
-use crate::hints::types::{DescentMap, PatriciaSkipValidationRunner, Preimage};
+use crate::hints::types::{PatriciaSkipValidationRunner, Preimage};
 use crate::hints::vars;
 use crate::hints::vars::constants::BLOCK_HASH_CONTRACT_ADDRESS;
 use crate::hints::vars::ids::{
@@ -40,6 +40,7 @@ use crate::hints::vars::scopes::{EXECUTION_HELPER, SYSCALL_HANDLER};
 use crate::io::input::StarknetOsInput;
 use crate::io::InternalTransaction;
 use crate::starknet::starknet_storage::StorageLeaf;
+use crate::starkware_utils::commitment_tree::base_types::DescentMap;
 use crate::starkware_utils::commitment_tree::update_tree::{DecodeNodeCase, TreeUpdate, UpdateTree};
 
 pub const LOAD_NEXT_TX: &str = indoc! {r#"

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -48,7 +48,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 157] = [
+static HINTS: [(&str, HintImpl); 158] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -141,6 +141,7 @@ static HINTS: [(&str, HintImpl); 157] = [
     (output::SET_AP_TO_BLOCK_HASH, output::set_ap_to_block_hash),
     (output::SET_TREE_STRUCTURE, output::set_tree_structure),
     (patricia::ASSERT_CASE_IS_RIGHT, patricia::assert_case_is_right),
+    (patricia::BUILD_DESCENT_MAP, patricia::build_descent_map),
     (patricia::HEIGHT_IS_ZERO_OR_LEN_NODE_PREIMAGE_IS_TWO, patricia::height_is_zero_or_len_node_preimage_is_two),
     (patricia::IS_CASE_RIGHT, patricia::is_case_right),
     (patricia::PREPARE_PREIMAGE_VALIDATION_NON_DETERMINISTIC_HASHES, patricia::prepare_preimage_validation_non_deterministic_hashes),

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -22,7 +22,7 @@ use crate::cairo_types::trie::NodeEdge;
 use crate::hints::types::{skip_verification_if_configured, Preimage};
 use crate::hints::vars;
 use crate::starknet::starknet_storage::StorageLeaf;
-use crate::starkware_utils::commitment_tree::base_types::{DescentMap, Height};
+use crate::starkware_utils::commitment_tree::base_types::{DescentMap, DescentStart, Height, NodePath};
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_guess_descents::patricia_guess_descents;
 use crate::starkware_utils::commitment_tree::update_tree::{
     build_update_tree, decode_node, DecodeNodeCase, DecodedNode, TreeUpdate,
@@ -114,7 +114,11 @@ pub fn set_ap_to_descend(
     let height = get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?;
     let path = get_integer_from_var_name(vars::ids::PATH, vm, ids_data, ap_tracking)?;
 
-    let ap = match descent_map.get(&(height, path)) {
+    let height = height.try_into()?;
+    let path = NodePath(path.to_biguint());
+
+    let descent_start = DescentStart(height, path);
+    let ap = match descent_map.get(&descent_start) {
         None => Felt252::ZERO,
         Some(value) => {
             exec_scopes.insert_value(vars::ids::DESCEND, value.clone());

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -5,6 +5,7 @@ use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
     insert_value_into_ap,
 };
 use cairo_vm::hint_processor::hint_processor_definition::HintReference;
+use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
 use cairo_vm::serde::deserialize_program::ApTracking;
 use cairo_vm::types::errors::math_errors::MathError;
 use cairo_vm::types::exec_scope::ExecutionScopes;
@@ -16,11 +17,16 @@ use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
 use crate::cairo_types::builtins::HashBuiltin;
+use crate::cairo_types::dict_access::DictAccess;
 use crate::cairo_types::trie::NodeEdge;
-use crate::hints::types::{skip_verification_if_configured, DescentMap, Preimage};
+use crate::hints::types::{skip_verification_if_configured, Preimage};
 use crate::hints::vars;
 use crate::starknet::starknet_storage::StorageLeaf;
-use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, TreeUpdate};
+use crate::starkware_utils::commitment_tree::base_types::{DescentMap, Height};
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_guess_descents::patricia_guess_descents;
+use crate::starkware_utils::commitment_tree::update_tree::{
+    build_update_tree, decode_node, DecodeNodeCase, DecodedNode, TreeUpdate,
+};
 
 pub const SET_SIBLINGS: &str = "memory[ids.siblings], ids.word = descend";
 
@@ -242,6 +248,82 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
         _ => Felt252::ONE,
     };
     insert_value_into_ap(vm, ap)?;
+
+    Ok(())
+}
+
+pub const BUILD_DESCENT_MAP: &str = indoc! {r#"
+	from starkware.cairo.common.patricia_utils import canonic, patricia_guess_descents
+	from starkware.python.merkle_tree import build_update_tree
+
+	# Build modifications list.
+	modifications = []
+	DictAccess_key = ids.DictAccess.key
+	DictAccess_new_value = ids.DictAccess.new_value
+	DictAccess_SIZE = ids.DictAccess.SIZE
+	for i in range(ids.n_updates):
+	    curr_update_ptr = ids.update_ptr.address_ + i * DictAccess_SIZE
+	    modifications.append((
+	        memory[curr_update_ptr + DictAccess_key],
+	        memory[curr_update_ptr + DictAccess_new_value]))
+
+	node = build_update_tree(ids.height, modifications)
+	descent_map = patricia_guess_descents(
+	    ids.height, node, preimage, ids.prev_root, ids.new_root)
+	del modifications
+	__patricia_skip_validation_runner = globals().get(
+	    '__patricia_skip_validation_runner')
+
+	common_args = dict(
+	    preimage=preimage, descent_map=descent_map,
+	    __patricia_skip_validation_runner=__patricia_skip_validation_runner)
+	common_args['common_args'] = common_args"#
+};
+
+pub fn build_descent_map(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    // Build modifications list.
+    let n_updates = get_integer_from_var_name(vars::ids::N_UPDATES, vm, ids_data, ap_tracking)?;
+    let n_updates = felt_to_usize(&n_updates)?;
+    let update_ptr_address = get_relocatable_from_var_name(vars::ids::UPDATE_PTR, vm, ids_data, ap_tracking)?;
+
+    let modifications = {
+        let mut modifications = vec![];
+        for i in 0..n_updates {
+            let curr_update_ptr = (update_ptr_address + i * DictAccess::cairo_size())?;
+            let tree_index = vm.get_integer((curr_update_ptr + DictAccess::key_offset())?)?;
+            let new_value = vm.get_integer((curr_update_ptr + DictAccess::new_value_offset())?)?;
+
+            modifications.push((tree_index.into_owned().to_biguint(), StorageLeaf::new(new_value.into_owned())));
+        }
+        modifications
+    };
+
+    // Build the descent map.
+    let height: Height =
+        get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?.into_owned().try_into()?;
+    let prev_root = get_integer_from_var_name(vars::ids::PREV_ROOT, vm, ids_data, ap_tracking)?.to_biguint();
+    let new_root = get_integer_from_var_name(vars::ids::NEW_ROOT, vm, ids_data, ap_tracking)?.to_biguint();
+
+    let preimage: &Preimage = exec_scopes.get_ref(vars::scopes::PREIMAGE)?;
+
+    let node = build_update_tree(height, modifications);
+    let descent_map = patricia_guess_descents::<StorageLeaf>(height, node, preimage, prev_root, new_root)?;
+
+    // Notes:
+    // 1. We do not build `common_args` as it seems to be a Python trick to enter new scopes with a dict
+    //    destructuring one-liner as the dict references itself. Neat trick that does not translate too
+    //    well in Rust. We just make sure that `descent_map`, `__patricia_skip_validation_runner` and
+    //    `preimage` are in the scope.
+    // 2. The Rust VM has no `globals()`, `__patricia_skip_validation_runner` should already be in
+    //    `exec_scopes`. `preimage` is also guaranteed to be present as we fetch it earlier. Conclusion:
+    //    we only need to insert `descent_map`.
+    exec_scopes.insert_value(vars::scopes::DESCENT_MAP, descent_map);
 
     Ok(())
 }

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -305,8 +305,7 @@ pub fn build_descent_map(
     };
 
     // Build the descent map.
-    let height: Height =
-        get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?.into_owned().try_into()?;
+    let height: Height = get_integer_from_var_name(vars::ids::HEIGHT, vm, ids_data, ap_tracking)?.try_into()?;
     let prev_root = get_integer_from_var_name(vars::ids::PREV_ROOT, vm, ids_data, ap_tracking)?.to_biguint();
     let new_root = get_integer_from_var_name(vars::ids::NEW_ROOT, vm, ids_data, ap_tracking)?.to_biguint();
 

--- a/src/hints/types.rs
+++ b/src/hints/types.rs
@@ -14,9 +14,6 @@ pub struct PatriciaSkipValidationRunner {
     pub verified_addresses: HashSet<Relocatable>,
 }
 
-// TODO: define correctly when implementing the descend functionality
-pub type DescentMap = HashMap<(Felt252, Felt252), Vec<Felt252>>;
-
 /// Inserts a hash result address in `__patricia_skip_validation_runner` if it exists.
 ///
 /// This skips validation of the preimage dict to speed up the VM. When this flag is set,

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -260,6 +260,7 @@ pub const COMPUTE_Q_MOD_PRIME: &str = indoc! {r#"
     ids.q = q % PRIME"#
 };
 
+#[allow(unused)]
 pub const COMPUTE_SLOPE_2: &str = indoc! {r#"
     from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
     from starkware.cairo.common.cairo_secp.secp_utils import pack

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -260,36 +260,6 @@ pub const COMPUTE_Q_MOD_PRIME: &str = indoc! {r#"
     ids.q = q % PRIME"#
 };
 
-#[allow(unused)]
-pub const CREATE_COMMON_ARGS: &str = indoc! {r#"
-    from starkware.cairo.common.patricia_utils import canonic, patricia_guess_descents
-    from starkware.python.merkle_tree import build_update_tree
-
-    # Build modifications list.
-    modifications = []
-    DictAccess_key = ids.DictAccess.key
-    DictAccess_new_value = ids.DictAccess.new_value
-    DictAccess_SIZE = ids.DictAccess.SIZE
-    for i in range(ids.n_updates):
-        curr_update_ptr = ids.update_ptr.address_ + i * DictAccess_SIZE
-        modifications.append((
-            memory[curr_update_ptr + DictAccess_key],
-            memory[curr_update_ptr + DictAccess_new_value]))
-
-    node = build_update_tree(ids.height, modifications)
-    descent_map = patricia_guess_descents(
-        ids.height, node, preimage, ids.prev_root, ids.new_root)
-    del modifications
-    __patricia_skip_validation_runner = globals().get(
-        '__patricia_skip_validation_runner')
-
-    common_args = dict(
-        preimage=preimage, descent_map=descent_map,
-        __patricia_skip_validation_runner=__patricia_skip_validation_runner)
-    common_args['common_args'] = common_args"#
-};
-
-#[allow(unused)]
 pub const COMPUTE_SLOPE_2: &str = indoc! {r#"
     from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
     from starkware.cairo.common.cairo_secp.secp_utils import pack

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -53,7 +53,9 @@ pub mod ids {
     pub const MAX_FEE: &str = "max_fee";
     pub const MERKLE_HEIGHT: &str = "MERKLE_HEIGHT";
     pub const N: &str = "n";
+    pub const N_UPDATES: &str = "n_updates";
     pub const NEW_LENGTH: &str = "new_length";
+    pub const NEW_ROOT: &str = "new_root";
     pub const NEW_STATE_ENTRY: &str = "new_state_entry";
     pub const NODE: &str = "node";
     pub const OLD_BLOCK_HASH: &str = "old_block_hash";
@@ -63,6 +65,7 @@ pub mod ids {
     pub const OUTPUT_PTR: &str = "output_ptr";
     pub const REQUEST_BLOCK_NUMBER: &str = "request_block_number";
     pub const PATH: &str = "path";
+    pub const PREV_ROOT: &str = "prev_root";
     pub const PREV_VALUE: &str = "prev_value";
     pub const REQUEST: &str = "request";
     pub const RESPONSE: &str = "response";
@@ -78,7 +81,7 @@ pub mod ids {
     pub const STATE_ENTRY: &str = "state_entry";
     pub const SYSCALL_PTR: &str = "syscall_ptr";
     pub const TX_VERSION: &str = "tx_version";
-
+    pub const UPDATE_PTR: &str = "update_ptr";
     pub const VALUE: &str = "value";
     pub const WORD: &str = "word";
     pub const Y: &str = "y";

--- a/src/starkware_utils/commitment_tree/base_types.rs
+++ b/src/starkware_utils/commitment_tree/base_types.rs
@@ -12,7 +12,7 @@ use crate::storage::storage::HASH_BYTES;
 
 pub type TreeIndex = BigUint;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Eq, Hash)]
 pub struct NodePath(pub BigUint);
 
 impl Display for NodePath {
@@ -34,7 +34,7 @@ impl Serializable for NodePath {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Eq)]
 pub struct Length(pub u64);
 
 impl Sub<u64> for Length {
@@ -64,7 +64,7 @@ impl Serializable for Length {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Eq, Hash)]
 pub struct Height(pub u64);
 
 impl TryFrom<Felt252> for Height {
@@ -90,4 +90,8 @@ impl Display for Height {
     }
 }
 
-pub type DescentMap = HashMap<(Felt252, Felt252), Vec<Felt252>>;
+#[derive(Debug, Clone, PartialEq, Default, Eq, Hash)]
+pub struct DescentStart(pub Height, pub NodePath);
+#[derive(Debug, Clone, PartialEq, Default, Eq)]
+pub struct DescentPath(pub Length, pub NodePath);
+pub type DescentMap = HashMap<DescentStart, DescentPath>;

--- a/src/starkware_utils/commitment_tree/base_types.rs
+++ b/src/starkware_utils/commitment_tree/base_types.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::ops::Sub;
 
+use cairo_vm::types::errors::math_errors::MathError;
+use cairo_vm::Felt252;
 use num_bigint::BigUint;
+use num_traits::ToPrimitive;
 
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
 use crate::storage::storage::HASH_BYTES;
@@ -63,6 +67,15 @@ impl Serializable for Length {
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct Height(pub u64);
 
+impl TryFrom<Felt252> for Height {
+    type Error = MathError;
+
+    fn try_from(value: Felt252) -> Result<Self, Self::Error> {
+        let height = value.to_u64().ok_or(MathError::Felt252ToU64Conversion(Box::new(value)))?;
+        Ok(Self(height))
+    }
+}
+
 impl Sub<u64> for Height {
     type Output = Self;
 
@@ -76,3 +89,5 @@ impl Display for Height {
         self.0.fmt(f)
     }
 }
+
+pub type DescentMap = HashMap<(Felt252, Felt252), Vec<Felt252>>;

--- a/src/starkware_utils/commitment_tree/patricia_tree/mod.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/mod.rs
@@ -1,4 +1,5 @@
 pub mod nodes;
+pub mod patricia_guess_descents;
 #[allow(clippy::module_inception)] // Use the same name as the parent module
 pub mod patricia_tree;
 pub mod patricia_utils;

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_guess_descents.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_guess_descents.rs
@@ -1,0 +1,463 @@
+use std::collections::{HashMap, VecDeque};
+
+use cairo_vm::types::errors::math_errors::MathError;
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::Felt252;
+use num_bigint::BigUint;
+use num_traits::ToPrimitive;
+
+use crate::starkware_utils::commitment_tree::base_types::{DescentMap, Height, NodePath};
+use crate::starkware_utils::commitment_tree::update_tree::{TreeUpdate, UpdateTree};
+
+type Preimage = HashMap<Felt252, Vec<Felt252>>;
+type Triplet = (Felt252, Felt252, Felt252);
+
+fn empty_triplet() -> Triplet {
+    (Felt252::ZERO, Felt252::ZERO, Felt252::ZERO)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DescentError {
+    #[error("Key not found in preimage: {0}")]
+    PreimageNotFound(Felt252),
+
+    #[error("Expected a branch")]
+    IsNotBranch,
+
+    #[error("The heights of the trees do not match")]
+    TreeHeightMismatch,
+
+    #[error(transparent)]
+    Math(#[from] MathError),
+}
+
+impl From<DescentError> for HintError {
+    fn from(descent_error: DescentError) -> Self {
+        match descent_error {
+            DescentError::Math(e) => HintError::Math(e),
+            other => HintError::CustomHint(other.to_string().into_boxed_str()),
+        }
+    }
+}
+
+/// Retrieves the children of a node. Assumes canonic representation.
+fn get_children(preimage: &Preimage, node: &Triplet) -> Result<(Triplet, Triplet), DescentError> {
+    let length = node.0;
+    let word = node.1;
+    let node_hash = node.2;
+
+    if length == Felt252::ZERO {
+        let (left, right) = if node_hash == Felt252::ZERO {
+            (Felt252::ZERO, Felt252::ZERO)
+        } else {
+            let node_preimage = preimage.get(&node_hash).ok_or(DescentError::PreimageNotFound(node_hash))?;
+            (node_preimage[0], node_preimage[1])
+        };
+
+        return Ok((canonic(preimage, left), canonic(preimage, right)));
+    }
+
+    let length_u64 = length.to_u64().ok_or(MathError::Felt252ToU64Conversion(Box::new(length)))?;
+
+    if word.to_biguint() >> (length_u64 - 1) == BigUint::from(0u64) {
+        return Ok(((length - 1, word, node_hash), empty_triplet()));
+    }
+
+    Ok((empty_triplet(), (length - 1, word - (1 << (length_u64 - 1)), node_hash)))
+}
+
+enum PreimageNode<'preimage> {
+    Leaf,
+    Branch { left: Option<PreimageNodeIterator<'preimage>>, right: Option<PreimageNodeIterator<'preimage>> },
+}
+
+struct PreimageNodeIterator<'preimage> {
+    height: Height,
+    preimage: &'preimage Preimage,
+    queue: VecDeque<PreimageNode<'preimage>>,
+}
+impl<'preimage> PreimageNodeIterator<'preimage> {
+    fn new(height: Height, preimage: &'preimage Preimage, node: &Triplet) -> Result<Self, DescentError> {
+        let mut iter = Self { height, preimage, queue: VecDeque::new() };
+        iter.fill_queue(node)?;
+        Ok(iter)
+    }
+
+    fn fill_queue(&mut self, node: &Triplet) -> Result<(), DescentError> {
+        // Check for children
+        if self.height.0 == 0 {
+            self.queue.push_back(PreimageNode::Leaf);
+            return Ok(());
+        }
+        let (left, right) = get_children(self.preimage, node)?;
+        let empty_node = empty_triplet();
+
+        let left_child = if left == empty_node {
+            None
+        } else {
+            Some(PreimageNodeIterator::new(self.height - 1, self.preimage, &left)?)
+        };
+        let right_child = if right == empty_node {
+            None
+        } else {
+            Some(PreimageNodeIterator::new(self.height - 1, self.preimage, &right)?)
+        };
+
+        self.queue.push_back(PreimageNode::Branch { left: left_child, right: right_child });
+
+        Ok(())
+    }
+}
+
+impl<'preimage> Iterator for PreimageNodeIterator<'preimage> {
+    type Item = PreimageNode<'preimage>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.queue.pop_front()
+    }
+}
+
+/// Builds a tree structure similar to build_update_tree(), from a root hash, and a preimage
+/// dictionary.
+/// The Python implementation returns a generator as follows:
+/// * if node is a leaf: [0]
+/// * Otherwise: [left, right] where each child is either None if empty or a generator defined
+/// recursively.
+/// Note that this does not necessarily traverse the entire tree. The caller may open the branches
+/// as they wish.
+fn preimage_tree<'preimage>(
+    height: Height,
+    preimage: &'preimage Preimage,
+    node: &Triplet,
+) -> Result<PreimageNodeIterator<'preimage>, DescentError> {
+    PreimageNodeIterator::new(height, preimage, node)
+}
+
+/// Builds a descent map given multiple trees.
+/// A descent is a maximal subpath s.t.
+/// 1. In each tree, the authentication subpath consists of empty nodes.
+/// 2. The subpath is longer than 1.
+///
+/// Returns descents as a map: (height, path_to_upper_node) -> (subpath_length, subpath).
+/// The function does not return descents that begin at an empty node in the first tree.
+///
+/// Note: This function will be called with 3 trees:
+///   The modifications tree, previous tree, new tree.
+///
+/// Args:
+/// height - height of the current node. The length of a path from the node to a leaf.
+/// path - path from the root to the current node.
+/// nodes - a list of 'node' structures, similar to build_update_tree().
+///   In particular, it is assumed that a non empty node cannot have two empty children.
+fn get_descents<LF>(
+    mut height: Height,
+    mut path: NodePath,
+    mut update_tree: &UpdateTree<LF>,
+    mut previous_tree: Option<PreimageNodeIterator>,
+    mut new_tree: Option<PreimageNodeIterator>,
+) -> Result<DescentMap, DescentError>
+where
+    LF: Clone,
+{
+    let mut descent_map = DescentMap::new();
+
+    if update_tree.is_none() || height.0 == 0 {
+        return Ok(descent_map);
+    }
+
+    // Find longest edge.
+    let orig_height = height;
+    let orig_path = path.clone();
+
+    // Traverse all the trees simultaneously, as long as they all satisfy the descent condition,
+    // to find the maximal descent subpath.
+    // Compared to the Python implementation, we unroll the loop to avoid having to Box<dyn>
+    // everything to emulate duck-typing.
+    let (lefts, rights) = loop {
+        let (update_left, update_right) = match update_tree {
+            None => return Err(DescentError::TreeHeightMismatch),
+
+            Some(TreeUpdate::Leaf(_)) => {
+                return Err(DescentError::IsNotBranch);
+            }
+            Some(TreeUpdate::Tuple(left, right)) => (left.as_ref(), right.as_ref()),
+        };
+
+        let (previous_left, previous_right) = match previous_tree {
+            None => (None, None),
+            Some(mut iter) => match iter.next().ok_or(DescentError::TreeHeightMismatch)? {
+                PreimageNode::Leaf => {
+                    return Err(DescentError::IsNotBranch);
+                }
+                PreimageNode::Branch { left, right } => (left, right),
+            },
+        };
+
+        let (new_left, new_right) = match new_tree {
+            None => (None, None),
+            Some(mut iter) => match iter.next().ok_or(DescentError::TreeHeightMismatch)? {
+                PreimageNode::Leaf => {
+                    return Err(DescentError::IsNotBranch);
+                }
+                PreimageNode::Branch { left, right } => (left, right),
+            },
+        };
+
+        // Note: we decrement height in each branch to avoid having to clone the nodes.
+        // This results in a bit of (ugly) duplication.
+        if update_left.is_none() && previous_left.is_none() && new_left.is_none() {
+            path = NodePath(path.0 * 2u64 + 1u64);
+            height = Height(height.0 - 1);
+            if height.0 == 0 {
+                break ((update_left, previous_left, new_left), (update_right, previous_right, new_right));
+            }
+
+            update_tree = update_right;
+            previous_tree = previous_right;
+            new_tree = new_right;
+        } else if update_right.is_none() && previous_right.is_none() && new_right.is_none() {
+            path = NodePath(path.0 * 2u64);
+            height = Height(height.0 - 1);
+            if height.0 == 0 {
+                break ((update_left, previous_left, new_left), (update_right, previous_right, new_right));
+            }
+
+            update_tree = update_left;
+            previous_tree = previous_left;
+            new_tree = new_left;
+        } else {
+            break ((update_left, previous_left, new_left), (update_right, previous_right, new_right));
+        }
+    };
+
+    let length = orig_height.0 - height.0;
+    // length <= 1 is not a descent.
+    if length > 1 {
+        descent_map.insert(
+            (Felt252::from(orig_height.0), Felt252::from(orig_path.0)),
+            vec![Felt252::from(length), Felt252::from(&path.0 % (BigUint::from(1u64) << length))],
+        );
+    }
+
+    if height.0 > 0 {
+        let next_height = Height(height.0 - 1);
+        descent_map.extend(get_descents(next_height, NodePath(&path.0 * 2u64), lefts.0, lefts.1, lefts.2)?);
+        descent_map.extend(get_descents(next_height, NodePath(path.0 * 2u64 + 1u64), rights.0, rights.1, rights.2)?);
+    }
+
+    Ok(descent_map)
+}
+
+/// Returns the canonic encoding of a node hash as a triplet.
+/// This implies that if the returned encoding is (0, 0, node_hash), then node_hash is not an edge
+/// node.
+fn canonic(preimage: &Preimage, node_hash: Felt252) -> Triplet {
+    if let Some(back) = preimage.get(&node_hash) {
+        if back.len() == 3 {
+            return (back[0], back[1], back[2]);
+        }
+    }
+    (Felt252::ZERO, Felt252::ZERO, node_hash)
+}
+
+/// Builds a descent map for a Patricia update. See get_descents().
+/// node - The modification tree for the patricia update, given by build_update_tree().
+pub fn patricia_guess_descents<LF>(
+    height: Height,
+    node: UpdateTree<LF>,
+    preimage: &Preimage,
+    prev_root: BigUint,
+    new_root: BigUint,
+) -> Result<DescentMap, DescentError>
+where
+    LF: Clone,
+{
+    let node_prev = preimage_tree(height, preimage, &canonic(preimage, Felt252::from(prev_root)))?;
+    let node_new = preimage_tree(height, preimage, &canonic(preimage, Felt252::from(new_root)))?;
+
+    get_descents::<LF>(height, NodePath(BigUint::from(0u64)), &node, Some(node_prev), Some(node_new))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::starkware_utils::commitment_tree::base_types::TreeIndex;
+    use crate::starkware_utils::commitment_tree::update_tree::build_update_tree;
+    use crate::storage::storage_utils::SimpleLeafFact;
+
+    type LF = SimpleLeafFact;
+
+    fn build_full_tree(height: Height, path: NodePath) -> UpdateTree<LF> {
+        if height.0 == 0 {
+            return Some(TreeUpdate::Leaf(LF::new(Felt252::from(path.0))));
+        }
+        Some(TreeUpdate::Tuple(
+            Box::new(build_full_tree(Height(height.0 - 1), NodePath(path.0.clone() * 2u64))),
+            Box::new(build_full_tree(Height(height.0 - 1), NodePath(path.0 * 2u64 + 1u64))),
+        ))
+    }
+
+    fn build_full_preimage(height: Height, root_hash: Felt252) -> Preimage {
+        let mut preimage = Preimage::new();
+        let left_child_hash = root_hash * Felt252::TWO;
+        let right_child_hash = root_hash * Felt252::TWO + Felt252::ONE;
+        preimage.insert(root_hash, vec![left_child_hash, right_child_hash]);
+
+        // We can stop at height 1, the leaf nodes are not relevant.
+        if height.0 > 1 {
+            let next_height = Height(height.0 - 1);
+            preimage.extend(build_full_preimage(next_height, left_child_hash));
+            preimage.extend(build_full_preimage(next_height, right_child_hash));
+        }
+        preimage
+    }
+
+    fn print_descent_map(descent_map: &DescentMap) {
+        for (key, value) in descent_map {
+            println!(
+                "{}-{}: {:?}",
+                key.0.to_biguint(),
+                key.1.to_biguint(),
+                value.iter().map(|x| x.to_biguint()).collect::<Vec<_>>()
+            )
+        }
+    }
+
+    #[test]
+    fn test_get_descents_empty() {
+        let descent_map = get_descents::<LF>(Height(1), NodePath(BigUint::from(0u64)), &None, None, None).unwrap();
+        assert!(descent_map.is_empty());
+    }
+
+    /// The descent map for a full tree should be empty.
+    #[rstest]
+    fn test_guess_descents_full_tree() {
+        // Create a full tree of height 3
+        let height = Height(3);
+        let update_tree = build_full_tree(height, NodePath(0u64.into()));
+
+        let prev_root = BigUint::from(1u64);
+        let new_root = BigUint::from(100u64);
+        let preimage = {
+            let mut preimage = build_full_preimage(height, Felt252::from(prev_root.clone()));
+            preimage.extend(build_full_preimage(height, Felt252::from(new_root.clone())));
+            preimage
+        };
+
+        let descent_map = patricia_guess_descents::<LF>(height, update_tree, &preimage, prev_root, new_root).unwrap();
+        assert!(descent_map.is_empty());
+    }
+
+    /// Tests generating a descent map for an update tree of one element, against
+    /// an empty tree. The new tree is also empty to have the descent map reflect
+    /// the structure of the update tree and nothing else.
+    #[rstest]
+    fn test_guess_descents_update_one_leaf() {
+        let height = Height(3);
+
+        // The update tree should look like this:
+        //        0
+        //    0       0
+        //  0   0   0   0
+        // 0 u 0 0 0 0 0 0
+        // Resulting in a descent of 3.
+        let update_tree = build_update_tree(height, vec![(TreeIndex::from(1u64), LF::new(Felt252::from(128)))]);
+
+        // Start from an empty tree
+        let prev_root = BigUint::from(0u64);
+        // Setting an empty tree as end state works for testing the function.
+        // The descent map will then only depend on the structure of the update tree.
+        // Of course this does not make any sense in a real-setting.
+        let new_root = BigUint::from(0u64);
+
+        let preimage = Preimage::new();
+
+        let descent_map = patricia_guess_descents::<LF>(height, update_tree, &preimage, prev_root, new_root).unwrap();
+        print_descent_map(&descent_map);
+        assert_eq!(
+            descent_map,
+            DescentMap::from([((Felt252::from(3), Felt252::from(0)), vec![Felt252::from(3), Felt252::from(1)])]),
+        );
+    }
+
+    /// Tests generating a descent map for an update tree of two adjacent leaves, against
+    /// an empty tree. The new tree is also empty to have the descent map reflect
+    /// the structure of the update tree and nothing else.
+    #[rstest]
+    fn test_guess_descents_update_two_adjacent_leaves() {
+        let height = Height(3);
+
+        // The update tree should look like this:
+        //        0
+        //    0       0
+        //  0   0   0   0
+        // u u 0 0 0 0 0 0
+        // Resulting in a descent of 2.
+        let update_tree = build_update_tree(
+            height,
+            vec![
+                (TreeIndex::from(0u64), LF::new(Felt252::from(127))),
+                (TreeIndex::from(1u64), LF::new(Felt252::from(128))),
+            ],
+        );
+
+        // Start from an empty tree
+        let prev_root = BigUint::from(0u64);
+        // Setting an empty tree as end state works for testing the function.
+        // The descent map will then only depend on the structure of the update tree.
+        // Of course this does not make any sense in a real-setting.
+        let new_root = BigUint::from(0u64);
+
+        let preimage = Preimage::new();
+
+        let descent_map = patricia_guess_descents::<LF>(height, update_tree, &preimage, prev_root, new_root).unwrap();
+        print_descent_map(&descent_map);
+        assert_eq!(
+            descent_map,
+            DescentMap::from([((Felt252::from(3), Felt252::from(0)), vec![Felt252::from(2), Felt252::from(0)])]),
+        );
+    }
+
+    /// Tests generating a descent map for an update tree of two leaves, against
+    /// an empty tree. The new tree is also empty to have the descent map reflect
+    /// the structure of the update tree and nothing else.
+    #[rstest]
+    fn test_guess_descents_update_two_leaves() {
+        let height = Height(3);
+
+        // The update tree should look like this:
+        //        0
+        //    0       0
+        //  0   0   0   0
+        // 0 u 0 0 u 0 0 0
+        // Resulting in two descents of 3.
+        let update_tree = build_update_tree(
+            height,
+            vec![
+                (TreeIndex::from(1u64), LF::new(Felt252::from(128))),
+                (TreeIndex::from(4u64), LF::new(Felt252::from(129))),
+            ],
+        );
+
+        // Start from an empty tree
+        let prev_root = BigUint::from(0u64);
+        // Setting an empty tree as end state works for testing the function.
+        // The descent map will then only depend on the structure of the update tree.
+        // Of course this does not make any sense in a real-setting.
+        let new_root = BigUint::from(0u64);
+
+        let preimage = Preimage::new();
+
+        let descent_map = patricia_guess_descents::<LF>(height, update_tree, &preimage, prev_root, new_root).unwrap();
+        print_descent_map(&descent_map);
+        assert_eq!(
+            descent_map,
+            DescentMap::from([
+                ((Felt252::from(2), Felt252::from(0)), vec![Felt252::from(2), Felt252::from(1)]),
+                ((Felt252::from(2), Felt252::from(1)), vec![Felt252::from(2), Felt252::from(0)]),
+            ]),
+        );
+    }
+}

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_guess_descents.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_guess_descents.rs
@@ -66,6 +66,7 @@ fn get_children(preimage: &Preimage, node: &Triplet) -> Result<(Triplet, Triplet
     Ok((empty_triplet(), (length - 1, word - (1 << (length_u64 - 1)), node_hash)))
 }
 
+#[allow(clippy::large_enum_variant)]
 enum PreimageNode<'preimage> {
     Leaf,
     Branch { left: Option<PreimageNodeIterator<'preimage>>, right: Option<PreimageNodeIterator<'preimage>> },

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_guess_descents.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_guess_descents.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
+use std::ops::{Add, Mul};
 
 use cairo_vm::types::errors::math_errors::MathError;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
-use std::ops::{Add, Mul};
 
-use crate::starkware_utils::commitment_tree::base_types::{DescentMap, DescentPath, DescentStart, Height, Length, NodePath};
+use crate::starkware_utils::commitment_tree::base_types::{
+    DescentMap, DescentPath, DescentStart, Height, Length, NodePath,
+};
 use crate::starkware_utils::commitment_tree::update_tree::{TreeUpdate, UpdateTree};
 
 type Preimage = HashMap<Felt252, Vec<Felt252>>;
@@ -255,7 +257,13 @@ where
     if height.0 > 0 {
         let next_height = Height(height.0 - 1);
         descent_map.extend(get_descents(next_height, NodePath(path.0.clone().mul(2u64)), lefts.0, lefts.1, lefts.2)?);
-        descent_map.extend(get_descents(next_height, NodePath(path.0.mul(2u64).add(1u64)), rights.0, rights.1, rights.2)?);
+        descent_map.extend(get_descents(
+            next_height,
+            NodePath(path.0.mul(2u64).add(1u64)),
+            rights.0,
+            rights.1,
+            rights.2,
+        )?);
     }
 
     Ok(descent_map)
@@ -329,13 +337,7 @@ mod tests {
 
     fn print_descent_map(descent_map: &DescentMap) {
         for (key, value) in descent_map {
-            println!(
-                "{}-{}: {}-{}",
-                key.0,
-                key.1,
-                value.0,
-                value.1,
-            )
+            println!("{}-{}: {}-{}", key.0, key.1, value.0, value.1,)
         }
     }
 
@@ -392,7 +394,10 @@ mod tests {
         print_descent_map(&descent_map);
         assert_eq!(
             descent_map,
-            DescentMap::from([(DescentStart(Height(3), NodePath(0usize.into())), DescentPath(Length(3), NodePath(1usize.into())))]),
+            DescentMap::from([(
+                DescentStart(Height(3), NodePath(0usize.into())),
+                DescentPath(Length(3), NodePath(1usize.into()))
+            )]),
         );
     }
 
@@ -430,7 +435,10 @@ mod tests {
         print_descent_map(&descent_map);
         assert_eq!(
             descent_map,
-            DescentMap::from([(DescentStart(Height(3), NodePath(0usize.into())), DescentPath(Length(2), NodePath(0usize.into())))]),
+            DescentMap::from([(
+                DescentStart(Height(3), NodePath(0usize.into())),
+                DescentPath(Length(2), NodePath(0usize.into()))
+            )]),
         );
     }
 

--- a/src/starkware_utils/commitment_tree/update_tree.rs
+++ b/src/starkware_utils/commitment_tree/update_tree.rs
@@ -276,7 +276,7 @@ type Layer<LF> = HashMap<TreeIndex, TreeUpdate<LF>>;
 ///  * None (if no modifications exist in its subtree).
 ///  * A leaf (if a single modification is given at height 0; i.e., a leaf).
 ///  * A pair of trees.
-fn build_update_tree<LF>(height: Height, modifications: Vec<(TreeIndex, LF)>) -> UpdateTree<LF>
+pub fn build_update_tree<LF>(height: Height, modifications: Vec<(TreeIndex, LF)>) -> UpdateTree<LF>
 where
     LF: Clone,
 {


### PR DESCRIPTION
Improves the typing around `DescentMap`. This was meant to be a PoC, it could be improved quite a bit, esp. around type conversions.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
