### PR TITLE
Feature: build storage from Blockifier state

### DIFF
--- a/src/execution/deprecated_syscall_handler.rs
+++ b/src/execution/deprecated_syscall_handler.rs
@@ -163,7 +163,6 @@ mod test {
     use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
     use blockifier::execution::call_info::Retdata;
     use blockifier::execution::entry_point_execution::CallResult;
-    use blockifier::state::cached_state::CachedState;
     use cairo_vm::types::exec_scope::ExecutionScopes;
     use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
     use cairo_vm::vm::vm_core::VirtualMachine;
@@ -176,7 +175,7 @@ mod test {
 
     use crate::config::STORED_BLOCK_HASH_BUFFER;
     use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
-    use crate::execution::helper::ExecutionHelperWrapper;
+    use crate::execution::helper::{ContractStorageMap, ExecutionHelperWrapper};
     use crate::hints::vars;
 
     #[fixture]
@@ -216,7 +215,7 @@ mod test {
 
         let execution_infos = Default::default();
         let exec_helper = ExecutionHelperWrapper::new(
-            CachedState::default(),
+            ContractStorageMap::default(),
             execution_infos,
             &block_context,
             old_block_number_and_hash,

--- a/src/execution/helper.rs
+++ b/src/execution/helper.rs
@@ -189,13 +189,6 @@ impl ExecutionHelperWrapper {
         key: Felt252,
         value: Felt252,
     ) -> Result<(), StorageError> {
-        println!(
-            "writing storage for {} - key: {:#x}, value: {}",
-            address.to_biguint(),
-            key.to_biguint(),
-            value.to_biguint()
-        );
-
         let storage_by_address = &mut self.execution_helper.as_ref().borrow_mut().storage_by_address;
         if let Some(storage) = storage_by_address.get_mut(&address) {
             storage.write(key.to_biguint(), value);

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1749,7 +1749,6 @@ mod tests {
     use std::rc::Rc;
 
     use blockifier::block_context::BlockContext;
-    use blockifier::state::cached_state::CachedState;
     use cairo_vm::hint_processor::builtin_hint_processor::dict_manager::DictManager;
     use cairo_vm::types::relocatable::Relocatable;
     use num_bigint::BigUint;
@@ -1759,6 +1758,7 @@ mod tests {
     use super::*;
     use crate::config::STORED_BLOCK_HASH_BUFFER;
     use crate::crypto::pedersen::PedersenHash;
+    use crate::execution::helper::ContractStorageMap;
     use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, OsSingleStarknetStorage, StorageLeaf};
     use crate::starkware_utils::commitment_tree::base_types::Height;
     use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
@@ -1782,7 +1782,7 @@ mod tests {
         block_context: BlockContext,
         old_block_number_and_hash: (Felt252, Felt252),
     ) -> ExecutionHelperWrapper {
-        ExecutionHelperWrapper::new(CachedState::default(), vec![], &block_context, old_block_number_and_hash)
+        ExecutionHelperWrapper::new(ContractStorageMap::default(), vec![], &block_context, old_block_number_and_hash)
     }
 
     #[fixture]

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1514,17 +1514,20 @@ pub fn write_syscall_result(
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let request = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
+    let storage_write_address = *vm.get_integer((request + NewStorageWriteRequest::key_offset())?)?;
+    let storage_write_value = vm.get_integer((request + NewStorageWriteRequest::value_offset())?)?.into_owned();
+
+    println!(
+        "write_syscall_result hint wants to write {} to {}/{}",
+        storage_write_value, contract_address, storage_write_address
+    );
 
     // ids.prev_value = storage.read(key=ids.request.key)
-    let storage_write_address = *vm.get_integer((request + NewStorageWriteRequest::key_offset())?)?;
     let prev_value =
-        execution_helper.read_storage_for_address(contract_address, storage_write_address).map_err(|_| {
-            HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str())
-        })?;
+        execution_helper.read_storage_for_address(contract_address, storage_write_address).unwrap_or_default();
     insert_value_from_var_name(vars::ids::PREV_VALUE, prev_value, vm, ids_data, ap_tracking)?;
 
     // storage.write(key=ids.request.key, value=ids.request.value)
-    let storage_write_value = vm.get_integer((request + NewStorageWriteRequest::value_offset())?)?.into_owned();
     execution_helper.write_storage_for_address(contract_address, storage_write_address, storage_write_value).map_err(
         |_| HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str()),
     )?;

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1517,11 +1517,6 @@ pub fn write_syscall_result(
     let storage_write_address = *vm.get_integer((request + NewStorageWriteRequest::key_offset())?)?;
     let storage_write_value = vm.get_integer((request + NewStorageWriteRequest::value_offset())?)?.into_owned();
 
-    println!(
-        "write_syscall_result hint wants to write {} to {}/{}",
-        storage_write_value, contract_address, storage_write_address
-    );
-
     // ids.prev_value = storage.read(key=ids.request.key)
     let prev_value =
         execution_helper.read_storage_for_address(contract_address, storage_write_address).unwrap_or_default();

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -351,13 +351,13 @@ mod tests {
     use std::borrow::Cow;
 
     use blockifier::block_context::BlockContext;
-    use blockifier::state::cached_state::CachedState;
     use num_bigint::BigUint;
     use rstest::{fixture, rstest};
 
     use super::*;
     use crate::config::STORED_BLOCK_HASH_BUFFER;
     use crate::crypto::pedersen::PedersenHash;
+    use crate::execution::helper::ContractStorageMap;
     use crate::hints::types::PatriciaSkipValidationRunner;
     use crate::starknet::starknet_storage::{OsSingleStarknetStorage, StorageLeaf};
     use crate::starkware_utils::commitment_tree::base_types::Height;
@@ -407,7 +407,7 @@ mod tests {
         block_context: BlockContext,
         old_block_number_and_hash: (Felt252, Felt252),
     ) -> ExecutionHelperWrapper {
-        ExecutionHelperWrapper::new(CachedState::default(), vec![], &block_context, old_block_number_and_hash)
+        ExecutionHelperWrapper::new(ContractStorageMap::default(), vec![], &block_context, old_block_number_and_hash)
     }
 
     #[fixture]

--- a/src/hints/syscalls.rs
+++ b/src/hints/syscalls.rs
@@ -383,11 +383,11 @@ pub fn os_logger_enter_syscall_preprare_exit_syscall(
 #[cfg(test)]
 mod tests {
     use blockifier::block_context::BlockContext;
-    use blockifier::state::cached_state::CachedState;
     use cairo_vm::types::relocatable::Relocatable;
     use rstest::{fixture, rstest};
 
     use super::*;
+    use crate::execution::helper::ContractStorageMap;
     use crate::hints::tests::tests::{block_context, old_block_number_and_hash};
     use crate::ExecutionHelperWrapper;
 
@@ -395,7 +395,7 @@ mod tests {
     fn exec_scopes(block_context: BlockContext, old_block_number_and_hash: (Felt252, Felt252)) -> ExecutionScopes {
         let execution_infos = vec![];
         let exec_helper = ExecutionHelperWrapper::new(
-            CachedState::default(),
+            ContractStorageMap::default(),
             execution_infos,
             &block_context,
             old_block_number_and_hash,

--- a/src/hints/tests.rs
+++ b/src/hints/tests.rs
@@ -3,7 +3,6 @@ pub mod tests {
     use std::sync::Arc;
 
     use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
-    use blockifier::state::cached_state::CachedState;
     use blockifier::transaction::objects::TransactionExecutionInfo;
     use cairo_vm::serde::deserialize_program::ApTracking;
     use cairo_vm::types::exec_scope::ExecutionScopes;
@@ -16,6 +15,7 @@ pub mod tests {
     use starknet_api::{contract_address, patricia_key};
 
     use crate::config::STORED_BLOCK_HASH_BUFFER;
+    use crate::execution::helper::ContractStorageMap;
     use crate::hints::*;
 
     macro_rules! references {
@@ -97,7 +97,7 @@ pub mod tests {
         // inject txn execution info with a fee for hint to use
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(
-            CachedState::default(),
+            ContractStorageMap::default(),
             execution_infos,
             &block_context,
             old_block_number_and_hash,
@@ -166,7 +166,7 @@ pub mod tests {
         // we need an execution info in order to start a tx
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(
-            CachedState::default(),
+            ContractStorageMap::default(),
             execution_infos,
             &block_context,
             old_block_number_and_hash,
@@ -203,7 +203,7 @@ pub mod tests {
         // execution info to chew through
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(
-            CachedState::default(),
+            ContractStorageMap::default(),
             execution_infos,
             &block_context,
             old_block_number_and_hash,
@@ -244,7 +244,7 @@ pub mod tests {
 
         let execution_infos = vec![transaction_execution_info];
         let exec_helper = ExecutionHelperWrapper::new(
-            CachedState::default(),
+            ContractStorageMap::default(),
             execution_infos,
             &block_context,
             old_block_number_and_hash,

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -116,10 +116,6 @@ impl CommitmentInfo {
         let actual_updated_root = Felt252::from_bytes_be_slice(&actual_updated_tree.root);
 
         if actual_updated_root != expected_updated_root {
-            println!(
-                "actual_updated_root != expected_updated_root ({} != {})",
-                actual_updated_root, expected_updated_root
-            );
             return Err(CommitmentInfoError::UpdatedRootMismatch);
         }
 

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -116,6 +116,10 @@ impl CommitmentInfo {
         let actual_updated_root = Felt252::from_bytes_be_slice(&actual_updated_tree.root);
 
         if actual_updated_root != expected_updated_root {
+            println!(
+                "actual_updated_root != expected_updated_root ({} != {})",
+                actual_updated_root, expected_updated_root
+            );
             return Err(CommitmentInfoError::UpdatedRootMismatch);
         }
 

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -1,8 +1,22 @@
-use cairo_vm::Felt252;
+use std::collections::HashMap;
 
+use blockifier::state::cached_state::{CachedState, StorageEntry};
+use blockifier::state::state_api::State;
+use blockifier::test_utils::dict_state_reader::DictStateReader;
+use cairo_vm::Felt252;
+use starknet_api::hash::StarkFelt;
+
+use crate::execution::helper::ContractStorageMap;
+use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, OsSingleStarknetStorage, StorageLeaf};
+use crate::starkware_utils::commitment_tree::base_types::Height;
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
+use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
-use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage};
+use crate::storage::dict_storage::DictStorage;
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
+use crate::utils::felt_api2vm;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SimpleLeafFact {
@@ -50,4 +64,88 @@ where
     fn is_empty(&self) -> bool {
         self.value == Felt252::ZERO
     }
+}
+
+/// An intermediate contract -> [(key, value), ...] map representation.
+type StorageMap = HashMap<Felt252, Vec<(Felt252, Felt252)>>;
+
+/// CachedState's `state.state.storage_view` is a mapping of (contract, storage_key) -> value
+/// but we need a mapping of (contract) -> [(storage_key, value)] so we can build the tree
+/// in one go.
+fn get_contract_storage_map(storage_view: &HashMap<StorageEntry, StarkFelt>) -> StorageMap {
+    let mut contract_storage_map: HashMap<Felt252, Vec<(Felt252, Felt252)>> = Default::default();
+    for ((contract_address, storage_key), value) in storage_view {
+        let contract_address = felt_api2vm(*contract_address.0.key());
+        let storage_key = felt_api2vm(*storage_key.0.key());
+        let value = felt_api2vm(*value);
+
+        contract_storage_map.entry(contract_address).or_default();
+        contract_storage_map.get_mut(&contract_address).unwrap().push((storage_key, value));
+    }
+
+    contract_storage_map
+}
+
+/// Builds the final state storage map.
+fn build_final_storage_map(final_state: &mut CachedState<DictStateReader>) -> StorageMap {
+    let mut storage = final_state.state.storage_view.clone();
+    let storage_updates = final_state.to_state_diff().storage_updates;
+
+    for (contract_address, contract_storage_updates) in storage_updates {
+        for (key, value) in contract_storage_updates {
+            storage.insert((contract_address, key), value);
+        }
+    }
+
+    get_contract_storage_map(&storage)
+}
+
+/// Builds a Patricia tree for a specific contract.
+///
+/// Applies the `contract_storage` values as modifications to an empty Patricia tree and returns
+/// the updated tree.
+async fn build_patricia_tree_from_contract_storage<S, H>(
+    ffc: &mut FactFetchingContext<S, H>,
+    contract_storage: &[(Felt252, Felt252)],
+) -> Result<PatriciaTree, TreeError>
+where
+    S: Storage + Send + Sync + 'static,
+    H: HashFunctionType + Send + Sync + 'static,
+{
+    let modifications: Vec<_> =
+        contract_storage.iter().map(|(key, value)| (key.to_biguint(), StorageLeaf::new(*value))).collect();
+
+    let mut facts = None;
+    let mut tree = PatriciaTree::empty_tree(ffc, Height(251), StorageLeaf::empty()).await.unwrap();
+    tree.update(ffc, modifications, &mut facts).await
+}
+
+/// Translates the (final) Blockifier state into an OS-compatible structure.
+///
+/// This function uses the fact that `CachedState` is a wrapper around a read-only `DictStateReader`
+/// object. The initial state is obtained through this read-only view while the final storage
+/// is obtained by extracting the state diff from the `CachedState` part.
+pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader>) -> ContractStorageMap {
+    let initial_contract_storage_map = get_contract_storage_map(&blockifier_state.state.storage_view);
+    let final_contract_storage_map = build_final_storage_map(blockifier_state);
+
+    let mut storage_by_address = ContractStorageMap::new();
+
+    let mut ffc = FactFetchingContext::new(DictStorage::default());
+    for (contract_address, initial_contract_storage) in initial_contract_storage_map {
+        let final_contract_storage = final_contract_storage_map.get(&contract_address).unwrap();
+
+        execute_coroutine_threadsafe(async {
+            let initial_tree =
+                build_patricia_tree_from_contract_storage(&mut ffc, &initial_contract_storage).await.unwrap();
+            let updated_tree =
+                build_patricia_tree_from_contract_storage(&mut ffc, final_contract_storage).await.unwrap();
+
+            let contract_storage =
+                OsSingleStarknetStorage::new(initial_tree, updated_tree, &[], ffc.clone()).await.unwrap();
+            storage_by_address.insert(contract_address, contract_storage);
+        });
+    }
+
+    storage_by_address
 }

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -17,7 +17,7 @@ use snos::{config, run_os};
 use starknet_api::hash::StarkFelt;
 use starknet_crypto::{pedersen_hash, FieldElement};
 
-use crate::common::block_utils::{copy_state, os_hints};
+use crate::common::block_utils::os_hints;
 
 pub fn to_felt252(stark_felt: &StarkFelt) -> Felt252 {
     Felt252::from_bytes_be_slice(stark_felt.bytes())
@@ -138,10 +138,9 @@ fn execute_txs(
     txs: Vec<AccountTransaction>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper) {
     let internal_txs: Vec<_> = txs.iter().map(to_internal_tx).collect();
-    let initial_state = copy_state(&state);
     let execution_infos =
         txs.into_iter().map(|tx| tx.execute(&mut state, block_context, true, true).unwrap()).collect();
-    os_hints(&block_context, initial_state, internal_txs, execution_infos)
+    os_hints(&block_context, state, internal_txs, execution_infos)
 }
 
 pub fn execute_txs_and_run_os(

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -141,5 +141,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     let r = execute_txs_and_run_os(state, block_context, txs);
 
     // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
+    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
 }

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -39,8 +39,9 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
 
-    // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
+    // temporarily expect test to break at the descent map hint
+    let err_log = format!("{:?}", r);
+    assert!(err_log.contains(r#"UnknownHint"#), "{}", err_log);
 }
 
 #[rstest]
@@ -69,8 +70,9 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
 
-    // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
+    // temporarily expect test to break at the descent map hint
+    let err_log = format!("{:?}", r);
+    assert!(err_log.contains(r#"UnknownHint"#), "{}", err_log);
 }
 
 #[rstest]
@@ -140,6 +142,7 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     let r = execute_txs_and_run_os(state, block_context, txs);
 
-    // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
+    // temporarily expect test to break at the descent map hint
+    let err_log = format!("{:?}", r);
+    assert!(err_log.contains(r#"UnknownHint"#), "{}", err_log);
 }

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -40,7 +40,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
     let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
 
     // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"CustomHint("Could not find commitment info"#));
+    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
 }
 
 #[rstest]
@@ -70,7 +70,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
     let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
 
     // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"CustomHint("Could not find commitment info"#));
+    assert!(&format!("{:?}", r).contains(r#"AssertionFailed("Tree height does not match Merkle height")))"#));
 }
 
 #[rstest]
@@ -141,5 +141,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     let r = execute_txs_and_run_os(state, block_context, txs);
 
     // temporarily expect test to break somewhere in the state_update function
-    assert!(&format!("{:?}", r).contains(r#"CustomHint("Could not find commitment info"#));
+    assert!(&format!("{:?}", r).contains(r#"CustomHint("Storage not found for contract 3221227264")"#));
 }


### PR DESCRIPTION
Problem: we currently use the Blockifier state structures inside the OS. We wish to be agnostic of the data source inside the OS.

Solution: Add a mechanism to translate the Blockifier state into an OS-specific storage map at boot.

This fix allows to reach further in the OS execution.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes
- [ ] no
