### PR TITLE
Fix: use set_storage_at instead of storage_view when inserting block hash

### DIFF
--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use blockifier::block_context::BlockContext;
 use blockifier::execution::contract_class::ContractClass::{V0, V1};
 use blockifier::state::cached_state::CachedState;
-use blockifier::state::state_api::StateReader;
+use blockifier::state::state_api::{State as _, StateReader};
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::contracts::FeatureContract::{
     AccountWithLongValidate, AccountWithoutValidations, Empty, FaultyAccount, SecurityTests, TestContract, ERC20,
@@ -156,9 +156,7 @@ pub fn test_state(
 
     let block_hash_contract_address = ContractAddress::try_from(stark_felt!(BLOCK_HASH_CONTRACT_ADDRESS)).unwrap();
 
-    let storage_view = &mut state.state.storage_view;
-
-    storage_view.insert((block_hash_contract_address, block_number), block_hash);
+    state.set_storage_at(block_hash_contract_address, block_number, block_hash).unwrap();
 
     state
 }

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,7 +41,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"DiffAssertValues"#), "{}", err_log);
+    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
 }
 
 #[rstest]
@@ -72,7 +72,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"DiffAssertValues"#), "{}", err_log);
+    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
 }
 
 #[rstest]
@@ -144,5 +144,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"DiffAssertValues"#), "{}", err_log);
+    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
 }


### PR DESCRIPTION
Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
