### PR TITLE
Move block number mapping update out of `test_state`

### DIFF
--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -4,27 +4,26 @@ use blockifier::block_context::BlockContext;
 use blockifier::execution::contract_class::ContractClass::{V0, V1};
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::{State as _, StateReader};
+use blockifier::test_utils::CairoVersion;
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::contracts::FeatureContract::{
-    AccountWithLongValidate, AccountWithoutValidations, Empty, FaultyAccount, SecurityTests, TestContract, ERC20,
+    AccountWithLongValidate, AccountWithoutValidations, Empty, ERC20, FaultyAccount, SecurityTests, TestContract,
 };
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier::test_utils::initial_test_state::fund_account;
-use blockifier::test_utils::CairoVersion;
 use blockifier::transaction::objects::{FeeType, TransactionExecutionInfo};
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_vm::Felt252;
-use snos::config::{StarknetGeneralConfig, StarknetOsConfig, BLOCK_HASH_CONTRACT_ADDRESS, STORED_BLOCK_HASH_BUFFER};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
+use starknet_api::hash::StarkHash;
+use starknet_crypto::FieldElement;
+
+use snos::config::{StarknetGeneralConfig, StarknetOsConfig, STORED_BLOCK_HASH_BUFFER};
 use snos::execution::helper::ExecutionHelperWrapper;
 use snos::io::input::{ContractState, StarknetOsInput, StorageCommitment};
 use snos::io::InternalTransaction;
 use snos::storage::storage_utils::build_starknet_storage;
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
-use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::stark_felt;
-use starknet_api::state::StorageKey;
-use starknet_crypto::FieldElement;
 
 use crate::common::transaction_utils::to_felt252;
 
@@ -149,15 +148,6 @@ pub fn test_state(
             }
         }
     }
-
-    let upper_bound_block_number = block_context.block_number.0 - STORED_BLOCK_HASH_BUFFER;
-    let block_number = StorageKey::from(upper_bound_block_number);
-    let block_hash = stark_felt!(66_u64);
-
-    let block_hash_contract_address = ContractAddress::try_from(stark_felt!(BLOCK_HASH_CONTRACT_ADDRESS)).unwrap();
-
-    state.set_storage_at(block_hash_contract_address, block_number, block_hash).unwrap();
-
     state
 }
 

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -4,26 +4,25 @@ use blockifier::block_context::BlockContext;
 use blockifier::execution::contract_class::ContractClass::{V0, V1};
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::{State as _, StateReader};
-use blockifier::test_utils::CairoVersion;
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::contracts::FeatureContract::{
-    AccountWithLongValidate, AccountWithoutValidations, Empty, ERC20, FaultyAccount, SecurityTests, TestContract,
+    AccountWithLongValidate, AccountWithoutValidations, Empty, FaultyAccount, SecurityTests, TestContract, ERC20,
 };
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier::test_utils::initial_test_state::fund_account;
+use blockifier::test_utils::CairoVersion;
 use blockifier::transaction::objects::{FeeType, TransactionExecutionInfo};
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_vm::Felt252;
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
-use starknet_api::hash::StarkHash;
-use starknet_crypto::FieldElement;
-
 use snos::config::{StarknetGeneralConfig, StarknetOsConfig, STORED_BLOCK_HASH_BUFFER};
 use snos::execution::helper::ExecutionHelperWrapper;
 use snos::io::input::{ContractState, StarknetOsInput, StorageCommitment};
 use snos::io::InternalTransaction;
 use snos::storage::storage_utils::build_starknet_storage;
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
+use starknet_api::hash::StarkHash;
+use starknet_crypto::FieldElement;
 
 use crate::common::transaction_utils::to_felt252;
 

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -8,7 +8,6 @@ use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError::VmException;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::Felt252;
-use starknet_api::core::ContractAddress;
 use snos::config::{BLOCK_HASH_CONTRACT_ADDRESS, SN_GOERLI, STORED_BLOCK_HASH_BUFFER};
 use snos::error::SnOsError;
 use snos::error::SnOsError::Runner;
@@ -16,6 +15,7 @@ use snos::execution::helper::ExecutionHelperWrapper;
 use snos::io::input::StarknetOsInput;
 use snos::io::InternalTransaction;
 use snos::{config, run_os};
+use starknet_api::core::ContractAddress;
 use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
 use starknet_api::state::StorageKey;
@@ -141,7 +141,6 @@ fn execute_txs(
     block_context: &BlockContext,
     txs: Vec<AccountTransaction>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper) {
-
     let upper_bound_block_number = block_context.block_number.0 - STORED_BLOCK_HASH_BUFFER;
     let block_number = StorageKey::from(upper_bound_block_number);
     let block_hash = stark_felt!(66_u64);

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -1,5 +1,6 @@
 use blockifier::block_context::BlockContext;
 use blockifier::state::cached_state::CachedState;
+use blockifier::state::state_api::State;
 use blockifier::test_utils::dict_state_reader::DictStateReader;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::account_transaction::AccountTransaction::{Declare, DeployAccount, Invoke};
@@ -7,7 +8,8 @@ use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError::VmException;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::Felt252;
-use snos::config::SN_GOERLI;
+use starknet_api::core::ContractAddress;
+use snos::config::{BLOCK_HASH_CONTRACT_ADDRESS, SN_GOERLI, STORED_BLOCK_HASH_BUFFER};
 use snos::error::SnOsError;
 use snos::error::SnOsError::Runner;
 use snos::execution::helper::ExecutionHelperWrapper;
@@ -15,6 +17,8 @@ use snos::io::input::StarknetOsInput;
 use snos::io::InternalTransaction;
 use snos::{config, run_os};
 use starknet_api::hash::StarkFelt;
+use starknet_api::stark_felt;
+use starknet_api::state::StorageKey;
 use starknet_crypto::{pedersen_hash, FieldElement};
 
 use crate::common::block_utils::os_hints;
@@ -137,6 +141,15 @@ fn execute_txs(
     block_context: &BlockContext,
     txs: Vec<AccountTransaction>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper) {
+
+    let upper_bound_block_number = block_context.block_number.0 - STORED_BLOCK_HASH_BUFFER;
+    let block_number = StorageKey::from(upper_bound_block_number);
+    let block_hash = stark_felt!(66_u64);
+
+    let block_hash_contract_address = ContractAddress::try_from(stark_felt!(BLOCK_HASH_CONTRACT_ADDRESS)).unwrap();
+
+    state.set_storage_at(block_hash_contract_address, block_number, block_hash).unwrap();
+
     let internal_txs: Vec<_> = txs.iter().map(to_internal_tx).collect();
     let execution_infos =
         txs.into_iter().map(|tx| tx.execute(&mut state, block_context, true, true).unwrap()).collect();


### PR DESCRIPTION
Moves block number mapping update to `execute_txs` out of `test_state`.
