### PR TITLE
Implement cairo1 deploy syscall

### DIFF
--- a/src/execution/helper.rs
+++ b/src/execution/helper.rs
@@ -132,7 +132,7 @@ impl ExecutionHelperWrapper {
             .iter()
             .filter_map(|call| {
                 if matches!(call.call.entry_point_type, EntryPointType::Constructor) {
-                    Some(Felt252::from_bytes_be_slice(call.call.caller_address.0.key().bytes()))
+                    Some(Felt252::from_bytes_be_slice(call.call.storage_address.0.key().bytes()))
                 } else {
                     None
                 }

--- a/src/execution/syscall_handler.rs
+++ b/src/execution/syscall_handler.rs
@@ -8,12 +8,13 @@ use cairo_vm::vm::vm_core::VirtualMachine;
 
 use super::helper::ExecutionHelperWrapper;
 use crate::execution::constants::{
-    CALL_CONTRACT_GAS_COST, EMIT_EVENT_GAS_COST, GET_BLOCK_HASH_GAS_COST, GET_EXECUTION_INFO_GAS_COST,
+    CALL_CONTRACT_GAS_COST, DEPLOY_GAS_COST, EMIT_EVENT_GAS_COST, GET_BLOCK_HASH_GAS_COST, GET_EXECUTION_INFO_GAS_COST,
     SEND_MESSAGE_TO_L1_GAS_COST, STORAGE_READ_GAS_COST, STORAGE_WRITE_GAS_COST,
 };
 use crate::execution::syscall_utils::{execute_syscall, felt_from_ptr, SyscallSelector};
 use crate::execution::syscalls::{
-    call_contract, emit_event, get_block_hash, get_execution_info, send_message_to_l1, storage_read, storage_write,
+    call_contract, deploy, emit_event, get_block_hash, get_execution_info, send_message_to_l1, storage_read,
+    storage_write,
 };
 
 /// DeprecatedSyscallHandlerimplementation for execution of system calls in the StarkNet OS
@@ -75,6 +76,7 @@ impl OsSyscallHandlerWrapper {
             SyscallSelector::CallContract => {
                 execute_syscall(syscall_handler_syscall_ptr, vm, ehw, call_contract, CALL_CONTRACT_GAS_COST)
             }
+            SyscallSelector::Deploy => execute_syscall(syscall_handler_syscall_ptr, vm, ehw, deploy, DEPLOY_GAS_COST),
             SyscallSelector::EmitEvent => {
                 execute_syscall(syscall_handler_syscall_ptr, vm, ehw, emit_event, EMIT_EVENT_GAS_COST)
             }

--- a/src/execution/syscall_utils.rs
+++ b/src/execution/syscall_utils.rs
@@ -292,7 +292,7 @@ pub struct SingleSegmentResponse {
     pub segment: ReadOnlySegment,
 }
 
-fn write_segment(vm: &mut VirtualMachine, ptr: &mut Relocatable, segment: ReadOnlySegment) -> SyscallResult<()> {
+pub fn write_segment(vm: &mut VirtualMachine, ptr: &mut Relocatable, segment: ReadOnlySegment) -> SyscallResult<()> {
     write_maybe_relocatable(vm, ptr, segment.start_ptr)?;
     let segment_end_ptr = (segment.start_ptr + segment.length)?;
     write_maybe_relocatable(vm, ptr, segment_end_ptr)?;

--- a/src/execution/syscalls.rs
+++ b/src/execution/syscalls.rs
@@ -101,10 +101,10 @@ pub fn deploy(
     exec_wrapper: &mut ExecutionHelperWrapper,
     remaining_gas: &mut u64,
 ) -> SyscallResult<DeployResponse> {
-
     let execution_helper = &mut exec_wrapper.execution_helper.as_ref().borrow_mut();
 
-    let result = execution_helper.result_iter
+    let result = execution_helper
+        .result_iter
         .next()
         .ok_or(SyscallExecutionError::InternalError(Box::from("No result left in the result iterator.")))?;
 
@@ -121,11 +121,9 @@ pub fn deploy(
 
     let constructor_retdata = ReadOnlySegment { start_ptr, length: retdata.len() };
 
-    let contract_address = execution_helper.deployed_contracts_iter.next().ok_or(
-        HintError::SyscallError("n: No more deployed contracts available to replay".to_string().into_boxed_str()),
-    )?;
-
-    println!("new contract_address: {}", contract_address);
+    let contract_address = execution_helper.deployed_contracts_iter.next().ok_or(HintError::SyscallError(
+        "n: No more deployed contracts available to replay".to_string().into_boxed_str(),
+    ))?;
 
     Ok(DeployResponse { contract_address, constructor_retdata })
 }

--- a/src/execution/syscalls.rs
+++ b/src/execution/syscalls.rs
@@ -63,12 +63,7 @@ pub fn call_contract(
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct DeployRequest {
-    // pub class_hash: Felt252,
-    // pub contract_address_salt: Felt252,
-    // pub constructor_calldata: Vec<Felt252>,
-    // pub deploy_from_zero: bool,
-}
+pub struct DeployRequest {}
 
 impl SyscallRequest for DeployRequest {
     fn read(_vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<DeployRequest> {

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -432,8 +432,6 @@ pub fn initialize_state_changes(
         vm.insert_value((change_base + 1)?, storage_commitment_base)?;
         vm.insert_value((change_base + 2)?, contract_state.nonce)?;
 
-        println!("adding addr: {} to state changes dict", addr);
-
         state_dict.insert(MaybeRelocatable::from(addr), MaybeRelocatable::from(change_base));
     }
 

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -432,6 +432,8 @@ pub fn initialize_state_changes(
         vm.insert_value((change_base + 1)?, storage_commitment_base)?;
         vm.insert_value((change_base + 2)?, contract_state.nonce)?;
 
+        println!("adding addr: {} to state changes dict", addr);
+
         state_dict.insert(MaybeRelocatable::from(addr), MaybeRelocatable::from(change_base));
     }
 

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -138,7 +138,6 @@ pub fn build_starknet_storage(blockifier_state: &mut CachedState<DictStateReader
 
     let mut ffc = FactFetchingContext::new(DictStorage::default());
     for contract_address in all_contracts {
-        println!("Creating initial state for contract {}", contract_address);
         let initial_contract_storage = initial_contract_storage_map.get(contract_address).unwrap_or(&empty_state);
         let final_contract_storage =
             final_contract_storage_map.get(contract_address).expect("any contract should appear in final storage");

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -196,7 +196,7 @@ pub fn os_hints(
     let mut class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252> = Default::default();
 
     for c in contracts.keys() {
-        let address = ContractAddress::try_from(StarkHash::try_from(c.to_bytes_be()).unwrap()).unwrap();
+        let address = ContractAddress::try_from(StarkHash::new(c.to_bytes_be()).unwrap()).unwrap();
         let class_hash = blockifier_state.get_class_hash_at(address).unwrap();
         let blockifier_class = blockifier_state.get_compiled_contract_class(class_hash).unwrap();
         match blockifier_class {

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use blockifier::block_context::BlockContext;
 use blockifier::execution::contract_class::ContractClass::{V0, V1};
@@ -167,13 +167,23 @@ pub fn os_hints(
     transactions: Vec<InternalTransaction>,
     tx_execution_infos: Vec<TransactionExecutionInfo>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper) {
-    let mut contracts: HashMap<Felt252, ContractState> = blockifier_state
-        .state
-        .address_to_class_hash
-        .keys()
+    let state_diff = blockifier_state.to_state_diff();
+    let deployed_addresses = state_diff.address_to_class_hash.keys().cloned().collect::<HashSet<_>>();
+
+    let initial_addresses = blockifier_state.state.address_to_class_hash.keys().cloned().collect::<HashSet<_>>();
+
+    let addresses = initial_addresses.union(&deployed_addresses);
+
+    let mut contracts: HashMap<Felt252, ContractState> = addresses
+        .into_iter()
         .map(|address| {
+            let contract_hash = if deployed_addresses.contains(address) {
+                Felt252::ZERO
+            } else {
+                to_felt252(&blockifier_state.get_class_hash_at(*address).unwrap().0)
+            };
             let contract_state = ContractState {
-                contract_hash: to_felt252(&blockifier_state.state.address_to_class_hash.get(address).unwrap().0),
+                contract_hash,
                 storage_commitment_tree: StorageCommitment::default(), // TODO
                 nonce: 0.into(),                                       // TODO
             };
@@ -186,11 +196,8 @@ pub fn os_hints(
     let mut class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252> = Default::default();
 
     for c in contracts.keys() {
-        let class_hash = blockifier_state
-            .get_class_hash_at(
-                ContractAddress::try_from(StarkHash::try_from(c.to_hex_string().as_str()).unwrap()).unwrap(),
-            )
-            .unwrap();
+        let address = ContractAddress::try_from(StarkHash::try_from(c.to_bytes_be()).unwrap()).unwrap();
+        let class_hash = blockifier_state.get_class_hash_at(address).unwrap();
         let blockifier_class = blockifier_state.get_compiled_contract_class(class_hash).unwrap();
         match blockifier_class {
             V0(_) => {

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -1,6 +1,7 @@
 use blockifier::block_context::BlockContext;
 use blockifier::invoke_tx_args;
-use blockifier::test_utils::{create_calldata, NonceManager};
+use blockifier::test_utils::contracts::FeatureContract;
+use blockifier::test_utils::{create_calldata, CairoVersion, NonceManager};
 use blockifier::transaction::test_utils;
 use blockifier::transaction::test_utils::max_fee;
 use rstest::rstest;
@@ -125,7 +126,6 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     });
 
     // test_send_message_to_l1
-
     let to_address = stark_felt!(1234_u16);
     let payload = vec![stark_felt!(2019_u16), stark_felt!(2020_u16), stark_felt!(2021_u16)];
     let entrypoint_args = &[vec![to_address, stark_felt!(payload.len() as u64)], payload].concat();
@@ -138,7 +138,37 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![test_emit_event_tx, test_storage_read_write_tx, test_get_block_hash_tx, test_send_message_to_l1_tx];
+    // test_deploy
+
+    // class_hash: ClassHash,
+    // contract_address_salt: felt252,
+    // calldata: Array::<felt252>,
+    // deploy_from_zero: bool,
+
+    let entrypoint_args = &[
+        FeatureContract::TestContract(CairoVersion::Cairo1).get_class_hash().0, // class hash
+        stark_felt!(123_u8),                                                  // contract_address_salt
+        stark_felt!(2_u8),                                                    // calldata length
+        stark_felt!(3_u8),                                                    // calldata: arg1
+        stark_felt!(3_u8),                                                    // calldata: arg2
+        stark_felt!(0_u8),                                                    // deploy_from_zero
+    ];
+
+    let test_deploy_tx = test_utils::account_invoke_tx(invoke_tx_args! {
+        max_fee,
+        sender_address: sender_address,
+        calldata: create_calldata(contract_address, "test_deploy", entrypoint_args),
+        version: tx_version,
+        nonce: nonce_manager.next(sender_address),
+    });
+
+    let txs = vec![
+        test_emit_event_tx,
+        test_storage_read_write_tx,
+        test_get_block_hash_tx,
+        test_send_message_to_l1_tx,
+        test_deploy_tx,
+    ];
 
     let r = execute_txs_and_run_os(state, block_context, txs);
 

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -145,13 +145,14 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     // calldata: Array::<felt252>,
     // deploy_from_zero: bool,
 
+    let test_contract_class_hash = FeatureContract::TestContract(CairoVersion::Cairo1).get_class_hash().0;
     let entrypoint_args = &[
-        FeatureContract::TestContract(CairoVersion::Cairo1).get_class_hash().0, // class hash
-        stark_felt!(123_u8),                                                  // contract_address_salt
-        stark_felt!(2_u8),                                                    // calldata length
-        stark_felt!(3_u8),                                                    // calldata: arg1
-        stark_felt!(3_u8),                                                    // calldata: arg2
-        stark_felt!(0_u8),                                                    // deploy_from_zero
+        test_contract_class_hash, // class hash
+        stark_felt!(255_u8),      // contract_address_salt
+        stark_felt!(2_u8),        // calldata length
+        stark_felt!(3_u8),        // calldata: arg1
+        stark_felt!(3_u8),        // calldata: arg2
+        stark_felt!(0_u8),        // deploy_from_zero
     ];
 
     let test_deploy_tx = test_utils::account_invoke_tx(invoke_tx_args! {

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -139,12 +139,6 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
     });
 
     // test_deploy
-
-    // class_hash: ClassHash,
-    // contract_address_salt: felt252,
-    // calldata: Array::<felt252>,
-    // deploy_from_zero: bool,
-
     let test_contract_class_hash = FeatureContract::TestContract(CairoVersion::Cairo1).get_class_hash().0;
     let entrypoint_args = &[
         test_contract_class_hash, // class hash


### PR DESCRIPTION
Implements cairo1 deploy syscall. It is interesting because it uses state_diff to prepare os_hints data.