### PR TITLE
Fix: multiple issues related to the state update hints

### DIFF
--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -248,6 +248,7 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
 
     exec_scopes.insert_value(vars::scopes::LEFT_CHILD, left_child.clone());
     exec_scopes.insert_value(vars::scopes::RIGHT_CHILD, right_child.clone());
+    exec_scopes.insert_value(vars::scopes::CASE, case.clone());
 
     let node_preimage =
         preimage.get(&ids_node).ok_or(HintError::CustomHint("Node preimage not found".to_string().into_boxed_str()))?;

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
 use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
-    get_integer_from_var_name, get_ptr_from_var_name, get_relocatable_from_var_name, insert_value_from_var_name,
-    insert_value_into_ap,
+    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name, insert_value_into_ap,
 };
 use cairo_vm::hint_processor::hint_processor_definition::HintReference;
 use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
@@ -256,7 +255,7 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
     let right_hash = node_preimage[1];
 
     // Fill non deterministic hashes.
-    let hash_ptr = get_relocatable_from_var_name(vars::ids::CURRENT_HASH, vm, ids_data, ap_tracking)?;
+    let hash_ptr = get_ptr_from_var_name(vars::ids::CURRENT_HASH, vm, ids_data, ap_tracking)?;
     // memory[hash_ptr + ids.HashBuiltin.x] = left_hash
     vm.insert_value((hash_ptr + HashBuiltin::x_offset())?, left_hash)?;
     // memory[hash_ptr + ids.HashBuiltin.y] = right_hash

--- a/src/hints/state.rs
+++ b/src/hints/state.rs
@@ -22,7 +22,7 @@ use crate::hints::types::{skip_verification_if_configured, Preimage};
 use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, CommitmentInfo, StorageLeaf};
-use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, TreeUpdate};
+use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, UpdateTree};
 use crate::utils::get_constant;
 
 fn assert_tree_height_eq_merkle_height(tree_height: Felt252, merkle_height: Felt252) -> Result<(), HintError> {
@@ -278,7 +278,8 @@ pub fn decode_node_hint(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let node: TreeUpdate<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
+    let node: UpdateTree<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
+    let node = node.ok_or(HintError::AssertionFailed("'node' should not be None".to_string().into_boxed_str()))?;
     let DecodedNode { left_child, right_child, case } = decode_node(&node)?;
     exec_scopes.insert_value(vars::scopes::LEFT_CHILD, left_child.clone());
     exec_scopes.insert_value(vars::scopes::RIGHT_CHILD, right_child.clone());

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,7 +41,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"IdentifierNotRelocatable(("edge""#), "{}", err_log);
+    assert!(err_log.contains(r#"Could not find commitment info for contract 1073742336"#), "{}", err_log);
 }
 
 #[rstest]
@@ -72,7 +72,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"IdentifierNotRelocatable(("edge""#), "{}", err_log);
+    assert!(err_log.contains(r#"Could not find commitment info for contract 1073743616"#), "{}", err_log);
 }
 
 #[rstest]
@@ -144,5 +144,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"IdentifierNotRelocatable(("edge""#), "{}", err_log);
+    assert!(err_log.contains(r#"Could not find commitment info for contract 3221225984"#), "{}", err_log);
 }

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,7 +41,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
+    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
 }
 
 #[rstest]
@@ -72,7 +72,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
+    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
 }
 
 #[rstest]
@@ -144,5 +144,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"VariableNotInScopeError("node")"#), "{}", err_log);
+    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
 }

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,7 +41,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
+    assert!(err_log.contains(r#"IdentifierNotRelocatable(("edge""#), "{}", err_log);
 }
 
 #[rstest]
@@ -72,7 +72,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
+    assert!(err_log.contains(r#"IdentifierNotRelocatable(("edge""#), "{}", err_log);
 }
 
 #[rstest]
@@ -144,5 +144,5 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"InconsistentMemory"#), "{}", err_log);
+    assert!(err_log.contains(r#"IdentifierNotRelocatable(("edge""#), "{}", err_log);
 }


### PR DESCRIPTION
This PR allows to reach the end of one iteration of the state update loop. The integration tests now fail on a missing contract in the commitment info.

Fixed the following issues (one issue per commit):
1. Wrong type used for the `node` variable
2. The `case` variable must be set in the scope in one of the preimage hints
3. Two instances of misuse of `get_ptr` vs `get_relocatable`.


Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
