### PR TITLE
Fix: share storage across contracts

### DIFF
--- a/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
@@ -109,7 +109,7 @@ where
 
     async fn get_children(&mut self, node: &Self::NodeType) -> Result<Vec<Self::NodeType>, TreeError> {
         if node.previous.is_leaf() {
-            let storage = self.ffc.storage().await;
+            let storage = self.ffc.acquire_storage().await;
             // unwrap() on leaf_hash is guaranteed to be safe because of the check above
             let previous = LF::get_or_fail(storage.deref(), &node.previous.leaf_hash().unwrap()).await?;
             let current = LF::get_or_fail(storage.deref(), &node.current.leaf_hash().unwrap()).await?;
@@ -260,7 +260,7 @@ where
             // TODO: determine what to do with the assertion in the Python code
             // assert set(indices) == {0}, f"Commitment tree indices out of range: {indices}."
 
-            let storage = ffc.storage().await;
+            let storage = ffc.acquire_storage().await;
             let leaf = LF::get_or_fail(storage.deref(), &self._leaf_hash()).await?;
             Ok(HashMap::from([(BigUint::from(0u64), leaf)]))
         }
@@ -296,7 +296,7 @@ where
     H: HashFunctionType,
     INF: InnerNodeFact<S, H>,
 {
-    let storage = ffc.storage().await;
+    let storage = ffc.acquire_storage().await;
     let inner_node_fact = INF::get_or_fail(storage.deref(), fact_hash).await?;
 
     if let Some(facts) = facts {

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::ops::Deref;
 
 use futures::future::FutureExt;
 use num_bigint::BigUint;
@@ -293,7 +294,8 @@ where
         return Ok(HashMap::new());
     }
 
-    let empty_leaf = LF::get_or_fail(&ffc.storage, EMPTY_NODE_HASH.as_ref()).await?;
+    let storage = ffc.storage().await;
+    let empty_leaf = LF::get_or_fail(storage.deref(), EMPTY_NODE_HASH.as_ref()).await?;
     let result: HashMap<_, LF> = indices.iter().map(|index| (index.clone(), empty_leaf.clone())).collect();
     Ok(result)
 }

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -294,7 +294,7 @@ where
         return Ok(HashMap::new());
     }
 
-    let storage = ffc.storage().await;
+    let storage = ffc.acquire_storage().await;
     let empty_leaf = LF::get_or_fail(storage.deref(), EMPTY_NODE_HASH.as_ref()).await?;
     let result: HashMap<_, LF> = indices.iter().map(|index| (index.clone(), empty_leaf.clone())).collect();
     Ok(result)

--- a/src/starkware_utils/commitment_tree/update_tree.rs
+++ b/src/starkware_utils/commitment_tree/update_tree.rs
@@ -323,7 +323,7 @@ where
 {
     // TODO: this implementation is sync and simplistic for now.
     //       Determine if it is necessary to improve it.
-    let mut storage = ffc.storage().await;
+    let mut storage = ffc.acquire_storage().await;
     for (root_hash, root_node) in fact_nodes.inner_nodes.iter() {
         root_node.set(storage.deref_mut(), root_hash).await?;
     }

--- a/src/starkware_utils/commitment_tree/update_tree.rs
+++ b/src/starkware_utils/commitment_tree/update_tree.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
+use std::ops::DerefMut;
 
 use num_bigint::BigUint;
 
@@ -322,11 +323,12 @@ where
 {
     // TODO: this implementation is sync and simplistic for now.
     //       Determine if it is necessary to improve it.
+    let mut storage = ffc.storage().await;
     for (root_hash, root_node) in fact_nodes.inner_nodes.iter() {
-        root_node.set(&mut ffc.storage, root_hash).await?;
+        root_node.set(storage.deref_mut(), root_hash).await?;
     }
     for (root_hash, root_node) in fact_nodes.leaves.iter() {
-        root_node.set(&mut ffc.storage, root_hash).await?;
+        root_node.set(storage.deref_mut(), root_hash).await?;
     }
 
     Ok(())

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -161,7 +161,7 @@ where
         Self { storage: Arc::new(Mutex::new(storage)), _h: Default::default() }
     }
 
-    pub async fn storage(&self) -> tokio::sync::MutexGuard<S> {
+    pub async fn acquire_storage(&self) -> tokio::sync::MutexGuard<S> {
         self.storage.lock().await
     }
 }
@@ -172,7 +172,7 @@ pub trait Fact<S: Storage, H: HashFunctionType>: DbObject {
 
     async fn set_fact(&self, ffc: &mut FactFetchingContext<S, H>) -> Result<Vec<u8>, StorageError> {
         let hash_val = self.hash();
-        let mut storage = ffc.storage().await;
+        let mut storage = ffc.acquire_storage().await;
         self.set(storage.deref_mut(), &hash_val).await?;
 
         Ok(hash_val)


### PR DESCRIPTION
Problem: `OsSingleStarknetStorage` is currently built with a different FFC/storage for each contract. This creates N distinct storage objects while we should use one.

Solution: wrap the storage object inside an `Arc<Mutex<_>>` to make it shareable.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
