### PR TITLE
Print last stack frame in test

### DIFF
--- a/tests/common/transaction_utils.rs
+++ b/tests/common/transaction_utils.rs
@@ -163,6 +163,10 @@ pub fn execute_txs_and_run_os(
         Err(Runner(VmException(vme))) => {
             if let Some(traceback) = vme.traceback.as_ref() {
                 println!("traceback:\n{}", traceback);
+                if let Some(inst_location) = &vme.inst_location {
+                    println!("died at: {}:{}", inst_location.input_file.filename, inst_location.start_line);
+                    println!("inst_location:\n{:?}", inst_location);
+                }
             }
         }
         Err(other) => {

--- a/tests/common/transaction_utils.rs
+++ b/tests/common/transaction_utils.rs
@@ -163,10 +163,10 @@ pub fn execute_txs_and_run_os(
         Err(Runner(VmException(vme))) => {
             if let Some(traceback) = vme.traceback.as_ref() {
                 println!("traceback:\n{}", traceback);
-                if let Some(inst_location) = &vme.inst_location {
-                    println!("died at: {}:{}", inst_location.input_file.filename, inst_location.start_line);
-                    println!("inst_location:\n{:?}", inst_location);
-                }
+            }
+            if let Some(inst_location) = &vme.inst_location {
+                println!("died at: {}:{}", inst_location.input_file.filename, inst_location.start_line);
+                println!("inst_location:\n{:?}", inst_location);
             }
         }
         Err(other) => {


### PR DESCRIPTION
Prints the last stack frame, also formatting it such that it can be opened easily in a text editor (e.g. `filename:line_number`)