### PR TITLE
Feature: WRITE_KZG_COMMITMENT hint

### DIFF
--- a/src/execution/kzg.rs
+++ b/src/execution/kzg.rs
@@ -1,0 +1,18 @@
+use cairo_vm::Felt252;
+
+pub trait KzgCommitmentComputer {
+    fn compute_kzg_commitment_from_coefficients(&self, coefficients: &[Felt252]) -> (Felt252, Felt252);
+}
+
+/// A struct with a default implementation of the KZG commitment computation.
+///
+/// We do not know yet how to compute the KZG commitment, this structure is a default
+/// implementation that will panic until we figure it out properly.
+#[derive(Debug)]
+pub struct PlaceholderKzgCommitmentComputer;
+
+impl KzgCommitmentComputer for PlaceholderKzgCommitmentComputer {
+    fn compute_kzg_commitment_from_coefficients(&self, _coefficients: &[Felt252]) -> (Felt252, Felt252) {
+        todo!("Define correct method to compute KZG commitment");
+    }
+}

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -2,5 +2,6 @@ mod constants;
 pub mod deprecated_syscall_handler;
 pub mod execute_syscalls;
 pub mod helper;
+mod kzg;
 pub mod syscall_handler;
 pub mod syscall_handler_utils;

--- a/src/hints/commitment.rs
+++ b/src/hints/commitment.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
+    get_integer_from_var_name, get_ptr_from_var_name, get_relocatable_from_var_name,
+};
+use cairo_vm::hint_processor::hint_processor_definition::HintReference;
+use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
+use cairo_vm::serde::deserialize_program::ApTracking;
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use cairo_vm::Felt252;
+use indoc::indoc;
+
+use crate::execution::helper::ExecutionHelperWrapper;
+use crate::hints::vars;
+use crate::utils::execute_coroutine;
+
+pub const WRITE_ZKG_COMMITMENT: &str = indoc! {r#"
+    execution_helper.store_da_segment(
+        da_segment=memory.get_range_as_ints(addr=ids.state_updates_start, size=ids.da_size)
+    )
+    segments.write_arg(
+        ids.kzg_commitment.address_,
+        execution_helper.polynomial_coefficients_to_kzg_commitment_callback(
+            execution_helper.da_segment
+        )
+    )"#
+};
+
+pub async fn write_zkg_commitment_async(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+) -> Result<(), HintError> {
+    let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+
+    let state_updates_start = get_ptr_from_var_name(vars::ids::STATE_UPDATES_START, vm, ids_data, ap_tracking)?;
+    let da_size_felt = get_integer_from_var_name(vars::ids::DA_START, vm, ids_data, ap_tracking)?;
+    let da_size = felt_to_usize(&da_size_felt)?;
+
+    let da_segment: Vec<_> =
+        vm.get_integer_range(state_updates_start, da_size)?.into_iter().map(|x| x.into_owned()).collect();
+
+    execution_helper.store_da_segment(da_segment.clone()).await?;
+
+    // Compute and store KZG commitment
+    let kzg_commitment_address = get_relocatable_from_var_name(vars::ids::KZG_COMMITMENT, vm, ids_data, ap_tracking)?;
+    let kzg_commitment = execution_helper.compute_kzg_commitment(&da_segment).await;
+
+    vm.write_arg(kzg_commitment_address, &vec![kzg_commitment.0, kzg_commitment.1])?;
+
+    Ok(())
+}
+
+pub fn write_zkg_commitment(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(write_zkg_commitment_async(vm, exec_scopes, ids_data, ap_tracking))?
+}

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -31,6 +31,7 @@ pub mod block_context;
 mod bls_field;
 mod bls_utils;
 pub mod builtins;
+mod commitment;
 mod compiled_class;
 mod deprecated_compiled_class;
 mod execute_transactions;
@@ -55,7 +56,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 172] = [
+static HINTS: [(&str, HintImpl); 173] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -85,6 +86,7 @@ static HINTS: [(&str, HintImpl); 172] = [
     (builtins::SELECTED_BUILTINS, builtins::selected_builtins),
     (builtins::SELECT_BUILTIN, builtins::select_builtin),
     (builtins::UPDATE_BUILTIN_PTRS, builtins::update_builtin_ptrs),
+    (commitment::WRITE_ZKG_COMMITMENT, commitment::write_zkg_commitment),
     (compiled_class::ASSIGN_BYTECODE_SEGMENTS, compiled_class::assign_bytecode_segments),
     (compiled_class::ASSERT_END_OF_BYTECODE_SEGMENTS, compiled_class::assert_end_of_bytecode_segments),
     (deprecated_compiled_class::LOAD_DEPRECATED_CLASS_FACTS, deprecated_compiled_class::load_deprecated_class_facts),

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -67,19 +67,6 @@ pub const COMPUTE_IDS_HIGH_LOW: &str = indoc! {r#"
 };
 
 #[allow(unused)]
-pub const WRITE_ZKG_COMMITMENT_ADDRESS: &str = indoc! {r#"
-    execution_helper.store_da_segment(
-        da_segment=memory.get_range_as_ints(addr=ids.state_updates_start, size=ids.da_size)
-    )
-    segments.write_arg(
-        ids.kzg_commitment.address_,
-        execution_helper.polynomial_coefficients_to_kzg_commitment_callback(
-            execution_helper.da_segment
-        )
-    )"#
-};
-
-#[allow(unused)]
 pub const WRITE_NIBBLES_TO_MEM: &str = indoc! {r#"
     memory[fp + 0] = to_felt_or_relocatable(nibbles.pop())"#
 };

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -54,7 +54,7 @@ pub mod ids {
     pub const INITIAL_CONTRACT_STATE_ROOT: &str = "initial_contract_state_root";
     pub const INITIAL_ROOT: &str = "initial_root";
     pub const IS_ON_CURVE: &str = "is_on_curve";
-    pub const USE_KZG_DA: &str = "use_kzg_da";
+    pub const KZG_COMMITMENT: &str = "kzg_commitment";
     pub const LENGTH: &str = "length";
     pub const LOW: &str = "low";
     pub const MAX_FEE: &str = "max_fee";
@@ -91,6 +91,7 @@ pub mod ids {
     pub const TX_INFO: &str = "tx_info";
     pub const TX_VERSION: &str = "tx_version";
     pub const UPDATE_PTR: &str = "update_ptr";
+    pub const USE_KZG_DA: &str = "use_kzg_da";
     pub const VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = "validate_declare_execution_context";
     pub const VALUE: &str = "value";
     pub const WORD: &str = "word";


### PR DESCRIPTION
This implementation uses a default (panicking) implementation of the KZG
commitment computation as we do not know how these must be computed.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
