### PR TITLE
Fix: use UpdateTree vs TreeUpdate consistently with vars::scopes::NODE

### DIFF
--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -22,7 +22,7 @@ use crate::hints::types::{skip_verification_if_configured, Preimage};
 use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, CommitmentInfo, StorageLeaf};
-use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, TreeUpdate};
+use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, UpdateTree};
 use crate::utils::get_constant;
 
 fn assert_tree_height_eq_merkle_height(tree_height: Felt252, merkle_height: Felt252) -> Result<(), HintError> {
@@ -278,7 +278,8 @@ pub fn decode_node_hint(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let node: TreeUpdate<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
+    let node: UpdateTree<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
+    let node = node.ok_or(HintError::AssertionFailed("'node' should not be None".to_string().into_boxed_str()))?;
     let DecodedNode { left_child, right_child, case } = decode_node(&node)?;
     exec_scopes.insert_value(vars::scopes::LEFT_CHILD, left_child.clone());
     exec_scopes.insert_value(vars::scopes::RIGHT_CHILD, right_child.clone());

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,7 +41,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
+    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
 }
 
 #[rstest]
@@ -72,7 +72,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
+    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
 }
 
 #[rstest]
@@ -144,5 +144,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
+    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
 }


### PR DESCRIPTION
Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
