### PR TITLE
Internal: introduce the `Hash` type for hashes

### DIFF
--- a/src/crypto/pedersen.rs
+++ b/src/crypto/pedersen.rs
@@ -1,15 +1,15 @@
 use starknet_crypto::{pedersen_hash, FieldElement};
 
-use crate::storage::storage::HashFunctionType;
+use crate::storage::storage::{Hash, HashFunctionType};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PedersenHash;
 
 impl HashFunctionType for PedersenHash {
-    fn hash(x: &[u8], y: &[u8]) -> Vec<u8> {
+    fn hash(x: &[u8], y: &[u8]) -> Hash {
         let x_felt = FieldElement::from_byte_slice_be(x).unwrap();
         let y_felt = FieldElement::from_byte_slice_be(y).unwrap();
 
-        pedersen_hash(&x_felt, &y_felt).to_bytes_be().to_vec()
+        Hash::from_bytes_be(pedersen_hash(&x_felt, &y_felt).to_bytes_be())
     }
 }

--- a/src/crypto/poseidon.rs
+++ b/src/crypto/poseidon.rs
@@ -1,25 +1,25 @@
 use cairo_vm::types::errors::math_errors::MathError;
 use starknet_crypto::{poseidon_hash, poseidon_hash_many, FieldElement};
 
-use crate::storage::storage::HashFunctionType;
+use crate::storage::storage::{Hash, HashFunctionType};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PoseidonHash;
 
 impl HashFunctionType for PoseidonHash {
-    fn hash(x: &[u8], y: &[u8]) -> Vec<u8> {
+    fn hash(x: &[u8], y: &[u8]) -> Hash {
         let x_felt = FieldElement::from_byte_slice_be(x).unwrap();
         let y_felt = FieldElement::from_byte_slice_be(y).unwrap();
 
-        poseidon_hash(x_felt, y_felt).to_bytes_be().to_vec()
+        Hash::from_bytes_be(poseidon_hash(x_felt, y_felt).to_bytes_be())
     }
 }
 
 /// A wrapper around `poseidon_hash_many` that takes and returns bytes.
-pub fn poseidon_hash_many_bytes(msgs: &[&[u8]]) -> Result<Vec<u8>, MathError> {
+pub fn poseidon_hash_many_bytes(msgs: &[&[u8]]) -> Result<Hash, MathError> {
     let field_elements: Result<Vec<_>, _> = msgs.iter().map(|elem| FieldElement::from_byte_slice_be(elem)).collect();
     let field_elements = field_elements.map_err(|_| MathError::ByteConversionError)?;
     let result = poseidon_hash_many(&field_elements);
 
-    Ok(result.to_bytes_be().to_vec())
+    Ok(Hash::from_bytes_be(result.to_bytes_be()))
 }

--- a/src/starknet/business_logic/fact_state/contract_state_objects.rs
+++ b/src/starknet/business_logic/fact_state/contract_state_objects.rs
@@ -1,3 +1,4 @@
+use std::cmp::PartialEq;
 use std::collections::HashMap;
 
 use cairo_vm::Felt252;
@@ -11,7 +12,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::{PatriciaTree, EMPTY_NODE_HASH};
 use crate::starkware_utils::serializable::SerializationPrefix;
-use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, Hash, HashFunctionType, Storage};
 
 pub const UNINITIALIZED_CLASS_HASH: [u8; 32] = [0; 32];
 
@@ -84,9 +85,9 @@ where
 {
     /// Computes the hash of the node containing the contract's information, including the contract
     /// definition and storage.
-    fn hash(&self) -> Vec<u8> {
+    fn hash(&self) -> Hash {
         if <ContractState as LeafFact<S, H>>::is_empty(self) {
-            return EMPTY_NODE_HASH.to_vec();
+            return Hash::empty();
         }
 
         let contract_state_hash_version = Felt252::ZERO;
@@ -134,20 +135,20 @@ mod tests {
     /// Tests that hashing a contract state generates the same result as the Python implementation.
     #[test]
     fn test_hash() {
-        let expected_hash = vec![
+        let expected_hash = Hash::from_bytes_be([
             0, 230, 218, 235, 11, 21, 37, 88, 4, 90, 177, 187, 242, 196, 238, 86, 196, 121, 84, 108, 89, 96, 12, 235,
             166, 11, 224, 7, 71, 12, 21, 229,
-        ];
+        ]);
 
         let contract_hash = vec![
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 105, 45, 97, 109, 45, 97, 45, 99, 111, 110, 116, 114, 97, 99, 116, 45,
             115, 116, 97, 116, 101,
         ];
         let patricia_tree = PatriciaTree {
-            root: vec![
+            root: Hash::from_bytes_be([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 111, 110, 116, 114, 97, 99, 116, 45, 116, 114, 101, 101,
                 45, 114, 111, 111, 116,
-            ],
+            ]),
             height: Height(251),
         };
 

--- a/src/starknet/business_logic/fact_state/state.rs
+++ b/src/starknet/business_logic/fact_state/state.rs
@@ -30,7 +30,7 @@ use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
-use crate::storage::storage::{DbObject, FactFetchingContext, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{DbObject, FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
 use crate::storage::storage_utils::{contract_class_cl2vm, deprecated_contract_class_api2vm};
 use crate::utils::{execute_coroutine, felt_api2vm, felt_vm2api};
 
@@ -142,7 +142,7 @@ where
     fn get_global_state_root(&self) -> Result<Felt252, MathError> {
         let contract_states_root = &self.contract_states.root;
 
-        let empty_tree_root = vec![0u8; 32];
+        let empty_tree_root = Hash::empty();
         let contract_classes_root = match &self.contract_classes {
             Some(tree) => &tree.root,
             None => &empty_tree_root,

--- a/src/starknet/business_logic/utils.rs
+++ b/src/starknet/business_logic/utils.rs
@@ -5,13 +5,13 @@ use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiled
 use crate::starknet::business_logic::fact_state::contract_class_objects::{
     CompiledClassFact, ContractClassFact, DeprecatedCompiledClassFact,
 };
-use crate::storage::storage::{Fact, FactFetchingContext, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{Fact, FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
 
 pub async fn write_class_facts<S, H>(
     contract_class: ContractClass,
     compiled_class: CasmContractClass,
     ffc: &mut FactFetchingContext<S, H>,
-) -> Result<(Vec<u8>, Vec<u8>), StorageError>
+) -> Result<(Hash, Hash), StorageError>
 where
     S: Storage,
     H: HashFunctionType,
@@ -28,7 +28,7 @@ where
 pub async fn write_deprecated_compiled_class_fact<S, H>(
     deprecated_compiled_class: DeprecatedCompiledClass,
     ffc: &mut FactFetchingContext<S, H>,
-) -> Result<Vec<u8>, StorageError>
+) -> Result<Hash, StorageError>
 where
     S: Storage,
     H: HashFunctionType,

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -12,9 +12,9 @@ use crate::starkware_utils::commitment_tree::binary_fact_tree::{
 };
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
-use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::{PatriciaTree, EMPTY_NODE_HASH};
+use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
-use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, Hash, HashFunctionType, Storage};
 use crate::utils::{Felt252Num, Felt252Str};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -37,11 +37,11 @@ where
     H: HashFunctionType,
     S: Storage,
 {
-    fn hash(&self) -> Vec<u8> {
+    fn hash(&self) -> Hash {
         if <StorageLeaf as LeafFact<S, H>>::is_empty(self) {
-            return EMPTY_NODE_HASH.to_vec();
+            return Hash::empty();
         }
-        self.serialize().unwrap()
+        Hash::from_bytes_be_slice(&self.serialize().unwrap())
     }
 }
 

--- a/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
@@ -11,7 +11,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::merkle_tree::traverse_tree::{traverse_tree, TreeTraverser};
-use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
 
 #[derive(Debug, PartialEq)]
 pub struct BinaryFactTreeNodeDiff<S, H, LF>
@@ -146,8 +146,8 @@ where
     fn is_leaf(&self) -> bool {
         self.get_height_in_tree() == Height(0)
     }
-    fn _leaf_hash(&self) -> Vec<u8>;
-    fn leaf_hash(&self) -> Option<Vec<u8>> {
+    fn _leaf_hash(&self) -> Hash;
+    fn leaf_hash(&self) -> Option<Hash> {
         match self.is_leaf() {
             true => Some(self._leaf_hash()),
             false => None,
@@ -157,7 +157,7 @@ where
     /// Returns the height of the node in a tree.
     fn get_height_in_tree(&self) -> Height;
 
-    fn create_leaf(hash_value: Vec<u8>) -> Self;
+    fn create_leaf(hash_value: Hash) -> Self;
 
     /// Returns the two BinaryFactTreeNode objects which are the roots of the subtrees of the
     /// current BinaryFactTreeNode.
@@ -310,7 +310,7 @@ pub async fn write_node_fact<S, H, INF>(
     ffc: &mut FactFetchingContext<S, H>,
     inner_node_fact: INF,
     facts: &mut Option<BinaryFactDict>,
-) -> Result<Vec<u8>, StorageError>
+) -> Result<Hash, StorageError>
 where
     S: Storage,
     H: HashFunctionType,

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -10,13 +10,13 @@ use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::virtual_calculation_node::VirtualCalculationNode;
 use crate::starkware_utils::commitment_tree::patricia_tree::virtual_patricia_node::VirtualPatriciaNode;
 use crate::starkware_utils::commitment_tree::update_tree::update_tree;
-use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
+use crate::storage::storage::{FactFetchingContext, Hash, HashFunctionType, Storage};
 
 pub const EMPTY_NODE_HASH: [u8; 32] = [0; 32];
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PatriciaTree {
-    pub root: Vec<u8>,
+    pub root: Hash,
     pub height: Height,
 }
 
@@ -97,13 +97,12 @@ mod tests {
     /// the bottom node fact and the path, plus the path length.
     fn hash_preimage(preimage: &[BigUint]) -> BigUint {
         let hash = if preimage.len() == 2 {
-            let node_fact =
-                BinaryNodeFact::new(preimage[0].to_bytes_be().to_vec(), preimage[1].to_bytes_be().to_vec()).unwrap();
+            let node_fact = BinaryNodeFact::new(Hash::from(&preimage[0]), Hash::from(&preimage[1])).unwrap();
             <BinaryNodeFact as Fact<StorageType, HashFunction>>::hash(&node_fact)
         } else {
             let length = Length(preimage[0].to_u64().unwrap());
             let path = NodePath(preimage[1].clone());
-            let bottom = preimage[2].to_bytes_be().to_vec();
+            let bottom = Hash::from(&preimage[2]);
             let node_fact = EdgeNodeFact::new(bottom, path, length).unwrap();
             <EdgeNodeFact as Fact<StorageType, HashFunction>>::hash(&node_fact)
         };

--- a/src/starkware_utils/commitment_tree/update_tree.rs
+++ b/src/starkware_utils/commitment_tree/update_tree.rs
@@ -259,10 +259,7 @@ where
     if let Some(facts) = facts {
         // The leaves aren't stored in `facts`. Only nodes are stored there.
         for (fact_hash, node_fact) in new_facts.inner_nodes.iter() {
-            facts.insert(
-                BigUint::from_bytes_be(fact_hash),
-                <PatriciaNodeFact as InnerNodeFact<S, H>>::to_tuple(node_fact),
-            );
+            facts.insert(BigUint::from(fact_hash), <PatriciaNodeFact as InnerNodeFact<S, H>>::to_tuple(node_fact));
         }
     }
 

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -109,6 +109,8 @@ impl Hash {
         Self(bytes)
     }
 
+    /// Builds a `Hash` from a bytes slice.
+    /// The slice length must be <= 32.
     pub fn from_bytes_be_slice(bytes: &[u8]) -> Self {
         let mut array = [0u8; 32];
         let start = 32 - bytes.len();
@@ -149,10 +151,9 @@ impl From<&Hash> for BigUint {
 
 impl From<&BigUint> for Hash {
     fn from(value: &BigUint) -> Self {
-        // This conversion is safe, BigUint is 32 bytes max so this will always work.
-        // TODO: improve this
-        let felt252 = Felt252::from(value);
-        Self::from(felt252)
+        // `BigUint.to_bytes_be()` only returns the minimum amount of bytes, so we need to use
+        // `from_bytes_be_slice` for this conversion.
+        Self::from_bytes_be_slice(&value.to_bytes_be())
     }
 }
 

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -12,7 +12,7 @@ use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
-use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, Hash, HashFunctionType, Storage};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SimpleLeafFact {
@@ -36,8 +36,8 @@ where
     H: HashFunctionType,
     S: Storage,
 {
-    fn hash(&self) -> Vec<u8> {
-        self.serialize().unwrap()
+    fn hash(&self) -> Hash {
+        Hash::from_bytes_be_slice(&self.serialize().unwrap())
     }
 }
 


### PR DESCRIPTION
Problem: we did not use a custom type when porting most of the code, resulting in hashes being `Vec<u8>` all over the place. This is inconvenient and error-prone.

Solution: introduce the `Hash` type to encapsulate all hashes. With this, hashes are now type-safe and provide implementations of `From` for common types in Cairo VM and Starknet API.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
