### PR TITLE
Chore: update cairo-vm to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.0-rc1"
-source = "git+https://github.com/lambdaclass/cairo-vm#6de8f56fcb28f5e5c0669c747cc76ce34cfef6aa"
+source = "git+https://github.com/lambdaclass/cairo-vm#a462d8d453d2510867c5e640ba1c5bccea6b644d"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4c222d5b2fdc0faf702d3ab361d14589b097f40eac9dc550e27083483edc65"
+checksum = "458fee521f12d0aa97a2e06eaf134398a5d2ae7b2074af77eb402b0d93138c47"
 dependencies = [
  "lambdaworks-math",
  "serde",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee7dcab3968c71896b8ee4dc829147acc918cffe897af6265b1894527fe3add"
+checksum = "6c74ce6f0d9cb672330b6ca59e85a6c3607a3329e0372ab0d3fe38c2d38e50f9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3452,14 +3452,13 @@ dependencies = [
 
 [[package]]
 name = "starknet-types-core"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d53160556d1f23425100f42b3230df747ea05763efee685a2cd939dfb640701"
+checksum = "1051b4f4af0bb9b546388a404873ee1e6b9787b9d5b0b3319ecbfadf315ef276"
 dependencies = [
  "bitvec",
  "lambdaworks-crypto",
  "lambdaworks-math",
- "lazy_static",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.18",

--- a/cairo-type-derive/src/lib.rs
+++ b/cairo-type-derive/src/lib.rs
@@ -20,7 +20,7 @@ pub fn cairo_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                 let n_fields = field_names_read.clone().count();
                 let field_values = field_names_read.clone().enumerate().map(|(index, field_name)| {
                     quote! {
-                        let #field_name = vm.get_integer(&address + #index)?.into_owned();
+                        let #field_name = vm.get_integer((address + #index)?)?.into_owned();
                     }
                 });
 
@@ -34,7 +34,7 @@ pub fn cairo_type_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                         }
                         fn to_memory(&self, vm: &mut VirtualMachine, address: Relocatable) -> Result<(), MemoryError> {
                             let mut offset = 0;
-                            #(vm.insert_value(&address + offset, &self.#field_names_write)?; offset += 1;)*
+                            #(vm.insert_value((address + offset)?, &self.#field_names_write)?; offset += 1;)*
 
                             Ok(())
                         }

--- a/src/cairo_types/traits.rs
+++ b/src/cairo_types/traits.rs
@@ -62,8 +62,8 @@ mod tests {
 
         // Write the data and read it
         vm.insert_value(base_address, Felt252::ONE).unwrap();
-        vm.insert_value(&base_address + 1, Felt252::TWO).unwrap();
-        vm.insert_value(&base_address + 2, Felt252::THREE).unwrap();
+        vm.insert_value((base_address + 1usize).unwrap(), Felt252::TWO).unwrap();
+        vm.insert_value((base_address + 2usize).unwrap(), Felt252::THREE).unwrap();
 
         let m = MyType::from_memory(&vm, base_address).unwrap();
         assert_eq!(m.a, Felt252::ONE);

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use blockifier::abi::constants::{MAX_STEPS_PER_TX, N_STEPS_RESOURCE};
 use blockifier::block_context::{BlockContext, FeeTokenAddresses, GasPrices};
 use blockifier::transaction::objects::FeeType;
+use cairo_vm::types::layout_name::LayoutName;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_api::block::{BlockNumber, BlockTimestamp};
@@ -15,12 +16,16 @@ use starknet_api::{contract_address, patricia_key};
 use starknet_crypto::FieldElement;
 
 use crate::error::SnOsError;
+use crate::utils::ChainIdNum;
+
+pub fn default_layout() -> LayoutName {
+    LayoutName::starknet_with_keccak
+}
 
 const DEFAULT_CONFIG_PATH: &str = "cairo-lang/src/starkware/starknet/definitions/general_config.yml";
 pub const STORED_BLOCK_HASH_BUFFER: u64 = 10;
 pub const BLOCK_HASH_CONTRACT_ADDRESS: u64 = 1;
 pub const STARKNET_OS_CONFIG_HASH_VERSION: &str = "StarknetOsConfig1";
-pub const DEFAULT_LAYOUT: &str = "starknet_with_keccak";
 pub const DEFAULT_COMPILED_OS: &str = "build/os_latest.json";
 pub const DEFAULT_INPUT_PATH: &str = "build/input.json";
 pub const DEFAULT_COMPILER_VERSION: &str = "0.12.2";
@@ -32,7 +37,6 @@ pub const DEFAULT_DEPRECATED_FEE_TOKEN_ADDR: &str = "482bc27fc5627bf974a72b65c43
 pub const SEQUENCER_ADDR_0_13_0: &str = "0x4acb67f8e29379b475ccc408fc8269c116f64b4fe5a625644c507d7df07132";
 pub const SN_GOERLI: &str = "534e5f474f45524c49";
 
-use crate::utils::ChainIdNum;
 #[serde_as]
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq)]
 pub struct StarknetOsConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::fs;
 
 use blockifier::block_context::BlockContext;
 use cairo_vm::cairo_run::CairoRunConfig;
+use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::program::Program;
 use cairo_vm::vm::errors::vm_exception::VmException;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
