### PR TITLE
Fix: write hash_ptr.result correctly in LOAD_EDGE hint

### DIFF
--- a/src/cairo_types/builtins.rs
+++ b/src/cairo_types/builtins.rs
@@ -9,6 +9,7 @@ pub struct HashBuiltin {
     pub result: Felt252,
 }
 
+#[allow(unused)]
 #[derive(FieldOffsetGetters)]
 pub struct SpongeHashBuiltin {
     pub x: Felt252,

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -14,7 +14,7 @@ use cairo_vm::{any_box, Felt252};
 use indoc::indoc;
 
 use super::bls_utils::split;
-use crate::cairo_types::builtins::{HashBuiltin, SpongeHashBuiltin};
+use crate::cairo_types::builtins::HashBuiltin;
 use crate::cairo_types::traits::CairoType;
 use crate::cairo_types::trie::NodeEdge;
 use crate::execution::helper::ExecutionHelperWrapper;
@@ -213,12 +213,11 @@ pub fn load_edge(
     let res = node - edge.length;
 
     // ids.hash_ptr refers to SpongeHashBuiltin (see cairo-lang's sponge_as_hash.cairo)
-    let hash_ptr = get_relocatable_from_var_name(vars::ids::HASH_PTR, vm, ids_data, ap_tracking)?;
-    let hash_result_ptr: Relocatable = (hash_ptr + SpongeHashBuiltin::result_offset())?;
+    let hash_ptr = get_ptr_from_var_name(vars::ids::HASH_PTR, vm, ids_data, ap_tracking)?;
+    let hash_result_ptr: Relocatable = (hash_ptr + HashBuiltin::result_offset())?;
     vm.insert_value(hash_result_ptr, res)?;
 
-    let hash_result_address = (hash_ptr + HashBuiltin::result_offset())?;
-    skip_verification_if_configured(exec_scopes, hash_result_address)?;
+    skip_verification_if_configured(exec_scopes, hash_result_ptr)?;
 
     Ok(())
 }

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -550,6 +550,7 @@ mod tests {
         let mut vm = VirtualMachine::new(false);
         vm.add_memory_segment();
         vm.add_memory_segment();
+        vm.add_memory_segment();
         vm.set_fp(3);
 
         let ap_tracking = ApTracking::new();
@@ -562,6 +563,9 @@ mod tests {
         ]);
         insert_value_from_var_name(vars::ids::NODE, 1_usize, &mut vm, &ids_data, &ap_tracking)
             .expect("Couldn't insert into ids.NODE");
+
+        let hash_ptr = Relocatable::from((2, 0));
+        insert_value_from_var_name(vars::ids::HASH_PTR, hash_ptr, &mut vm, &ids_data, &ap_tracking).unwrap();
 
         let mut exec_scopes: ExecutionScopes = Default::default();
         // TODO: insert meaningful values into preimage


### PR DESCRIPTION
Two fixes:
1. Use `get_ptr` instead of `get_relocatable`
2. Use `HashBuiltin` instead of `SpongeHashBuiltin` as this hint is encountered in `patricia.cairo` and not `patricia_with_sponge.cairo`.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
