### PR TITLE
Impl ASSERT_END_OF_BYTECODE_SEGMENTS hint

### DIFF
--- a/src/hints/compiled_class.rs
+++ b/src/hints/compiled_class.rs
@@ -41,11 +41,11 @@ pub fn assert_end_of_bytecode_segments(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let mut bytecode_segments: <Vec<BytecodeSegment> as IntoIterator>::IntoIter = exec_scopes.get(vars::scopes::BYTECODE_SEGMENTS)?;
+    let mut bytecode_segments: <Vec<BytecodeSegment> as IntoIterator>::IntoIter =
+        exec_scopes.get(vars::scopes::BYTECODE_SEGMENTS)?;
     if let Some(_) = bytecode_segments.next() {
         return Err(HintError::AssertionFailed("bytecode_segments is not exhausted".to_string().into_boxed_str()));
     }
 
     Ok(())
 }
-

--- a/src/hints/compiled_class.rs
+++ b/src/hints/compiled_class.rs
@@ -41,7 +41,8 @@ pub fn assert_end_of_bytecode_segments(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let bytecode_segments = exec_scopes.get_mut_ref::<<Vec<BytecodeSegment> as IntoIterator>::IntoIter>(vars::scopes::BYTECODE_SEGMENTS)?;
+    let bytecode_segments =
+        exec_scopes.get_mut_ref::<<Vec<BytecodeSegment> as IntoIterator>::IntoIter>(vars::scopes::BYTECODE_SEGMENTS)?;
     if let Some(_) = bytecode_segments.next() {
         return Err(HintError::AssertionFailed("bytecode_segments is not exhausted".to_string().into_boxed_str()));
     }

--- a/src/hints/compiled_class.rs
+++ b/src/hints/compiled_class.rs
@@ -9,7 +9,7 @@ use cairo_vm::Felt252;
 use indoc::indoc;
 
 use crate::hints::vars;
-use crate::starknet::core::os::contract_class::compiled_class_hash_objects::BytecodeSegmentedNode;
+use crate::starknet::core::os::contract_class::compiled_class_hash_objects::{BytecodeSegment, BytecodeSegmentedNode};
 
 pub const ASSIGN_BYTECODE_SEGMENTS: &str = indoc! {r#"
     bytecode_segments = iter(bytecode_segment_structure.segments)"#
@@ -30,3 +30,22 @@ pub fn assign_bytecode_segments(
 
     Ok(())
 }
+
+pub const ASSERT_END_OF_BYTECODE_SEGMENTS: &str = indoc! {r#"
+    assert next(bytecode_segments, None) is None"#
+};
+pub fn assert_end_of_bytecode_segments(
+    _vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    _ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let mut bytecode_segments: <Vec<BytecodeSegment> as IntoIterator>::IntoIter = exec_scopes.get(vars::scopes::BYTECODE_SEGMENTS)?;
+    if let Some(_) = bytecode_segments.next() {
+        return Err(HintError::AssertionFailed("bytecode_segments is not exhausted".to_string().into_boxed_str()));
+    }
+
+    Ok(())
+}
+

--- a/src/hints/compiled_class.rs
+++ b/src/hints/compiled_class.rs
@@ -93,7 +93,13 @@ mod tests {
         // iter is not empty, so the next call should fail. notice that it will consume next(),
         // though.
         let res = assert_end_of_bytecode_segments(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants);
-        assert!(res.is_err()); // TODO: match on exact error, HintError doesn't impl PartialEq
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            HintError::AssertionFailed(msg) => {
+                assert_eq!(msg, "bytecode_segments is not exhausted".to_string().into_boxed_str())
+            }
+            _ => panic!("Unexpected error returned"),
+        }
 
         // should succeed this time because iter as exhausted
         let res = assert_end_of_bytecode_segments(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants);

--- a/src/hints/compiled_class.rs
+++ b/src/hints/compiled_class.rs
@@ -41,8 +41,7 @@ pub fn assert_end_of_bytecode_segments(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let bytecode_segments: <Vec<BytecodeSegment> as IntoIterator>::IntoIter =
-        exec_scopes.get_mut_ref(vars::scopes::BYTECODE_SEGMENTS)?;
+    let bytecode_segments = exec_scopes.get_mut_ref::<<Vec<BytecodeSegment> as IntoIterator>::IntoIter>(vars::scopes::BYTECODE_SEGMENTS)?;
     if let Some(_) = bytecode_segments.next() {
         return Err(HintError::AssertionFailed("bytecode_segments is not exhausted".to_string().into_boxed_str()));
     }

--- a/src/hints/compiled_class.rs
+++ b/src/hints/compiled_class.rs
@@ -43,7 +43,8 @@ pub fn assert_end_of_bytecode_segments(
 ) -> Result<(), HintError> {
     let bytecode_segments =
         exec_scopes.get_mut_ref::<<Vec<BytecodeSegment> as IntoIterator>::IntoIter>(vars::scopes::BYTECODE_SEGMENTS)?;
-    if let Some(_) = bytecode_segments.next() {
+    // ensure the iter is exhausted. note that this consumes next() if it is not
+    if bytecode_segments.next().is_some() {
         return Err(HintError::AssertionFailed("bytecode_segments is not exhausted".to_string().into_boxed_str()));
     }
 

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -50,7 +50,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 162] = [
+static HINTS: [(&str, HintImpl); 164] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -82,6 +82,7 @@ static HINTS: [(&str, HintImpl); 162] = [
     (builtins::SELECT_BUILTIN, builtins::select_builtin),
     (builtins::UPDATE_BUILTIN_PTRS, builtins::update_builtin_ptrs),
     (compiled_class::ASSIGN_BYTECODE_SEGMENTS, compiled_class::assign_bytecode_segments),
+    (compiled_class::ASSERT_END_OF_BYTECODE_SEGMENTS, compiled_class::assert_end_of_bytecode_segments),
     (execute_syscalls::IS_BLOCK_NUMBER_IN_BLOCK_HASH_BUFFER, execute_syscalls::is_block_number_in_block_hash_buffer),
     (execution::ADD_RELOCATION_RULE, execution::add_relocation_rule),
     (execution::ASSERT_TRANSACTION_HASH, execution::assert_transaction_hash),

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -51,7 +51,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 165] = [
+static HINTS: [(&str, HintImpl); 166] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -79,11 +79,6 @@ pub const DATA_TO_HASH_NEW_SEGMENT: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-pub const ASSERT_END_OF_BYTECODE_SEGMENTS: &str = indoc! {r#"
-    assert next(bytecode_segments, None) is None"#
-};
-
-#[allow(unused)]
 pub const WRITE_ADDRESS: &str = indoc! {r#"
     from starkware.starknet.core.os.data_availability.bls_utils import split
 


### PR DESCRIPTION
Implements the `ASSERT_END_OF_BYTECODE_SEGMENTS` hint.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
