### PR TITLE
Hook up state commitment info to OsInput

### DIFF
--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -296,7 +296,7 @@ pub async fn os_hints(
         contracts.keys().chain(contract_storage_map.keys()).map(|address| address.to_biguint()).collect();
     let contract_indices: Vec<TreeIndex> = contract_indices.into_iter().collect();
 
-    let _contract_state_commitment_info =
+    let contract_state_commitment_info =
         CommitmentInfo::create_from_expected_updated_tree::<DictStorage, PedersenHash, ContractState>(
             previous_state.contract_states.clone(),
             updated_state.contract_states.clone(),
@@ -307,7 +307,7 @@ pub async fn os_hints(
         .expect("Could not create contract state commitment info");
 
     let os_input = StarknetOsInput {
-        contract_state_commitment_info: Default::default(),
+        contract_state_commitment_info,
         contract_class_commitment_info: Default::default(),
         deprecated_compiled_classes,
         compiled_classes: compiled_class_hash_to_compiled_class,

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -48,7 +48,7 @@ async fn return_result_cairo0_account(#[future] initial_state: TestState, block_
 
     // temporarily expect test to break prematurely
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"Tree height (0) does not match Merkle height"#), "{}", err_log);
+    assert!(err_log.contains(r#"Tree height does not match Merkle height"#), "{}", err_log);
 }
 
 #[rstest]

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -48,7 +48,7 @@ async fn return_result_cairo0_account(#[future] initial_state: TestState, block_
 
     // temporarily expect test to break prematurely
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"Tree height does not match Merkle height"#), "{}", err_log);
+    assert!(err_log.contains(r#"Tree height (0) does not match Merkle height"#), "{}", err_log);
 }
 
 #[rstest]


### PR DESCRIPTION
This PR hooks up the state commitment info to the OsInput.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
