### PR TITLE
Provide class trie commitment info

### DIFF
--- a/src/execution/helper.rs
+++ b/src/execution/helper.rs
@@ -14,7 +14,7 @@ use starknet_api::deprecated_contract_class::EntryPointType;
 use tokio::sync::RwLock;
 
 use crate::config::STORED_BLOCK_HASH_BUFFER;
-use crate::crypto::pedersen::PedersenHash;
+use crate::crypto::{pedersen::PedersenHash, poseidon::PoseidonHash};
 use crate::starknet::starknet_storage::{CommitmentInfo, CommitmentInfoError, OsSingleStarknetStorage};
 use crate::storage::dict_storage::DictStorage;
 use crate::storage::storage::StorageError;

--- a/src/hints/block_context.rs
+++ b/src/hints/block_context.rs
@@ -321,3 +321,22 @@ pub fn is_leaf(
     // ids_data, ap_tracking)?; TODO: complete when bytecode_segment_structure is implemented
     insert_value_from_var_name("is_leaf", 1, vm, ids_data, ap_tracking)
 }
+
+pub const WRITE_USE_ZKG_DA_TO_MEM: &str = indoc! {r#"
+    memory[fp + 15] = to_felt_or_relocatable(syscall_handler.block_info.use_kzg_da)"#
+};
+pub fn write_use_zkg_da_to_mem(
+    vm: &mut VirtualMachine,
+    _exec_scopes: &mut ExecutionScopes,
+    _ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    // TODO: add use_kzg_da to BlockContext
+    let value = Felt252::ZERO;
+
+    println!("Warning: skipping kzg_da (use_kzg_da = false)");
+
+    vm.insert_value((vm.get_fp() + 15)?, value)
+        .map_err(HintError::Memory)
+}

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -55,7 +55,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 171] = [
+static HINTS: [(&str, HintImpl); 172] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -227,6 +227,7 @@ static HINTS: [(&str, HintImpl); 171] = [
     (syscalls::STORAGE_WRITE, syscalls::storage_write),
     (transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT, transaction_hash::additional_data_new_segment),
     (transaction_hash::DATA_TO_HASH_NEW_SEGMENT, transaction_hash::data_to_hash_new_segment),
+    (block_context::WRITE_USE_ZKG_DA_TO_MEM, block_context::write_use_zkg_da_to_mem),
 ];
 
 /// Hint Extensions extend the current map of hints used by the VM.

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -84,10 +84,6 @@ pub const WRITE_NIBBLES_TO_MEM: &str = indoc! {r#"
     memory[fp + 0] = to_felt_or_relocatable(nibbles.pop())"#
 };
 
-#[allow(unused)]
-pub const WRITE_USE_ZKG_DA_TO_MEM: &str = indoc! {r#"
-    memory[fp + 15] = to_felt_or_relocatable(syscall_handler.block_info.use_kzg_da)"#
-};
 
 #[allow(unused)]
 pub const PACK_X_PRIME: &str = indoc! {r#"

--- a/src/starknet/business_logic/utils.rs
+++ b/src/starknet/business_logic/utils.rs
@@ -2,19 +2,19 @@ use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 
+use crate::crypto::poseidon::PoseidonHash;
 use crate::starknet::business_logic::fact_state::contract_class_objects::{
     CompiledClassFact, ContractClassFact, DeprecatedCompiledClassFact,
 };
 use crate::storage::storage::{Fact, FactFetchingContext, HashFunctionType, Storage, StorageError};
 
-pub async fn write_class_facts<S, H>(
+pub async fn write_class_facts<S>(
     contract_class: ContractClass,
     compiled_class: CasmContractClass,
-    ffc: &mut FactFetchingContext<S, H>,
+    ffc: &mut FactFetchingContext<S, PoseidonHash>,
 ) -> Result<(Vec<u8>, Vec<u8>), StorageError>
 where
     S: Storage,
-    H: HashFunctionType,
 {
     let contract_class_fact = ContractClassFact { contract_class };
     let compiled_class_fact = CompiledClassFact { compiled_class };
@@ -25,13 +25,12 @@ where
     Ok((contract_class_hash, compiled_class_hash))
 }
 
-pub async fn write_deprecated_compiled_class_fact<S, H>(
+pub async fn write_deprecated_compiled_class_fact<S>(
     deprecated_compiled_class: DeprecatedCompiledClass,
-    ffc: &mut FactFetchingContext<S, H>,
+    ffc: &mut FactFetchingContext<S, PoseidonHash>,
 ) -> Result<Vec<u8>, StorageError>
 where
     S: Storage,
-    H: HashFunctionType,
 {
     let deprecated_compiled_class_fact = DeprecatedCompiledClassFact { contract_definition: deprecated_compiled_class };
     deprecated_compiled_class_fact.set_fact(ffc).await

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -304,11 +304,23 @@ pub async fn os_hints(
             &mut ffc,
         )
         .await
-        .expect("Could not create contract state commitment info");
+        .unwrap_or_else(|e| panic!("Could not create contract state commitment info: {:?}", e));
+
+    let accessed_contracts: Vec<TreeIndex> = Default::default(); // TODO: build from `deployed_contracts` above...?
+
+    let contract_class_commitment_info =
+        CommitmentInfo::create_from_expected_updated_tree::<DictStorage, PedersenHash, ContractState>(
+            previous_state.contract_classes.clone().expect("previous state should have class trie"),
+            updated_state.contract_classes.clone().expect("updated state should have class trie"),
+            &accessed_contracts,
+            &mut ffc,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Could not create contract class commitment info: {:?}", e));
 
     let os_input = StarknetOsInput {
         contract_state_commitment_info,
-        contract_class_commitment_info: Default::default(),
+        contract_class_commitment_info,
         deprecated_compiled_classes,
         compiled_classes: compiled_class_hash_to_compiled_class,
         compiled_class_visited_pcs: Default::default(),

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -307,8 +307,6 @@ pub async fn os_hints(
     let accessed_contracts: Vec<TreeIndex> = state_diff
         .class_hash_to_compiled_class_hash
         .keys()
-        .chain(compiled_classes.keys())
-        .chain(deprecated_compiled_classes.keys())
         .map(|class_hash| {
             BigUint::from_bytes_be(class_hash.0.bytes())
         })


### PR DESCRIPTION
This PR continues working through the OS state update by providing class trie commitment info to the OsInput.

It contains some out-of-scope changes as well as we get closer to the end of the OS.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
