### PR TITLE
Fix: improve handling of sync -> async calls in hints

### DIFF
--- a/src/execution/helper.rs
+++ b/src/execution/helper.rs
@@ -1,5 +1,5 @@
-use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::vec::IntoIter;
 
@@ -11,6 +11,7 @@ use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::Felt252;
 use starknet_api::deprecated_contract_class::EntryPointType;
+use tokio::sync::RwLock;
 
 use crate::config::STORED_BLOCK_HASH_BUFFER;
 use crate::crypto::pedersen::PedersenHash;
@@ -54,10 +55,10 @@ pub struct ExecutionHelper {
 }
 
 /// ExecutionHelper is wrapped in Rc<RefCell<_>> in order
-/// to clone the refrence when entering and exiting vm scopes  
+/// to clone the refrence when entering and exiting vm scopes
 #[derive(Clone, Debug)]
 pub struct ExecutionHelperWrapper {
-    pub execution_helper: Rc<RefCell<ExecutionHelper>>,
+    pub execution_helper: Rc<RwLock<ExecutionHelper>>,
 }
 
 impl ExecutionHelperWrapper {
@@ -73,7 +74,7 @@ impl ExecutionHelperWrapper {
             block_context.block_number.0.checked_sub(STORED_BLOCK_HASH_BUFFER).map(|_| block_context.clone());
 
         Self {
-            execution_helper: Rc::new(RefCell::new(ExecutionHelper {
+            execution_helper: Rc::new(RwLock::new(ExecutionHelper {
                 _prev_block_context: prev_block_context,
                 tx_execution_info_iter: tx_execution_infos.into_iter(),
                 tx_execution_info: None,
@@ -90,38 +91,38 @@ impl ExecutionHelperWrapper {
         }
     }
 
-    pub fn get_old_block_number_and_hash(&self) -> Result<(Felt252, Felt252), HintError> {
-        let eh_ref = self.execution_helper.as_ref().borrow();
+    pub async fn get_old_block_number_and_hash(&self) -> Result<(Felt252, Felt252), HintError> {
+        let eh_ref = self.execution_helper.read().await;
         eh_ref.old_block_number_and_hash.ok_or(HintError::AssertionFailed(
             format!("Block number is probably < {STORED_BLOCK_HASH_BUFFER}.").into_boxed_str(),
         ))
     }
 
-    pub fn start_tx(&self, tx_info_ptr: Option<Relocatable>) {
-        let mut eh_ref = self.execution_helper.as_ref().borrow_mut();
+    pub async fn start_tx(&self, tx_info_ptr: Option<Relocatable>) {
+        let mut eh_ref = self.execution_helper.write().await;
         assert!(eh_ref.tx_info_ptr.is_none());
         eh_ref.tx_info_ptr = tx_info_ptr;
         assert!(eh_ref.tx_execution_info.is_none());
         eh_ref.tx_execution_info = eh_ref.tx_execution_info_iter.next();
         eh_ref.call_iter = eh_ref.tx_execution_info.as_ref().unwrap().gen_call_iterator();
     }
-    pub fn end_tx(&self) {
-        let mut eh_ref = self.execution_helper.as_ref().borrow_mut();
+    pub async fn end_tx(&self) {
+        let mut eh_ref = self.execution_helper.write().await;
         assert!(eh_ref.call_iter.clone().peekable().peek().is_none());
         eh_ref.tx_info_ptr = None;
         assert!(eh_ref.tx_execution_info.is_some());
         eh_ref.tx_execution_info = None;
     }
-    pub fn skip_tx(&self) {
-        self.start_tx(None);
-        self.end_tx()
+    pub async fn skip_tx(&self) {
+        self.start_tx(None).await;
+        self.end_tx().await
     }
-    pub fn enter_call(&self, execution_info_ptr: Option<Relocatable>) {
-        let mut eh_ref = self.execution_helper.as_ref().borrow_mut();
+    pub async fn enter_call(&self, execution_info_ptr: Option<Relocatable>) {
+        let mut eh_ref = self.execution_helper.write().await;
         assert!(eh_ref.call_execution_info_ptr.is_none());
         eh_ref.call_execution_info_ptr = execution_info_ptr;
 
-        assert_iterators_exhausted(&eh_ref);
+        assert_iterators_exhausted(eh_ref.deref());
 
         assert!(eh_ref.call_info.is_none());
         let call_info = eh_ref.call_iter.next().unwrap();
@@ -162,34 +163,36 @@ impl ExecutionHelperWrapper {
 
         eh_ref.call_info = Some(call_info);
     }
-    pub fn exit_call(&mut self) {
-        let mut eh_ref = self.execution_helper.as_ref().borrow_mut();
+    pub async fn exit_call(&mut self) {
+        let mut eh_ref = self.execution_helper.write().await;
         eh_ref.call_execution_info_ptr = None;
         assert_iterators_exhausted(&eh_ref);
         assert!(eh_ref.call_info.is_some());
         eh_ref.call_info = None;
     }
-    pub fn skip_call(&mut self) {
-        self.enter_call(None);
-        self.exit_call();
+    pub async fn skip_call(&mut self) {
+        self.enter_call(None).await;
+        self.exit_call().await;
     }
 
-    pub fn read_storage_for_address(&mut self, address: Felt252, key: Felt252) -> Result<Felt252, StorageError> {
-        let storage_by_address = &mut self.execution_helper.as_ref().borrow_mut().storage_by_address;
+    pub async fn read_storage_for_address(&mut self, address: Felt252, key: Felt252) -> Result<Felt252, StorageError> {
+        let mut eh_ref = self.execution_helper.write().await;
+        let storage_by_address = &mut eh_ref.storage_by_address;
         if let Some(storage) = storage_by_address.get_mut(&address) {
-            return storage.read(key).ok_or(StorageError::ContentNotFound);
+            return storage.read(key).await.ok_or(StorageError::ContentNotFound);
         }
 
         Err(StorageError::ContentNotFound)
     }
 
-    pub fn write_storage_for_address(
+    pub async fn write_storage_for_address(
         &mut self,
         address: Felt252,
         key: Felt252,
         value: Felt252,
     ) -> Result<(), StorageError> {
-        let storage_by_address = &mut self.execution_helper.as_ref().borrow_mut().storage_by_address;
+        let mut eh_ref = self.execution_helper.write().await;
+        let storage_by_address = &mut eh_ref.storage_by_address;
         if let Some(storage) = storage_by_address.get_mut(&address) {
             storage.write(key.to_biguint(), value);
             Ok(())
@@ -200,7 +203,8 @@ impl ExecutionHelperWrapper {
 
     #[allow(clippy::await_holding_refcell_ref)]
     pub async fn compute_storage_commitments(&self) -> Result<HashMap<Felt252, CommitmentInfo>, CommitmentInfoError> {
-        let storage_by_address = &mut self.execution_helper.as_ref().borrow_mut().storage_by_address;
+        let mut eh_ref = self.execution_helper.write().await;
+        let storage_by_address = &mut eh_ref.storage_by_address;
 
         let mut commitments = HashMap::new();
         for (key, storage) in storage_by_address.iter_mut() {
@@ -212,7 +216,7 @@ impl ExecutionHelperWrapper {
     }
 }
 
-fn assert_iterators_exhausted(eh_ref: &RefMut<'_, ExecutionHelper>) {
+fn assert_iterators_exhausted(eh_ref: &ExecutionHelper) {
     assert!(eh_ref.deployed_contracts_iter.clone().peekable().peek().is_none());
     assert!(eh_ref.result_iter.clone().peekable().peek().is_none());
     assert!(eh_ref.execute_code_read_iter.clone().peekable().peek().is_none());

--- a/src/hints/execute_transactions.rs
+++ b/src/hints/execute_transactions.rs
@@ -12,12 +12,29 @@ use indoc::indoc;
 use crate::cairo_types::structs::ExecutionContext;
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::hints::vars;
+use crate::utils::execute_coroutine;
 
 pub const START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = indoc! {r#"
     execution_helper.start_tx(
            tx_info_ptr=ids.validate_declare_execution_context.deprecated_tx_info.address_
     )"#
 };
+pub async fn start_tx_validate_declare_execution_context_async(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+) -> Result<(), HintError> {
+    let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_context_ptr =
+        get_relocatable_from_var_name(vars::ids::VALIDATE_DECLARE_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
+    let deprecated_tx_info_ptr = (execution_context_ptr + ExecutionContext::deprecated_tx_info_offset())?;
+
+    execution_helper.start_tx(Some(deprecated_tx_info_ptr)).await;
+
+    Ok(())
+}
+
 pub fn start_tx_validate_declare_execution_context(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -25,12 +42,5 @@ pub fn start_tx_validate_declare_execution_context(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
-    let execution_context_ptr =
-        get_relocatable_from_var_name(vars::ids::VALIDATE_DECLARE_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
-    let deprecated_tx_info_ptr = (execution_context_ptr + ExecutionContext::deprecated_tx_info_offset())?;
-
-    execution_helper.start_tx(Some(deprecated_tx_info_ptr));
-
-    Ok(())
+    execute_coroutine(start_tx_validate_declare_execution_context_async(vm, exec_scopes, ids_data, ap_tracking))?
 }

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -40,7 +40,7 @@ use crate::io::InternalTransaction;
 use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::base_types::DescentMap;
 use crate::starkware_utils::commitment_tree::update_tree::{DecodeNodeCase, TreeUpdate, UpdateTree};
-use crate::utils::get_constant;
+use crate::utils::{execute_coroutine, get_constant};
 
 pub const LOAD_NEXT_TX: &str = indoc! {r#"
         tx = next(transactions)
@@ -435,28 +435,13 @@ pub fn enter_syscall_scopes(
     Ok(())
 }
 
-// pub const START_DEPLOY_TX: &str = indoc! {r#"
-//     execution_helper.start_tx(
-//         tx_info_ptr=ids.constructor_execution_context.deprecated_tx_info.address_
-//     )"#
-// };
-pub fn start_deploy_tx(
-    vm: &mut VirtualMachine,
-    exec_scopes: &mut ExecutionScopes,
-    ids_data: &HashMap<String, HintReference>,
-    ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
-    let constructor_execution_context =
-        get_relocatable_from_var_name("constructor_execution_context", vm, ids_data, ap_tracking)?;
-    let deprecated_tx_info_ptr = (constructor_execution_context + 5usize).unwrap();
-
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper").unwrap();
-    execution_helper.start_tx(Some(deprecated_tx_info_ptr));
+pub const END_TX: &str = "execution_helper.end_tx()";
+pub async fn end_tx_async(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
+    execution_helper.end_tx().await;
     Ok(())
 }
 
-pub const END_TX: &str = "execution_helper.end_tx()";
 pub fn end_tx(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -464,15 +449,27 @@ pub fn end_tx(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
-    execution_helper.end_tx();
-    Ok(())
+    execute_coroutine(end_tx_async(exec_scopes))?
 }
 
 pub const ENTER_CALL: &str = indoc! {r#"
     execution_helper.enter_call(
         execution_info_ptr=ids.execution_context.execution_info.address_)"#
 };
+pub async fn enter_call_async(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+) -> Result<(), HintError> {
+    let execution_info_ptr =
+        vm.get_relocatable((get_ptr_from_var_name("execution_context", vm, ids_data, ap_tracking)? + 4i32).unwrap())?;
+
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
+    execution_helper.enter_call(Some(execution_info_ptr)).await;
+    Ok(())
+}
+
 pub fn enter_call(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -480,15 +477,16 @@ pub fn enter_call(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_info_ptr =
-        vm.get_relocatable((get_ptr_from_var_name("execution_context", vm, ids_data, ap_tracking)? + 4i32).unwrap())?;
-
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
-    execution_helper.enter_call(Some(execution_info_ptr));
-    Ok(())
+    execute_coroutine(enter_call_async(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const EXIT_CALL: &str = "execution_helper.exit_call()";
+pub async fn exit_call_async(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
+    execution_helper.exit_call().await;
+    Ok(())
+}
+
 pub fn exit_call(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -496,9 +494,7 @@ pub fn exit_call(
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
-    execution_helper.exit_call();
-    Ok(())
+    execute_coroutine(exit_call_async(exec_scopes))?
 }
 
 pub const CONTRACT_ADDRESS: &str = indoc! {r#"
@@ -866,18 +862,27 @@ pub const START_TX: &str = indoc! {r#"
     tx_info_ptr = ids.tx_execution_context.deprecated_tx_info.address_
     execution_helper.start_tx(tx_info_ptr=tx_info_ptr)"#
 };
-pub fn start_tx(
-    _vm: &mut VirtualMachine,
+pub async fn start_tx_async(
+    vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
-    _ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
+    ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let tx_execution_context = get_relocatable_from_var_name("tx_execution_context", _vm, ids_data, _ap_tracking)?;
+    let tx_execution_context = get_relocatable_from_var_name("tx_execution_context", vm, ids_data, ap_tracking)?;
     let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>("execution_helper")?;
     let tx_info_ptr = (tx_execution_context + ExecutionContext::deprecated_tx_info_offset())?;
-    execution_helper.start_tx(Some(tx_info_ptr));
+    execution_helper.start_tx(Some(tx_info_ptr)).await;
     Ok(())
+}
+
+pub fn start_tx(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(start_tx_async(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const IS_REVERTED: &str = "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.is_reverted)";
@@ -925,12 +930,11 @@ pub const CHECK_EXECUTION: &str = indoc! {r#"
 
 // implement check_execution according to the pythonic version given in the CHECK_EXECUTION const
 // above
-pub fn check_execution(
+pub async fn check_execution_async(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let return_values_ptr = get_ptr_from_var_name(ENTRY_POINT_RETURN_VALUES, vm, ids_data, ap_tracking)?;
 
@@ -967,10 +971,20 @@ pub fn check_execution(
 
     let syscall_ptr_end = vm.get_relocatable((return_values_ptr + EntryPointReturnValues::syscall_ptr_offset())?)?;
     let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper>(SYSCALL_HANDLER)?;
-    syscall_handler.validate_and_discard_syscall_ptr(syscall_ptr_end)?;
-    execution_helper.exit_call();
+    execute_coroutine(syscall_handler.validate_and_discard_syscall_ptr(syscall_ptr_end))??;
+    execution_helper.exit_call().await;
 
     Ok(())
+}
+
+pub fn check_execution(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(check_execution_async(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 fn assert_memory_ranges_equal(
@@ -1187,7 +1201,7 @@ pub fn check_response_return_value(
     Ok(())
 }
 
-fn cache_contract_storage(
+async fn cache_contract_storage(
     key: Felt252,
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -1198,7 +1212,7 @@ fn cache_contract_storage(
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
 
-    let value = execution_helper.read_storage_for_address(contract_address, key).map_err(|_| {
+    let value = execution_helper.read_storage_for_address(contract_address, key).await.map_err(|_| {
         HintError::CustomHint(format!("No storage found for contract {}", contract_address).into_boxed_str())
     })?;
 
@@ -1457,12 +1471,11 @@ pub const WRITE_SYSCALL_RESULT_DEPRECATED: &str = indoc! {r#"
 	ids.new_state_entry = segments.add()"#
 };
 
-pub fn write_syscall_result_deprecated(
+pub async fn write_syscall_result_deprecated_async(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
@@ -1472,16 +1485,19 @@ pub fn write_syscall_result_deprecated(
     // ids.prev_value = storage.read(key=ids.syscall_ptr.address)
     let storage_write_address = vm.get_integer((syscall_ptr + StorageWrite::address_offset())?)?.into_owned();
     let prev_value =
-        execution_helper.read_storage_for_address(contract_address, storage_write_address).map_err(|_| {
+        execution_helper.read_storage_for_address(contract_address, storage_write_address).await.map_err(|_| {
             HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str())
         })?;
     insert_value_from_var_name(vars::ids::PREV_VALUE, prev_value, vm, ids_data, ap_tracking)?;
 
     // storage.write(key=ids.syscall_ptr.address, value=ids.syscall_ptr.value)
     let storage_write_value = vm.get_integer((syscall_ptr + StorageWrite::value_offset())?)?.into_owned();
-    execution_helper.write_storage_for_address(contract_address, storage_write_address, storage_write_value).map_err(
-        |_| HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str()),
-    )?;
+    execution_helper
+        .write_storage_for_address(contract_address, storage_write_address, storage_write_value)
+        .await
+        .map_err(|_| {
+            HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str())
+        })?;
 
     let contract_state_changes = get_ptr_from_var_name(vars::ids::CONTRACT_STATE_CHANGES, vm, ids_data, ap_tracking)?;
     get_state_entry_and_set_new_state_entry(
@@ -1495,6 +1511,17 @@ pub fn write_syscall_result_deprecated(
 
     Ok(())
 }
+
+pub fn write_syscall_result_deprecated(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(write_syscall_result_deprecated_async(vm, exec_scopes, ids_data, ap_tracking))?
+}
+
 pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
     storage = execution_helper.storage_by_address[ids.contract_address]
     ids.prev_value = storage.read(key=ids.request.key)
@@ -1505,12 +1532,11 @@ pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
     ids.new_state_entry = segments.add()"#
 };
 
-pub fn write_syscall_result(
+pub async fn write_syscall_result_async(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
@@ -1522,13 +1548,16 @@ pub fn write_syscall_result(
 
     // ids.prev_value = storage.read(key=ids.request.key)
     let prev_value =
-        execution_helper.read_storage_for_address(contract_address, storage_write_address).unwrap_or_default();
+        execution_helper.read_storage_for_address(contract_address, storage_write_address).await.unwrap_or_default();
     insert_value_from_var_name(vars::ids::PREV_VALUE, prev_value, vm, ids_data, ap_tracking)?;
 
     // storage.write(key=ids.request.key, value=ids.request.value)
-    execution_helper.write_storage_for_address(contract_address, storage_write_address, storage_write_value).map_err(
-        |_| HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str()),
-    )?;
+    execution_helper
+        .write_storage_for_address(contract_address, storage_write_address, storage_write_value)
+        .await
+        .map_err(|_| {
+            HintError::CustomHint(format!("Storage not found for contract {}", contract_address).into_boxed_str())
+        })?;
 
     let contract_state_changes = get_ptr_from_var_name(vars::ids::CONTRACT_STATE_CHANGES, vm, ids_data, ap_tracking)?;
     get_state_entry_and_set_new_state_entry(
@@ -1541,6 +1570,16 @@ pub fn write_syscall_result(
     )?;
 
     Ok(())
+}
+
+pub fn write_syscall_result(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(write_syscall_result_async(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const GEN_CLASS_HASH_ARG: &str = indoc! {r#"
@@ -1603,7 +1642,7 @@ pub const WRITE_OLD_BLOCK_TO_STORAGE: &str = indoc! {r#"
 	storage.write(key=ids.old_block_number, value=ids.old_block_hash)"#
 };
 
-pub fn write_old_block_to_storage(
+pub async fn write_old_block_to_storage_async(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1619,6 +1658,7 @@ pub fn write_old_block_to_storage(
     println!("writing block number: {} -> block hash: {}", old_block_number, old_block_hash);
     execution_helper
         .write_storage_for_address(*block_hash_contract_address, old_block_number, old_block_hash)
+        .await
         .map_err(|_| {
             HintError::CustomHint(
                 format!("Storage not found for contract {}", block_hash_contract_address).into_boxed_str(),
@@ -1626,6 +1666,16 @@ pub fn write_old_block_to_storage(
         })?;
 
     Ok(())
+}
+
+pub fn write_old_block_to_storage(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(write_old_block_to_storage_async(vm, exec_scopes, ids_data, ap_tracking, constants))?
 }
 
 pub const CACHE_CONTRACT_STORAGE_REQUEST_KEY: &str = indoc! {r#"
@@ -1645,7 +1695,7 @@ pub fn cache_contract_storage_request_key(
     let request_ptr = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
     let key = vm.get_integer((request_ptr + new_syscalls::StorageReadRequest::key_offset())?)?.into_owned();
 
-    cache_contract_storage(key, vm, exec_scopes, ids_data, ap_tracking)
+    execute_coroutine(cache_contract_storage(key, vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS: &str = indoc! {r#"
@@ -1668,7 +1718,7 @@ pub fn cache_contract_storage_syscall_request_address(
     let offset = StorageRead::request_offset() + StorageReadRequest::address_offset();
     let key = vm.get_integer((syscall_ptr + offset)?)?.into_owned();
 
-    cache_contract_storage(key, vm, exec_scopes, ids_data, ap_tracking)
+    execute_coroutine(cache_contract_storage(key, vm, exec_scopes, ids_data, ap_tracking))?
 }
 pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	(
@@ -1681,15 +1731,14 @@ pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	ids.old_block_hash = old_block_hash"#
 };
 
-pub fn get_old_block_number_and_hash(
+pub async fn get_old_block_number_and_hash_async(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-    _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
-    let (old_block_number, old_block_hash) = execution_helper.get_old_block_number_and_hash()?;
+    let (old_block_number, old_block_hash) = execution_helper.get_old_block_number_and_hash().await?;
 
     let ids_old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
     if old_block_number != ids_old_block_number {
@@ -1703,6 +1752,16 @@ pub fn get_old_block_number_and_hash(
     insert_value_from_var_name(vars::ids::OLD_BLOCK_HASH, old_block_hash, vm, ids_data, ap_tracking)?;
 
     Ok(())
+}
+
+pub fn get_old_block_number_and_hash(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    ids_data: &HashMap<String, HintReference>,
+    ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    execute_coroutine(get_old_block_number_and_hash_async(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const FETCH_RESULT: &str = indoc! {r#"
@@ -1760,7 +1819,7 @@ mod tests {
     use crate::config::STORED_BLOCK_HASH_BUFFER;
     use crate::crypto::pedersen::PedersenHash;
     use crate::execution::helper::ContractStorageMap;
-    use crate::starknet::starknet_storage::{execute_coroutine_threadsafe, OsSingleStarknetStorage, StorageLeaf};
+    use crate::starknet::starknet_storage::{OsSingleStarknetStorage, StorageLeaf};
     use crate::starkware_utils::commitment_tree::base_types::Height;
     use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
     use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
@@ -1770,7 +1829,7 @@ mod tests {
 
     #[fixture]
     pub fn block_context() -> BlockContext {
-        BlockContext { block_number: BlockNumber(0), ..BlockContext::create_for_account_testing() }
+        BlockContext { block_number: BlockNumber(10), ..BlockContext::create_for_account_testing() }
     }
 
     #[fixture]
@@ -1792,26 +1851,22 @@ mod tests {
     }
 
     #[fixture]
-    fn execution_helper_with_storage(
+    async fn execution_helper_with_storage(
         execution_helper: ExecutionHelperWrapper,
         contract_address: Felt252,
     ) -> ExecutionHelperWrapper {
         let storage = DictStorage::default();
         let mut ffc = FactFetchingContext::<_, PedersenHash>::new(storage);
 
-        // Run async functions in a dedicated runtime to keep the test functions sync.
-        // Otherwise, we run into "cannot spawn a runtime from another runtime" issues.
-        let os_single_starknet_storage = execute_coroutine_threadsafe(async {
-            let mut tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
-            let modifications = vec![(BigUint::from(42u32), StorageLeaf::new(Felt252::from(8000)))];
-            let mut facts = None;
-            let tree = tree.update(&mut ffc, modifications, &mut facts).await.unwrap();
-            // We pass the same tree as previous and updated tree as this is enough for the tests.
-            OsSingleStarknetStorage::new(tree.clone(), tree, &vec![], ffc).await.unwrap()
-        });
+        let mut tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
+        let modifications = vec![(BigUint::from(42u32), StorageLeaf::new(Felt252::from(8000)))];
+        let mut facts = None;
+        let tree = tree.update(&mut ffc, modifications, &mut facts).await.unwrap();
+        // We pass the same tree as previous and updated tree as this is enough for the tests.
+        let os_single_starknet_storage = OsSingleStarknetStorage::new(tree.clone(), tree, &vec![], ffc).await.unwrap();
 
         {
-            let storage_by_address = &mut execution_helper.execution_helper.as_ref().borrow_mut().storage_by_address;
+            let storage_by_address = &mut execution_helper.execution_helper.write().await.storage_by_address;
             storage_by_address.insert(contract_address, os_single_starknet_storage);
         }
 
@@ -1819,11 +1874,14 @@ mod tests {
     }
 
     #[rstest]
-    #[ignore] // TODO: reenable when the stoge in execution helper is fixed
-    fn test_cache_contract_storage_request_key(
-        execution_helper_with_storage: ExecutionHelperWrapper,
+    #[tokio::test]
+    #[ignore] // TODO: fix
+    async fn test_cache_contract_storage_request_key(
+        #[future] execution_helper_with_storage: ExecutionHelperWrapper,
         contract_address: Felt252,
     ) {
+        let execution_helper_with_storage = execution_helper_with_storage.await;
+
         let mut vm = VirtualMachine::new(false);
         vm.add_memory_segment();
         vm.add_memory_segment();
@@ -1905,8 +1963,14 @@ mod tests {
     }
 
     #[rstest]
-    #[ignore] // TODO: reenable when the stoge in execution helper is fixed
-    fn test_write_syscall_result(mut execution_helper_with_storage: ExecutionHelperWrapper, contract_address: Felt252) {
+    #[tokio::test]
+    #[ignore] // TODO: fix
+    async fn test_write_syscall_result(
+        #[future] execution_helper_with_storage: ExecutionHelperWrapper,
+        contract_address: Felt252,
+    ) {
+        let mut execution_helper_with_storage = execution_helper_with_storage.await;
+
         let mut vm = VirtualMachine::new(false);
         vm.add_memory_segment();
         vm.add_memory_segment();
@@ -1963,7 +2027,7 @@ mod tests {
         // Check that the storage was updated
         let prev_value = get_integer_from_var_name(vars::ids::PREV_VALUE, &mut vm, &ids_data, &ap_tracking).unwrap();
         assert_eq!(prev_value, Felt252::from(8000));
-        let stored_value = execution_helper_with_storage.read_storage_for_address(contract_address, key).unwrap();
+        let stored_value = execution_helper_with_storage.read_storage_for_address(contract_address, key).await.unwrap();
         assert_eq!(stored_value, Felt252::from(777));
 
         // Check the state entry

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -150,7 +150,7 @@ pub fn test_state(
     state
 }
 
-pub fn os_hints(
+pub async fn os_hints(
     block_context: &BlockContext,
     mut blockifier_state: CachedState<DictStateReader>,
     transactions: Vec<InternalTransaction>,
@@ -258,7 +258,7 @@ pub fn os_hints(
     };
 
     // Convert the Blockifier storage into an OS-compatible one
-    let contract_storage_map = build_starknet_storage(&mut blockifier_state);
+    let contract_storage_map = build_starknet_storage(&mut blockifier_state).await;
 
     let execution_helper = ExecutionHelperWrapper::new(
         contract_storage_map,

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -136,7 +136,7 @@ pub fn to_internal_tx(account_tx: &AccountTransaction) -> InternalTransaction {
     };
 }
 
-fn execute_txs(
+async fn execute_txs(
     mut state: CachedState<DictStateReader>,
     block_context: &BlockContext,
     txs: Vec<AccountTransaction>,
@@ -152,15 +152,15 @@ fn execute_txs(
     let internal_txs: Vec<_> = txs.iter().map(to_internal_tx).collect();
     let execution_infos =
         txs.into_iter().map(|tx| tx.execute(&mut state, block_context, true, true).unwrap()).collect();
-    os_hints(&block_context, state, internal_txs, execution_infos)
+    os_hints(&block_context, state, internal_txs, execution_infos).await
 }
 
-pub fn execute_txs_and_run_os(
+pub async fn execute_txs_and_run_os(
     state: CachedState<DictStateReader>,
     block_context: BlockContext,
     txs: Vec<AccountTransaction>,
 ) -> Result<CairoPie, SnOsError> {
-    let (os_input, execution_helper) = execute_txs(state, &block_context, txs);
+    let (os_input, execution_helper) = execute_txs(state, &block_context, txs).await;
 
     let layout = config::default_layout();
     let result = run_os(config::DEFAULT_COMPILED_OS.to_string(), layout, os_input, block_context, execution_helper);

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -15,7 +15,9 @@ use crate::common::state::{initial_state, InitialState};
 use crate::common::transaction_utils::execute_txs_and_run_os;
 
 #[rstest]
-fn return_result_cairo0_account(block_context: BlockContext, initial_state: InitialState, max_fee: Fee) {
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn return_result_cairo0_account(block_context: BlockContext, initial_state: InitialState, max_fee: Fee) {
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
 
@@ -38,7 +40,7 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
         nonce: nonce_manager.next(sender_address),
     });
 
-    let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
+    let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]).await;
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
@@ -46,7 +48,9 @@ fn return_result_cairo0_account(block_context: BlockContext, initial_state: Init
 }
 
 #[rstest]
-fn return_result_cairo1_account(block_context: BlockContext, initial_state: InitialState, max_fee: Fee) {
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn return_result_cairo1_account(block_context: BlockContext, initial_state: InitialState, max_fee: Fee) {
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
 
@@ -69,7 +73,7 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
         nonce: nonce_manager.next(sender_address),
     });
 
-    let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]);
+    let r = execute_txs_and_run_os(state, block_context, vec![return_result_tx]).await;
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
@@ -77,7 +81,9 @@ fn return_result_cairo1_account(block_context: BlockContext, initial_state: Init
 }
 
 #[rstest]
-fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max_fee: Fee) {
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max_fee: Fee) {
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
 
@@ -165,7 +171,7 @@ fn syscalls_cairo1(block_context: BlockContext, initial_state: InitialState, max
         test_deploy_tx,
     ];
 
-    let r = execute_txs_and_run_os(state, block_context, txs);
+    let r = execute_txs_and_run_os(state, block_context, txs).await;
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);


### PR DESCRIPTION
Problem: we often encounter cases where `execute_coroutine_threadsafe()` causes a "cannot start a runtime from with a runtime" error. These errors are avoided by carefully placing the call. Ultimately, we have a lot of calls to `execute_coroutine_threadsafe()` deep inside the code and this is brittle.

Solution: acknowledge that most of the codebase needs to be async and handle sync -> async transitions from the highest level possible. Also, we now implement `execute_coroutine()` (we dropped the meaningless "threadsafe" suffix) to use `task::block_in_place` to run the coroutine on the calling thread. This is fine because we always end up here from the main thread running the OS.

Note that async tests must now use the `multi_thread` thread pool to enable using `task::block_in_place`, otherwise the OS panics.

Replaced all the RefCell instances by tokio::sync::RwLock instances as we need to hold references across await boundaries and clippy was (rightfully) having none of that.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
