### PR TITLE
Feature: enable class tree updates

### DIFF
--- a/src/hints/block_context.rs
+++ b/src/hints/block_context.rs
@@ -321,3 +321,22 @@ pub fn is_leaf(
     // ids_data, ap_tracking)?; TODO: complete when bytecode_segment_structure is implemented
     insert_value_from_var_name("is_leaf", 1, vm, ids_data, ap_tracking)
 }
+
+pub const WRITE_USE_ZKG_DA_TO_MEM: &str = indoc! {r#"
+    memory[fp + 15] = to_felt_or_relocatable(syscall_handler.block_info.use_kzg_da)"#
+};
+pub fn write_use_zkg_da_to_mem(
+    vm: &mut VirtualMachine,
+    _exec_scopes: &mut ExecutionScopes,
+    _ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    // TODO: add use_kzg_da to BlockContext
+    let value = Felt252::ZERO;
+
+    println!("Warning: skipping kzg_da (use_kzg_da = false)");
+
+    vm.insert_value((vm.get_fp() + 15)?, value)
+        .map_err(HintError::Memory)
+}

--- a/src/hints/block_context.rs
+++ b/src/hints/block_context.rs
@@ -337,6 +337,5 @@ pub fn write_use_zkg_da_to_mem(
 
     println!("Warning: skipping kzg_da (use_kzg_da = false)");
 
-    vm.insert_value((vm.get_fp() + 15)?, value)
-        .map_err(HintError::Memory)
+    vm.insert_value((vm.get_fp() + 15)?, value).map_err(HintError::Memory)
 }

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -55,7 +55,7 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 171] = [
+static HINTS: [(&str, HintImpl); 172] = [
     (BREAKPOINT, breakpoint),
     (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
     (INITIALIZE_STATE_CHANGES, initialize_state_changes),
@@ -227,6 +227,7 @@ static HINTS: [(&str, HintImpl); 171] = [
     (syscalls::STORAGE_WRITE, syscalls::storage_write),
     (transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT, transaction_hash::additional_data_new_segment),
     (transaction_hash::DATA_TO_HASH_NEW_SEGMENT, transaction_hash::data_to_hash_new_segment),
+    (block_context::WRITE_USE_ZKG_DA_TO_MEM, block_context::write_use_zkg_da_to_mem),
 ];
 
 /// Hint Extensions extend the current map of hints used by the VM.

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -16,7 +16,7 @@ use indoc::indoc;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
-use crate::cairo_types::builtins::HashBuiltin;
+use crate::cairo_types::builtins::{HashBuiltin, SpongeHashBuiltin};
 use crate::cairo_types::dict_access::DictAccess;
 use crate::cairo_types::trie::NodeEdge;
 use crate::hints::types::{skip_verification_if_configured, PatriciaSkipValidationRunner, Preimage};
@@ -239,6 +239,13 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
+    let class_trie_mode: bool = get_variable_from_root_exec_scope(exec_scopes, vars::scopes::CLASS_TRIE_MODE)?;
+    log::debug!("Poseidon mode: {class_trie_mode}");
+    let (x_offset, y_offset, result_offset) = match class_trie_mode {
+        true => (SpongeHashBuiltin::x_offset(), SpongeHashBuiltin::y_offset(), SpongeHashBuiltin::result_offset()),
+        false => (HashBuiltin::x_offset(), HashBuiltin::y_offset(), HashBuiltin::result_offset()),
+    };
+
     let node: UpdateTree<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
     let node = node.ok_or(HintError::AssertionFailed("'node' should not be None".to_string().into_boxed_str()))?;
 
@@ -260,11 +267,11 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
     // Fill non deterministic hashes.
     let hash_ptr = get_ptr_from_var_name(vars::ids::CURRENT_HASH, vm, ids_data, ap_tracking)?;
     // memory[hash_ptr + ids.HashBuiltin.x] = left_hash
-    vm.insert_value((hash_ptr + HashBuiltin::x_offset())?, left_hash)?;
+    vm.insert_value((hash_ptr + x_offset)?, left_hash)?;
     // memory[hash_ptr + ids.HashBuiltin.y] = right_hash
-    vm.insert_value((hash_ptr + HashBuiltin::y_offset())?, right_hash)?;
+    vm.insert_value((hash_ptr + y_offset)?, right_hash)?;
 
-    let hash_result_address = (hash_ptr + HashBuiltin::result_offset())?;
+    let hash_result_address = (hash_ptr + result_offset)?;
     skip_verification_if_configured(exec_scopes, hash_result_address)?;
 
     // memory[ap] = int(case != 'both')"#

--- a/src/hints/patricia.rs
+++ b/src/hints/patricia.rs
@@ -16,10 +16,11 @@ use indoc::indoc;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
-use crate::cairo_types::builtins::{HashBuiltin, SpongeHashBuiltin};
 use crate::cairo_types::dict_access::DictAccess;
 use crate::cairo_types::trie::NodeEdge;
-use crate::hints::types::{skip_verification_if_configured, PatriciaSkipValidationRunner, Preimage};
+use crate::hints::types::{
+    get_hash_builtin_fields, skip_verification_if_configured, PatriciaSkipValidationRunner, Preimage,
+};
 use crate::hints::vars;
 use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::base_types::{DescentMap, DescentPath, DescentStart, Height, NodePath};
@@ -239,12 +240,7 @@ pub fn prepare_preimage_validation_non_deterministic_hashes(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let class_trie_mode: bool = get_variable_from_root_exec_scope(exec_scopes, vars::scopes::CLASS_TRIE_MODE)?;
-    log::debug!("Poseidon mode: {class_trie_mode}");
-    let (x_offset, y_offset, result_offset) = match class_trie_mode {
-        true => (SpongeHashBuiltin::x_offset(), SpongeHashBuiltin::y_offset(), SpongeHashBuiltin::result_offset()),
-        false => (HashBuiltin::x_offset(), HashBuiltin::y_offset(), HashBuiltin::result_offset()),
-    };
+    let (x_offset, y_offset, result_offset) = get_hash_builtin_fields(exec_scopes)?;
 
     let node: UpdateTree<StorageLeaf> = exec_scopes.get(vars::scopes::NODE)?;
     let node = node.ok_or(HintError::AssertionFailed("'node' should not be None".to_string().into_boxed_str()))?;

--- a/src/hints/types.rs
+++ b/src/hints/types.rs
@@ -5,13 +5,41 @@ use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::Felt252;
 
+use crate::cairo_types::builtins::{HashBuiltin, SpongeHashBuiltin};
 use crate::hints::vars;
+use crate::utils::get_variable_from_root_exec_scope;
 
 pub type Preimage = HashMap<Felt252, Vec<Felt252>>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PatriciaSkipValidationRunner {
     pub verified_addresses: HashSet<Relocatable>,
+}
+
+/// Specifies if we are in the state or class update part of the OS.
+///
+/// The Patricia-related hints have the same Python code but differ in the structures
+/// they use internally, especially w.r.t. hashing. This enum allows to specify that we
+/// must use Poseidon hashing for the class tree updates once we get out of the contract
+/// state update.
+#[derive(Clone, Debug)]
+pub enum PatriciaTreeMode {
+    Class,
+    State,
+}
+
+/// Returns the offsets of the x, y and result fields of the hash struct used during Patricia
+/// tree updates depending on the tree being updated.
+pub fn get_hash_builtin_fields(exec_scopes: &ExecutionScopes) -> Result<(usize, usize, usize), HintError> {
+    let patricia_tree_mode: PatriciaTreeMode =
+        get_variable_from_root_exec_scope(exec_scopes, vars::scopes::PATRICIA_TREE_MODE)?;
+    log::debug!("Patricia tree mode: {patricia_tree_mode:?}");
+    Ok(match patricia_tree_mode {
+        PatriciaTreeMode::Class => {
+            (SpongeHashBuiltin::x_offset(), SpongeHashBuiltin::y_offset(), SpongeHashBuiltin::result_offset())
+        }
+        PatriciaTreeMode::State => (HashBuiltin::x_offset(), HashBuiltin::y_offset(), HashBuiltin::result_offset()),
+    })
 }
 
 /// Inserts a hash result address in `__patricia_skip_validation_runner` if it exists.

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -84,10 +84,6 @@ pub const WRITE_NIBBLES_TO_MEM: &str = indoc! {r#"
     memory[fp + 0] = to_felt_or_relocatable(nibbles.pop())"#
 };
 
-#[allow(unused)]
-pub const WRITE_USE_ZKG_DA_TO_MEM: &str = indoc! {r#"
-    memory[fp + 15] = to_felt_or_relocatable(syscall_handler.block_info.use_kzg_da)"#
-};
 
 #[allow(unused)]
 pub const PACK_X_PRIME: &str = indoc! {r#"

--- a/src/hints/unimplemented.rs
+++ b/src/hints/unimplemented.rs
@@ -84,7 +84,6 @@ pub const WRITE_NIBBLES_TO_MEM: &str = indoc! {r#"
     memory[fp + 0] = to_felt_or_relocatable(nibbles.pop())"#
 };
 
-
 #[allow(unused)]
 pub const PACK_X_PRIME: &str = indoc! {r#"
     from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -2,7 +2,6 @@ pub mod scopes {
     pub const BYTECODE_SEGMENT_STRUCTURE: &str = "bytecode_segment_structure";
     pub const BYTECODE_SEGMENTS: &str = "bytecode_segments";
     pub const CASE: &str = "case";
-    pub const CLASS_TRIE_MODE: &str = "class_tree_mode";
     pub const COMMITMENT_INFO: &str = "commitment_info";
     pub const COMMITMENT_INFO_BY_ADDRESS: &str = "commitment_info_by_address";
     pub const COMPILED_CLASS_HASH: &str = "compiled_class_hash";
@@ -17,6 +16,7 @@ pub mod scopes {
     pub const LEFT_CHILD: &str = "left_child";
     pub const OS_INPUT: &str = "os_input";
     pub const PATRICIA_SKIP_VALIDATION_RUNNER: &str = "__patricia_skip_validation_runner";
+    pub const PATRICIA_TREE_MODE: &str = "patricia_tree_mode";
     pub const PREIMAGE: &str = "preimage";
     pub const RIGHT_CHILD: &str = "right_child";
     pub const SYSCALL_HANDLER: &str = "syscall_handler";

--- a/src/hints/vars.rs
+++ b/src/hints/vars.rs
@@ -2,6 +2,7 @@ pub mod scopes {
     pub const BYTECODE_SEGMENT_STRUCTURE: &str = "bytecode_segment_structure";
     pub const BYTECODE_SEGMENTS: &str = "bytecode_segments";
     pub const CASE: &str = "case";
+    pub const CLASS_TRIE_MODE: &str = "class_tree_mode";
     pub const COMMITMENT_INFO: &str = "commitment_info";
     pub const COMMITMENT_INFO_BY_ADDRESS: &str = "commitment_info_by_address";
     pub const COMPILED_CLASS_HASH: &str = "compiled_class_hash";
@@ -11,6 +12,7 @@ pub mod scopes {
     #[allow(unused)]
     pub const DICT_MANAGER: &str = "dict_manager";
     pub const EXECUTION_HELPER: &str = "execution_helper";
+    pub const INITIAL_DICT: &str = "initial_dict";
     pub const NODE: &str = "node";
     pub const LEFT_CHILD: &str = "left_child";
     pub const OS_INPUT: &str = "os_input";

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -46,7 +46,7 @@ impl StarknetOsOutput {
             .base();
         let size_bound_up = match builtin_end_ptrs.last().unwrap() {
             MaybeRelocatable::Int(val) => val,
-            _ => panic!("Value should be an int"),
+            _ => return Err(SnOsError::CatchAll("value should be an int".to_string())),
         };
 
         // Get is input and check that everything is an integer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run_os(
     cairo_runner
         .exec_scopes
         .insert_value(vars::scopes::PATRICIA_SKIP_VALIDATION_RUNNER, None::<PatriciaSkipValidationRunner>);
+    cairo_runner.exec_scopes.insert_value(vars::scopes::CLASS_TRIE_MODE, false);
 
     // Run the Cairo VM
     let mut sn_hint_processor = hints::SnosHintProcessor::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub fn run_os(
     cairo_runner
         .exec_scopes
         .insert_value(vars::scopes::PATRICIA_SKIP_VALIDATION_RUNNER, None::<PatriciaSkipValidationRunner>);
-    cairo_runner.exec_scopes.insert_value(vars::scopes::CLASS_TRIE_MODE, false);
+    cairo_runner.exec_scopes.insert_value(vars::scopes::PATRICIA_TREE_MODE, false);
 
     // Run the Cairo VM
     let mut sn_hint_processor = hints::SnosHintProcessor::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use execution::helper::ExecutionHelperWrapper;
 use io::output::StarknetOsOutput;
 
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
-use crate::hints::types::PatriciaSkipValidationRunner;
+use crate::hints::types::{PatriciaSkipValidationRunner, PatriciaTreeMode};
 use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 
@@ -69,7 +69,7 @@ pub fn run_os(
     cairo_runner
         .exec_scopes
         .insert_value(vars::scopes::PATRICIA_SKIP_VALIDATION_RUNNER, None::<PatriciaSkipValidationRunner>);
-    cairo_runner.exec_scopes.insert_value(vars::scopes::PATRICIA_TREE_MODE, false);
+    cairo_runner.exec_scopes.insert_value(vars::scopes::PATRICIA_TREE_MODE, PatriciaTreeMode::State);
 
     // Run the Cairo VM
     let mut sn_hint_processor = hints::SnosHintProcessor::default();

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -10,9 +10,11 @@ use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use snos::config::{StarknetGeneralConfig, StarknetOsConfig, STORED_BLOCK_HASH_BUFFER};
 use snos::crypto::pedersen::PedersenHash;
+use snos::crypto::poseidon::PoseidonHash;
 use snos::execution::helper::ExecutionHelperWrapper;
 use snos::io::input::StarknetOsInput;
 use snos::io::InternalTransaction;
+use snos::starknet::business_logic::fact_state::contract_class_objects::ContractClassLeaf;
 use snos::starknet::business_logic::fact_state::contract_state_objects::ContractState;
 use snos::starknet::business_logic::fact_state::state::SharedState;
 use snos::starknet::starknet_storage::CommitmentInfo;
@@ -51,8 +53,9 @@ pub async fn os_hints(
 
     // provide an empty ContractState for any newly deployed contract
     // TODO: review -- what can to_state_diff() give us results we don't want to use here?
-    let deployed_addresses = blockifier_state.to_state_diff().address_to_class_hash;
-    for (address, _class_hash) in deployed_addresses {
+    let state_diff = blockifier_state.to_state_diff();
+    let deployed_addresses = state_diff.address_to_class_hash;
+    for (address, _class_hash) in &deployed_addresses {
         contracts.insert(
             to_felt252(address.0.key()),
             ContractState::empty(Height(251), &mut blockifier_state.state.ffc).await.unwrap(),
@@ -120,9 +123,6 @@ pub async fn os_hints(
         ..default_general_config
     };
 
-    let deprecated_compiled_classes: HashMap<_, _> =
-        deprecated_compiled_classes.into_iter().map(|(k, v)| (felt_api2vm(k.0), v)).collect();
-
     let mut ffc = blockifier_state.state.ffc.clone();
 
     // Convert the Blockifier storage into an OS-compatible one
@@ -142,11 +142,34 @@ pub async fn os_hints(
             &mut ffc,
         )
         .await
-        .expect("Could not create contract state commitment info");
+        .unwrap_or_else(|e| panic!("Could not create contract state commitment info: {:?}", e));
+
+    let accessed_contracts: Vec<TreeIndex> = state_diff
+        .class_hash_to_compiled_class_hash
+        .keys()
+        .chain(compiled_classes.keys())
+        // .chain(deprecated_compiled_classes.keys())
+        .map(|class_hash| BigUint::from_bytes_be(class_hash.0.bytes()))
+        .collect();
+
+    log::debug!("Created classes: {accessed_contracts:?}");
+
+    let contract_class_commitment_info =
+        CommitmentInfo::create_from_expected_updated_tree::<DictStorage, PoseidonHash, ContractClassLeaf>(
+            previous_state.contract_classes.clone().expect("previous state should have class trie"),
+            updated_state.contract_classes.clone().expect("updated state should have class trie"),
+            &accessed_contracts,
+            &mut ffc.clone_with_different_hash::<PoseidonHash>(),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Could not create contract class commitment info: {:?}", e));
+
+    let deprecated_compiled_classes: HashMap<_, _> =
+        deprecated_compiled_classes.into_iter().map(|(k, v)| (felt_api2vm(k.0), v)).collect();
 
     let os_input = StarknetOsInput {
         contract_state_commitment_info,
-        contract_class_commitment_info: Default::default(),
+        contract_class_commitment_info,
         deprecated_compiled_classes,
         compiled_classes: compiled_class_hash_to_compiled_class,
         compiled_class_visited_pcs: Default::default(),

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -148,11 +148,8 @@ pub async fn os_hints(
         .class_hash_to_compiled_class_hash
         .keys()
         .chain(compiled_classes.keys())
-        // .chain(deprecated_compiled_classes.keys())
         .map(|class_hash| BigUint::from_bytes_be(class_hash.0.bytes()))
         .collect();
-
-    log::debug!("Created classes: {accessed_contracts:?}");
 
     let contract_class_commitment_info =
         CommitmentInfo::create_from_expected_updated_tree::<DictStorage, PoseidonHash, ContractClassLeaf>(

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -52,7 +52,7 @@ async fn return_result_cairo0_account(
 
     // temporarily expect test to break prematurely
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"Tree height (0) does not match Merkle height"#), "{}", err_log);
+    assert!(err_log.contains(r#"value should be an int"#), "{}", err_log);
 }
 
 #[rstest]
@@ -94,7 +94,7 @@ async fn return_result_cairo1_account(
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"Tree height (0) does not match Merkle height"#), "{}", err_log);
+    assert!(err_log.contains(r#"value should be an int"#), "{}", err_log);
 }
 
 #[rstest]
@@ -201,5 +201,5 @@ async fn syscalls_cairo1(
 
     // temporarily expect test to break in the descent code
     let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"Tree height (0) does not match Merkle height"#), "{}", err_log);
+    assert!(err_log.contains(r#"value should be an int"#), "{}", err_log);
 }


### PR DESCRIPTION
Problem: we still pass an empty commitment info to the OS at startup.

Solution: use the correct class commitment info generated from the SharedState objects.

Additionally:
* Implement the `use_kzg_da` hint, note that the implementation only returns `false` for now.
* Added a mechanism to switch between Pedersen and Poseidon hashing in the Patricia hints. We enable a boolean flag after finishing the state update.

The tests now fail when building the OS output.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