@@ -31,14 +32,13 @@ pub mod utils;
 
 pub fn run_os(
     os_path: String,
-    layout: String,
+    layout: LayoutName,
     os_input: StarknetOsInput,
     block_context: BlockContext,
     execution_helper: ExecutionHelperWrapper,
 ) -> Result<CairoPie, SnOsError> {
     // Init CairoRunConfig
-    let cairo_run_config =
-        CairoRunConfig { layout: layout.as_str(), relocate_mem: true, trace_enabled: true, ..Default::default() };
+    let cairo_run_config = CairoRunConfig { layout, relocate_mem: true, trace_enabled: true, ..Default::default() };
 
     // Load the Starknet OS Program
     let starknet_os = fs::read(os_path).map_err(|e| SnOsError::CatchAll(format!("{e}")))?;

--- a/tests/integration/common/deprecated_hash_utils.rs
+++ b/tests/integration/common/deprecated_hash_utils.rs
@@ -170,7 +170,7 @@ pub fn compute_deprecated_class_hash(contract_class: &ContractClass) -> Result<F
 
     for builtin_name in contract_class.program().iter_builtins() {
         builtin_list_vec.push(Felt252::from_bytes_be_slice(
-            builtin_name.name().strip_suffix("_builtin").ok_or(ContractAddressError::BuiltinSuffix)?.as_bytes(),
+            builtin_name.to_str().strip_suffix("_builtin").ok_or(ContractAddressError::BuiltinSuffix)?.as_bytes(),
         ));
     }
 

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -3,6 +3,7 @@ use std::fs;
 use blockifier::block_context::BlockContext;
 use cairo_vm::cairo_run::{cairo_run, CairoRunConfig};
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
+use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use cairo_vm::vm::vm_core::VirtualMachine;
@@ -29,7 +30,7 @@ pub fn setup_runner() -> (CairoRunner, VirtualMachine) {
             entrypoint: "main",
             trace_enabled: true,
             relocate_mem: true,
-            layout: "small",
+            layout: LayoutName::small,
             proof_mode: false,
             secure_run: Some(true),
             disable_trace_padding: false,

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -151,13 +151,8 @@ pub fn execute_txs_and_run_os(
 ) -> Result<CairoPie, SnOsError> {
     let (os_input, execution_helper) = execute_txs(state, &block_context, txs);
 
-    let result = run_os(
-        config::DEFAULT_COMPILED_OS.to_string(),
-        config::DEFAULT_LAYOUT.to_string(),
-        os_input,
-        block_context,
-        execution_helper,
-    );
+    let layout = config::default_layout();
+    let result = run_os(config::DEFAULT_COMPILED_OS.to_string(), layout, os_input, block_context, execution_helper);
 
     match &result {
         Err(Runner(VmException(vme))) => {

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use cairo_vm::vm::runners::builtin_runner::OUTPUT_BUILTIN_NAME;
-use cairo_vm::vm::runners::cairo_pie::{BuiltinAdditionalData, CairoPie, OutputBuiltinAdditionalData, SegmentInfo};
+use cairo_vm::types::builtin_name::BuiltinName;
+use cairo_vm::vm::runners::cairo_pie::{
+    BuiltinAdditionalData, CairoPie, CairoPieAdditionalData, OutputBuiltinAdditionalData, SegmentInfo,
+};
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use rstest::rstest;
 use serde_json::json;
@@ -16,7 +18,7 @@ fn pie_metadata_ok(setup_pie: CairoPie) {
 
     assert_eq!(pie_metadata.ret_pc_segment, SegmentInfo::from((4, 0)));
     assert_eq!(pie_metadata.ret_fp_segment, SegmentInfo::from((3, 0)));
-    let expected_builtin_segments = HashMap::from([(String::from("output"), SegmentInfo::from((2, 3)))]);
+    let expected_builtin_segments = HashMap::from([(BuiltinName::output, SegmentInfo::from((2, 3)))]);
     assert_eq!(pie_metadata.builtin_segments, expected_builtin_segments);
     assert_eq!(pie_metadata.program_segment, SegmentInfo::from((0, 12)));
     assert_eq!(pie_metadata.execution_segment, SegmentInfo::from((1, 7)));
@@ -29,13 +31,13 @@ fn pie_metadata_ok(setup_pie: CairoPie) {
 fn pie_additional_data_ok(setup_pie: CairoPie) {
     let additional_data = setup_pie.additional_data;
 
-    let expected_additional_data = HashMap::from([(
-        OUTPUT_BUILTIN_NAME.to_string(),
+    let expected_additional_data = CairoPieAdditionalData(HashMap::from([(
+        BuiltinName::output,
         BuiltinAdditionalData::Output(OutputBuiltinAdditionalData {
             pages: HashMap::new(),
             attributes: HashMap::new(),
         }),
-    )]);
+    )]));
 
     assert_eq!(additional_data, expected_additional_data);
     let additional_data_s = serde_json::to_value(&additional_data).unwrap();
@@ -49,7 +51,7 @@ fn pie_execution_resources_ok(setup_pie: CairoPie) {
     let expected_execution_resources = ExecutionResources {
         n_steps: 8,
         n_memory_holes: 0,
-        builtin_instance_counter: HashMap::from([(OUTPUT_BUILTIN_NAME.to_string(), 3)]),
+        builtin_instance_counter: HashMap::from([(BuiltinName::output, 3)]),
     };
     assert_eq!(execution_resources, expected_execution_resources);
 


### PR DESCRIPTION
Addressed the following breaking changes:
* Layout names should now use the `LayoutName` enum
* Builtin names should now use the `BuiltinName` enum
* Addition on &Relocatable now returns a Result.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes
- [ ] no
