### PR TITLE
Internal: move `prefix()` from Serializable to new trait

### DIFF
--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -12,7 +12,7 @@ use crate::starkware_utils::commitment_tree::binary_fact_tree::{
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::{PatriciaTree, EMPTY_NODE_HASH};
-use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
 use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
 use crate::utils::{Felt252Num, Felt252Str};
 
@@ -46,10 +46,13 @@ where
 
 impl DbObject for StorageLeaf {}
 
-impl Serializable for StorageLeaf {
+impl SerializationPrefix for StorageLeaf {
     fn prefix() -> Vec<u8> {
         "starknet_storage_leaf".as_bytes().to_vec()
     }
+}
+
+impl Serializable for StorageLeaf {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
         Ok(self.value.to_bytes_be().to_vec())
     }

--- a/src/starkware_utils/commitment_tree/base_types.rs
+++ b/src/starkware_utils/commitment_tree/base_types.rs
@@ -7,7 +7,7 @@ use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
-use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
 use crate::storage::storage::HASH_BYTES;
 
 pub type TreeIndex = BigUint;
@@ -20,6 +20,8 @@ impl Display for NodePath {
         self.0.fmt(f)
     }
 }
+
+impl SerializationPrefix for NodePath {}
 
 impl Serializable for NodePath {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
@@ -50,6 +52,8 @@ impl Display for Length {
         self.0.fmt(f)
     }
 }
+
+impl SerializationPrefix for Length {}
 
 impl Serializable for Length {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {

--- a/src/starkware_utils/commitment_tree/patricia_tree/nodes.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/nodes.rs
@@ -5,7 +5,7 @@ use crate::starkware_utils::commitment_tree::base_types::{Length, NodePath};
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
-use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
 use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage, HASH_BYTES};
 
 const PATRICIA_NODE_PREFIX: &[u8] = "patricia_node".as_bytes();
@@ -39,10 +39,13 @@ where
 
 impl DbObject for EmptyNodeFact {}
 
-impl Serializable for EmptyNodeFact {
+impl SerializationPrefix for EmptyNodeFact {
     fn prefix() -> Vec<u8> {
         PATRICIA_NODE_PREFIX.to_vec()
     }
+}
+
+impl Serializable for EmptyNodeFact {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
         Ok("".as_bytes().to_vec())
     }
@@ -106,10 +109,13 @@ where
 
 impl DbObject for BinaryNodeFact {}
 
-impl Serializable for BinaryNodeFact {
+impl SerializationPrefix for BinaryNodeFact {
     fn prefix() -> Vec<u8> {
         PATRICIA_NODE_PREFIX.to_vec()
     }
+}
+
+impl Serializable for BinaryNodeFact {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
         let serialized = self.left_node.iter().cloned().chain(self.right_node.iter().cloned()).collect();
         Ok(serialized)
@@ -179,11 +185,13 @@ where
 
 impl DbObject for EdgeNodeFact {}
 
-impl Serializable for EdgeNodeFact {
+impl SerializationPrefix for EdgeNodeFact {
     fn prefix() -> Vec<u8> {
         PATRICIA_NODE_PREFIX.to_vec()
     }
+}
 
+impl Serializable for EdgeNodeFact {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
         serialize_edge(&self.bottom_node, self.edge_path.clone(), self.edge_length)
     }
@@ -234,11 +242,13 @@ pub enum PatriciaNodeFact {
     Edge(EdgeNodeFact),
 }
 
-impl Serializable for PatriciaNodeFact {
+impl SerializationPrefix for PatriciaNodeFact {
     fn prefix() -> Vec<u8> {
         PATRICIA_NODE_PREFIX.to_vec()
     }
+}
 
+impl Serializable for PatriciaNodeFact {
     fn serialize(&self) -> Result<Vec<u8>, SerializeError> {
         match self {
             Self::Empty(empty) => empty.serialize(),

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -13,7 +13,7 @@ use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
-use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializeError};
+use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
 use crate::storage::dict_storage::DictStorage;
 use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
 use crate::utils::felt_api2vm;
@@ -32,6 +32,8 @@ impl SimpleLeafFact {
         Self::new(Felt252::ZERO)
     }
 }
+
+impl SerializationPrefix for SimpleLeafFact {}
 
 impl<S, H> Fact<S, H> for SimpleLeafFact
 where


### PR DESCRIPTION
Problem: we wish to implement `prefix()` for JSON-serializable structs, but this then requires to duplicate the implementation of the `serialize()` and `deserialize()` methods as there is no specialization in Rust.

Solution: move `prefix()` to the new `SerializationPrefix` trait.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
