### PR TITLE
Fix: pass correct tree height when building commitment info

### DIFF
--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -122,7 +122,7 @@ impl CommitmentInfo {
         Ok(Self {
             previous_root: previous_tree_root,
             updated_root: actual_updated_root,
-            tree_height: 0,
+            tree_height: previous_tree.height.0 as usize,
             commitment_facts: Default::default(),
         })
     }


### PR DESCRIPTION
Problem: the commitment info height was incorrectly set to 0.

Solution: use the previous tree height, as is done in `cairo-lang`.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
