### PR TITLE
Feature: logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,6 +1883,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -3436,6 +3465,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-type-derive",
  "cairo-vm 1.0.0-rc1",
+ "env_logger",
  "futures",
  "futures-util",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ cairo-lang-filesystem = { version = "~2.5.4" }
 cairo-lang-semantic = { version = "~2.5.4" }
 cairo-lang-sierra = { version = "~2.5.4" }
 cairo-lang-syntax = { version = "~2.5.4" }
+env_logger = "0.11.3"
 
 [dev-dependencies]
 getset = "0.1.2"

--- a/src/execution/deprecated_syscall_handler.rs
+++ b/src/execution/deprecated_syscall_handler.rs
@@ -69,22 +69,22 @@ impl DeprecatedOsSyscallHandlerWrapper {
     }
     #[allow(unused)]
     pub fn delegate_call(&self, syscall_ptr: Relocatable) {
-        println!("delegate_call (TODO): {}", syscall_ptr);
+        log::error!("delegate_call (TODO): {}", syscall_ptr);
     }
     pub fn delegate_l1_handler(&self, syscall_ptr: Relocatable) {
-        println!("delegate_l1_handler (TODO): {}", syscall_ptr);
+        log::error!("delegate_l1_handler (TODO): {}", syscall_ptr);
     }
     pub fn deploy(&self, syscall_ptr: Relocatable) {
-        println!("deploy (TODO): {}", syscall_ptr);
+        log::error!("deploy (TODO): {}", syscall_ptr);
     }
     pub fn emit_event(&self, syscall_ptr: Relocatable) {
-        println!("emit_event (TODO): {}", syscall_ptr);
+        log::error!("emit_event (TODO): {}", syscall_ptr);
     }
     pub fn get_block_number(&self, syscall_ptr: Relocatable) {
-        println!("get_block_number (TODO): {}", syscall_ptr);
+        log::error!("get_block_number (TODO): {}", syscall_ptr);
     }
     pub fn get_block_timestamp(&self, syscall_ptr: Relocatable) {
-        println!("get_block_timestamp (TODO): {}", syscall_ptr);
+        log::error!("get_block_timestamp (TODO): {}", syscall_ptr);
     }
     pub async fn get_caller_address(&self, syscall_ptr: Relocatable, vm: &mut VirtualMachine) {
         let sys_hand = self.deprecated_syscall_handler.read().await;
@@ -96,33 +96,33 @@ impl DeprecatedOsSyscallHandlerWrapper {
         // TODO: create proper struct for this (similar to GetCallerAddress and friends)
         // TODO: abstract this similar to pythonic _write_syscall_response()
 
-        println!("get_caller_address() syscall, syscall_ptr = {}, caller_address = {}", syscall_ptr, caller_address);
+        log::debug!("get_caller_address() syscall, syscall_ptr = {}, caller_address = {}", syscall_ptr, caller_address);
 
         vm.insert_value((syscall_ptr + 1usize).unwrap(), caller_address).unwrap();
     }
     pub fn get_contract_address(&self, syscall_ptr: Relocatable) {
-        println!("get_contract_address (TODO): {}", syscall_ptr);
+        log::error!("get_contract_address (TODO): {}", syscall_ptr);
     }
     pub fn get_sequencer_address(&self, syscall_ptr: Relocatable) {
-        println!("get_sequencer_address (TODO): {}", syscall_ptr);
+        log::error!("get_sequencer_address (TODO): {}", syscall_ptr);
     }
     pub fn get_tx_info(&self, syscall_ptr: Relocatable) {
-        println!("get_tx_info (TODO): {}", syscall_ptr);
+        log::error!("get_tx_info (TODO): {}", syscall_ptr);
     }
     pub fn get_tx_signature(&self, syscall_ptr: Relocatable) {
-        println!("get_tx_signature (TODO): {}", syscall_ptr);
+        log::error!("get_tx_signature (TODO): {}", syscall_ptr);
     }
     pub fn library_call(&self, syscall_ptr: Relocatable) {
-        println!("library_call (TODO): {}", syscall_ptr);
+        log::error!("library_call (TODO): {}", syscall_ptr);
     }
     pub fn library_call_l1_handler(&self, syscall_ptr: Relocatable) {
-        println!("library_call (TODO): {}", syscall_ptr);
+        log::error!("library_call (TODO): {}", syscall_ptr);
     }
     pub fn replace_class(&self, syscall_ptr: Relocatable) {
-        println!("replace_class (TODO): {}", syscall_ptr);
+        log::error!("replace_class (TODO): {}", syscall_ptr);
     }
     pub fn send_message_to_l1(&self, syscall_ptr: Relocatable) {
-        println!("send_message_to_l1 (TODO): {}", syscall_ptr);
+        log::error!("send_message_to_l1 (TODO): {}", syscall_ptr);
     }
     pub async fn storage_read(&self, syscall_ptr: Relocatable, vm: &mut VirtualMachine) -> Result<(), HintError> {
         let sys_hand = self.deprecated_syscall_handler.write().await;

--- a/src/hints/block_context.rs
+++ b/src/hints/block_context.rs
@@ -216,7 +216,7 @@ pub fn fee_token_address(
 ) -> Result<(), HintError> {
     let os_input = exec_scopes.get::<StarknetOsInput>("os_input")?;
     let fee_token_address = *os_input.general_config.starknet_os_config.fee_token_address.0.key();
-    println!("fee_token_address: {}", fee_token_address);
+    log::debug!("fee_token_address: {}", fee_token_address);
     insert_value_into_ap(vm, felt_api2vm(fee_token_address))
 }
 
@@ -231,7 +231,7 @@ pub fn deprecated_fee_token_address(
 ) -> Result<(), HintError> {
     let os_input = exec_scopes.get::<StarknetOsInput>("os_input")?;
     let deprecated_fee_token_address = *os_input.general_config.starknet_os_config.deprecated_fee_token_address.0.key();
-    println!("deprecated_fee_token_address: {}", deprecated_fee_token_address);
+    log::debug!("deprecated_fee_token_address: {}", deprecated_fee_token_address);
     insert_value_into_ap(vm, felt_api2vm(deprecated_fee_token_address))
 }
 

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -74,7 +74,7 @@ pub fn load_next_tx(
     let mut transactions = exec_scopes.get::<IntoIter<InternalTransaction>>("transactions")?;
     // Safe to unwrap because the remaining number of txs is checked in the cairo code.
     let tx = transactions.next().unwrap();
-    println!("executing {} on: {}", tx.r#type, tx.sender_address.unwrap());
+    log::debug!("executing {} on: {}", tx.r#type, tx.sender_address.unwrap());
     exec_scopes.insert_value("transactions", transactions);
     exec_scopes.insert_value("tx", tx.clone());
     insert_value_from_var_name("tx_type", Felt252::from_bytes_be_slice(tx.r#type.as_bytes()), vm, ids_data, ap_tracking)
@@ -358,7 +358,7 @@ pub fn check_is_deprecated(
     let execution_into_ptr = vm.get_relocatable((execution_context + 4usize)?).unwrap();
     let contract_address = vm.get_integer((execution_into_ptr + 3usize)?).unwrap();
 
-    println!(
+    log::debug!(
         "about to call contract_address: {}, class_hash: {}, is_deprecated: {}",
         contract_address,
         class_hash,
@@ -948,11 +948,11 @@ pub async fn check_execution_async(
         let execution_context = get_relocatable_from_var_name(EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
         let class_hash = vm.get_integer((execution_context + ExecutionContext::class_hash_offset())?)?;
         let selector = vm.get_integer((execution_context + ExecutionContext::execution_info_offset())?)?;
-        println!("Invalid return value in execute_entry_point:");
-        println!("  Class hash: {}", class_hash.to_hex_string());
-        println!("  Selector: {}", selector.to_hex_string());
-        println!("  Size: {}", retdata_size);
-        println!("  Error (at most 100 elements): {:?}", error);
+        log::debug!("Invalid return value in execute_entry_point:");
+        log::debug!("  Class hash: {}", class_hash.to_hex_string());
+        log::debug!("  Selector: {}", selector.to_hex_string());
+        log::debug!("  Size: {}", retdata_size);
+        log::debug!("  Error (at most 100 elements): {:?}", error);
     }
 
     let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(EXECUTION_HELPER)?;
@@ -1130,7 +1130,7 @@ pub fn log_enter_syscall(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let selector = get_integer_from_var_name(SELECTOR, _vm, ids_data, _ap_tracking)?;
-    println!("entering syscall: {:?} execution", SyscallSelector::try_from(selector)?);
+    log::debug!("entering syscall: {:?} execution", SyscallSelector::try_from(selector)?);
     // TODO: implement logging
     Ok(())
 }
@@ -1196,7 +1196,7 @@ pub fn check_response_return_value(
     assert_eq!(expected, actual, "Return value mismatch; expected={:?}, actual={:?}", expected, actual);
 
     // relocate_segment(src_ptr=response.retdata_start, dest_ptr=retdata);
-    println!("response_retdata_start: {}, retdata: {}", response_retdata_start, retdata);
+    log::debug!("response_retdata_start: {}, retdata: {}", response_retdata_start, retdata);
 
     Ok(())
 }
@@ -1655,7 +1655,7 @@ pub async fn write_old_block_to_storage_async(
     let old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
     let old_block_hash = get_integer_from_var_name(vars::ids::OLD_BLOCK_HASH, vm, ids_data, ap_tracking)?;
 
-    println!("writing block number: {} -> block hash: {}", old_block_number, old_block_hash);
+    log::debug!("writing block number: {} -> block hash: {}", old_block_number, old_block_hash);
     execution_helper
         .write_storage_for_address(*block_hash_contract_address, old_block_number, old_block_hash)
         .await
@@ -1795,9 +1795,9 @@ pub fn fetch_result(
     // This hint is weird, there is absolutely no need to fetch 100 elements to do this.
     // Nonetheless, we implement it 1-1 with the Python version.
     if n_elements != 1 || result[0] != Some(Cow::Borrowed(&MaybeRelocatable::Int(*validated))) {
-        println!("Invalid return value from __validate__:");
-        println!("  Size: {n_elements}");
-        println!("  Result (at most 100 elements): {:?}", result);
+        log::info!("Invalid return value from __validate__:");
+        log::info!("  Size: {n_elements}");
+        log::info!("  Result (at most 100 elements): {:?}", result);
     }
 
     Ok(())

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -500,8 +500,8 @@ pub fn breakpoint(
     let pc = vm.get_pc();
     let fp = vm.get_fp();
     let ap = vm.get_ap();
-    println!("-----------BEGIN BREAKPOINT-----------");
-    println!("\tpc -> {}, fp -> {}, ap -> {}", pc, fp, ap);
+    log::debug!("-----------BEGIN BREAKPOINT-----------");
+    log::debug!("\tpc -> {}, fp -> {}, ap -> {}", pc, fp, ap);
     // println!("\tnum_constants -> {:?}", constants.len());
 
     // print!("\tbuiltins -> ");
@@ -514,7 +514,7 @@ pub fn breakpoint(
     // println!("\tap_tracking -> {ap_tracking:?}");
     // println!("\texec_scops -> {:?}", exec_scopes.get_local_variables().unwrap().keys());
     // println!("\tids -> {:?}", ids_data);
-    println!("-----------END BREAKPOINT-----------");
+    log::debug!("-----------END BREAKPOINT-----------");
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn run_os(
     // Prepare and check expected output.
     let os_output = StarknetOsOutput::from_run(&vm)?;
 
-    println!("output: {:?}", os_output);
+    log::debug!("output: {:?}", os_output);
 
     vm.verify_auto_deductions().map_err(|e| SnOsError::Runner(e.into()))?;
     cairo_runner.read_return_values(&mut vm, false).map_err(|e| SnOsError::Runner(e.into()))?;

--- a/src/starknet/business_logic/utils.rs
+++ b/src/starknet/business_logic/utils.rs
@@ -19,8 +19,6 @@ where
     let contract_class_fact = ContractClassFact { contract_class };
     let compiled_class_fact = CompiledClassFact { compiled_class };
 
-    println!("Writing cairo1 class facts");
-
     let contract_class_hash = contract_class_fact.set_fact(ffc).await?;
     let compiled_class_hash = compiled_class_fact.set_fact(ffc).await?;
 

--- a/src/starkware_utils/commitment_tree/binary_fact_tree.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree.rs
@@ -41,7 +41,7 @@ where
     ) -> Result<HashMap<TreeIndex, LF>, TreeError>;
 
     async fn get_leaf(&self, ffc: &mut FactFetchingContext<S, H>, index: TreeIndex) -> Result<Option<LF>, TreeError> {
-        println!("Getting fact with hash value {:x}", index);
+        log::debug!("Getting fact with hash value {:x}", index);
         let mut facts = None;
         let leaves = self.get_leaves(ffc, vec![index.clone()].as_ref(), &mut facts).await?;
         Ok(leaves.get(&index).cloned())

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
@@ -74,7 +74,6 @@ where
     let mut height = Felt252::ZERO;
 
     while layer.len() > 1 {
-        let values: Vec<_> = layer.iter().map(|node| node.bottom.to_biguint()).collect();
         for (i, x) in layer.iter().enumerate() {
             node_at_path.insert((height, Felt252::from(i)), x.clone());
         }

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_utils.rs
@@ -75,7 +75,6 @@ where
 
     while layer.len() > 1 {
         let values: Vec<_> = layer.iter().map(|node| node.bottom.to_biguint()).collect();
-        println!("{:?}", values);
         for (i, x) in layer.iter().enumerate() {
             node_at_path.insert((height, Felt252::from(i)), x.clone());
         }

--- a/src/storage/dict_storage.rs
+++ b/src/storage/dict_storage.rs
@@ -21,7 +21,6 @@ impl Storage for DictStorage {
         &self,
         key: K,
     ) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send {
-        // println!("looking up key {:x?}", key.as_ref());
         let result = Ok(self.db.get(key.as_ref()).cloned());
         async move { result }.boxed()
     }

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -196,10 +196,6 @@ pub trait Fact<S: Storage, H: HashFunctionType>: DbObject {
 
     async fn set_fact(&self, ffc: &mut FactFetchingContext<S, H>) -> Result<Vec<u8>, StorageError> {
         let hash_val = self.hash();
-        if hash_val.clone().into_iter().fold(0u64, |acc, x| acc + x as u64) == 0 {
-            println!("something hashed to 0!");
-        }
-        println!("Writing fact with hash value {:02x?}", hash_val);
         let mut storage = ffc.acquire_storage().await;
         self.set(storage.deref_mut(), &hash_val).await?;
 

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -86,7 +86,7 @@ pub async fn test_state(
     let erc20_class_hash_bytes = write_deprecated_compiled_class_fact(erc20_class.clone(), &mut ffc).await?;
     let erc20_class_hash = ClassHash(stark_felt_from_bytes(erc20_class_hash_bytes));
 
-    println!("ERC20 class_hash: {:?}", erc20_class_hash);
+    log::debug!("ERC20 class_hash: {:?}", erc20_class_hash);
 
     state.class_hash_to_class.insert(erc20_class_hash, deprecated_contract_class_api2vm(&erc20_class).unwrap());
     state.class_hash_to_compiled_class_hash.insert(erc20_class_hash, CompiledClassHash(erc20_class_hash.0));
@@ -116,7 +116,7 @@ pub async fn test_state(
         state.class_hash_to_compiled_class_hash.insert(class_hash, CompiledClassHash(class_hash.0));
 
         let address = ContractAddress::from(rand.gen::<u128>());
-        println!("Inserting deprecated class_hash_to_class: {:?} -> {:?}", address, class_hash);
+        log::debug!("Inserting deprecated class_hash_to_class: {:?} -> {:?}", address, class_hash);
         state.address_to_class_hash.insert(address, class_hash);
         deployed_addresses.push(address);
         deployed_deprecated_contract_classes.insert(class_hash, (*contract).clone()); // TODO: remove
@@ -137,7 +137,7 @@ pub async fn test_state(
         state.class_hash_to_compiled_class_hash.insert(class_hash, compiled_class_hash);
 
         let address = ContractAddress::from(rand.gen::<u128>());
-        println!("Inserting non-deprecated class_hash_to_class: {:?} -> {:?}", address, class_hash);
+        log::debug!("Inserting non-deprecated class_hash_to_class: {:?} -> {:?}", address, class_hash);
         state.address_to_class_hash.insert(address, class_hash);
         deployed_addresses.push(address);
 
@@ -245,26 +245,30 @@ pub async fn os_hints(
     contracts
         .insert(Felt252::from(1), ContractState::empty(Height(251), &mut blockifier_state.state.ffc).await.unwrap());
 
-    println!("contracts: {:?}\ndeprecated_compiled_classes: {:?}", contracts.len(), deprecated_compiled_classes.len());
+    log::debug!(
+        "contracts: {:?}\ndeprecated_compiled_classes: {:?}",
+        contracts.len(),
+        deprecated_compiled_classes.len()
+    );
 
-    println!("contracts to class_hash");
+    log::debug!("contracts to class_hash");
     for (a, c) in &contracts {
-        println!("\t{} -> {}", a, BigUint::from_bytes_be(&c.contract_hash));
+        log::debug!("\t{} -> {}", a, BigUint::from_bytes_be(&c.contract_hash));
     }
 
-    println!("deprecated classes");
+    log::debug!("deprecated classes");
     for (c, _) in &deprecated_compiled_classes {
-        println!("\t{}", c);
+        log::debug!("\t{}", c);
     }
 
-    println!("classes");
+    log::debug!("classes");
     for (c, _) in &compiled_classes {
-        println!("\t{}", c);
+        log::debug!("\t{}", c);
     }
 
-    println!("class_hash to compiled_class_hash");
+    log::debug!("class_hash to compiled_class_hash");
     for (ch, cch) in &class_hash_to_compiled_class_hash {
-        println!("\t{} -> {}", ch, cch);
+        log::debug!("\t{} -> {}", ch, cch);
     }
 
     let default_general_config = StarknetGeneralConfig::default();
@@ -291,7 +295,6 @@ pub async fn os_hints(
     let contract_indices: HashSet<TreeIndex> =
         contracts.keys().chain(contract_storage_map.keys()).map(|address| address.to_biguint()).collect();
     let contract_indices: Vec<TreeIndex> = contract_indices.into_iter().collect();
-    println!("Contract indices: {contract_indices:?}");
 
     let _contract_state_commitment_info =
         CommitmentInfo::create_from_expected_updated_tree::<DictStorage, PedersenHash, ContractState>(

--- a/tests/integration/common/blockifier_contracts.rs
+++ b/tests/integration/common/blockifier_contracts.rs
@@ -12,7 +12,7 @@ pub fn get_deprecated_feature_contract_class(contract_name: &str) -> DeprecatedC
     let filename = format!("{contract_name}_compiled.json");
     let contract_rel_path =
         Path::new("blockifier_contracts").join("feature_contracts").join("cairo0").join("compiled").join(filename);
-    println!("Getting contract at {:?}", contract_rel_path);
+    log::debug!("Getting contract at {:?}", contract_rel_path);
     get_deprecated_compiled_class(&contract_rel_path)
 }
 
@@ -28,7 +28,7 @@ pub fn get_feature_casm_contract_class(contract_name: &str) -> CasmContractClass
     let filename = format!("{contract_name}.casm.json");
     let contract_rel_path =
         Path::new("blockifier_contracts").join("feature_contracts").join("cairo1").join("compiled").join(filename);
-    println!("Getting contract at {:?}", contract_rel_path);
+    log::debug!("Getting contract at {:?}", contract_rel_path);
     get_compiled_casm_class(&contract_rel_path)
 }
 
@@ -36,6 +36,6 @@ pub fn get_feature_sierra_contract_class(contract_name: &str) -> ContractClass {
     let filename = format!("{contract_name}.sierra");
     let contract_rel_path =
         Path::new("blockifier_contracts").join("feature_contracts").join("cairo1").join("compiled").join(filename);
-    println!("Getting contract at {:?}", contract_rel_path);
+    log::debug!("Getting contract at {:?}", contract_rel_path);
     get_compiled_sierra_class(&contract_rel_path)
 }

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -75,6 +75,7 @@ pub fn load_cairo1_classes(name: &str) -> (&str, CasmContractClass, ContractClas
 }
 
 #[fixture]
+#[once]
 fn init_logging() {
     env_logger::builder()
         .is_test(true)

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -74,9 +74,19 @@ pub fn load_cairo1_classes(name: &str) -> (&str, CasmContractClass, ContractClas
     (name, get_feature_casm_contract_class(name), get_feature_sierra_contract_class(name))
 }
 
+#[fixture]
+fn init_logging() {
+    env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Debug)
+        .format_timestamp(None)
+        .try_init()
+        .expect("Failed to configure env_logger");
+}
+
 /// Fixture to create initial test state in which all test contracts are deployed.
 #[fixture]
-pub async fn initial_state(block_context: BlockContext) -> TestState {
+pub async fn initial_state(block_context: BlockContext, #[from(init_logging)] _logging: ()) -> TestState {
     let ffc = FactFetchingContext::<_, PedersenHash>::new(DictStorage::default());
     let test_state = test_state(
         &block_context,
@@ -101,7 +111,7 @@ pub async fn initial_state(block_context: BlockContext) -> TestState {
 /// Cairo 1 contract if possible.
 
 #[fixture]
-pub async fn initial_state_cairo1(block_context: BlockContext) -> TestState {
+pub async fn initial_state_cairo1(block_context: BlockContext, #[from(init_logging)] _logging: ()) -> TestState {
     let ffc = FactFetchingContext::<_, PedersenHash>::new(DictStorage::default());
     let test_state = test_state(
         &block_context,
@@ -119,7 +129,7 @@ pub async fn initial_state_cairo1(block_context: BlockContext) -> TestState {
 
 /// Initial state for the syscalls test.
 #[fixture]
-pub async fn initial_state_syscalls(block_context: BlockContext) -> TestState {
+pub async fn initial_state_syscalls(block_context: BlockContext, #[from(init_logging)] _logging: ()) -> TestState {
     let ffc = FactFetchingContext::<_, PedersenHash>::new(DictStorage::default());
     let test_state = test_state(
         &block_context,

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -179,11 +179,11 @@ pub async fn execute_txs_and_run_os(
     match &result {
         Err(Runner(VmException(vme))) => {
             if let Some(traceback) = vme.traceback.as_ref() {
-                println!("traceback:\n{}", traceback);
+                log::error!("traceback:\n{}", traceback);
             }
             if let Some(inst_location) = &vme.inst_location {
-                println!("died at: {}:{}", inst_location.input_file.filename, inst_location.start_line);
-                println!("inst_location:\n{:?}", inst_location);
+                log::error!("died at: {}:{}", inst_location.input_file.filename, inst_location.start_line);
+                log::error!("inst_location:\n{:?}", inst_location);
             }
         }
         _ => {}


### PR DESCRIPTION
Use the `log` and `env_logger` crates to display logs instead of `println!`.

Removed a few useless logs.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
