### PR TITLE
Fix: pass commitment fact in commitment info

### DIFF
--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use crate::starkware_utils::commitment_tree::base_types::TreeIndex;
-use crate::starkware_utils::commitment_tree::binary_fact_tree::{BinaryFactDict, BinaryFactTree};
+use crate::starkware_utils::commitment_tree::binary_fact_tree::{
+    binary_fact_dict_to_felts, BinaryFactDict, BinaryFactTree,
+};
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::{PatriciaTree, EMPTY_NODE_HASH};
@@ -119,11 +121,14 @@ impl CommitmentInfo {
             return Err(CommitmentInfoError::UpdatedRootMismatch);
         }
 
+        // Note: unwrapping is safe here as we wrap the value ourselves a few lines above.
+        let commitment_facts = binary_fact_dict_to_felts(commitment_facts.unwrap());
+
         Ok(Self {
             previous_root: previous_tree_root,
             updated_root: actual_updated_root,
             tree_height: previous_tree.height.0 as usize,
-            commitment_facts: Default::default(),
+            commitment_facts,
         })
     }
 }

--- a/src/starkware_utils/commitment_tree/binary_fact_tree.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use cairo_vm::Felt252;
 use num_bigint::BigUint;
 
 use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
@@ -10,6 +11,14 @@ use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
 pub trait Leaf: Clone {}
 
 pub type BinaryFactDict = HashMap<BigUint, Vec<BigUint>>;
+
+/// Converts a BinaryFactDict from maps of BigUints to Felt252s.
+pub fn binary_fact_dict_to_felts(binary_fact_dict: BinaryFactDict) -> HashMap<Felt252, Vec<Felt252>> {
+    binary_fact_dict
+        .into_iter()
+        .map(|(key, values)| (Felt252::from(key), values.into_iter().map(Felt252::from).collect()))
+        .collect()
+}
 
 /// An abstract base class for Merkle and Patricia-Merkle tree.
 /// An immutable binary tree backed by an immutable fact storage.

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -39,9 +39,9 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
 
-    // temporarily expect test to break at the descent map hint
+    // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"UnknownHint"#), "{}", err_log);
+    assert!(err_log.contains(r#"VariableNotInScopeError("descend")"#), "{}", err_log);
 }
 
 #[rstest]
@@ -70,9 +70,9 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
 
-    // temporarily expect test to break at the descent map hint
+    // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"UnknownHint"#), "{}", err_log);
+    assert!(err_log.contains(r#"VariableNotInScopeError("descend")"#), "{}", err_log);
 }
 
 #[rstest]
@@ -142,7 +142,7 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     let r = execute_txs_and_run_os(state, block_context, txs);
 
-    // temporarily expect test to break at the descent map hint
+    // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"UnknownHint"#), "{}", err_log);
+    assert!(err_log.contains(r#"VariableNotInScopeError("descend")"#), "{}", err_log);
 }


### PR DESCRIPTION
Problem: when building `CommitmentInfo` objects, the `commitment_facts` field is left as an empty hashmap.

Solution: convert the (already built) hashmap properly and pass it when building the `CommitmentInfo` object.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
