### PR TITLE
Fix: build Starknet OS output struct from VM output

### DIFF
--- a/src/hints/types.rs
+++ b/src/hints/types.rs
@@ -33,7 +33,7 @@ pub enum PatriciaTreeMode {
 pub fn get_hash_builtin_fields(exec_scopes: &ExecutionScopes) -> Result<(usize, usize, usize), HintError> {
     let patricia_tree_mode: PatriciaTreeMode =
         get_variable_from_root_exec_scope(exec_scopes, vars::scopes::PATRICIA_TREE_MODE)?;
-    log::debug!("Patricia tree mode: {patricia_tree_mode:?}");
+    log::trace!("Patricia tree mode: {patricia_tree_mode:?}");
     Ok(match patricia_tree_mode {
         PatriciaTreeMode::Class => {
             (SpongeHashBuiltin::x_offset(), SpongeHashBuiltin::y_offset(), SpongeHashBuiltin::result_offset())

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -61,25 +61,3 @@ pub struct InternalTransaction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fee: Option<Felt252>,
 }
-
-#[derive(Debug)]
-pub struct StarknetOsOutput {
-    /// The state commitment before this block.
-    pub prev_state_root: Felt252,
-    /// The state commitment after this block.
-    pub new_state_root: Felt252,
-    /// The number (height) of this block.
-    pub block_number: Felt252,
-    /// The hash of this block.
-    pub block_hash: Felt252,
-    /// The Starknet chain config hash
-    pub config_hash: Felt252,
-    /// List of messages sent to L1 in this block
-    pub messages_to_l1: Vec<Felt252>,
-    /// List of messages from L1 handled in this block
-    pub messages_to_l2: Vec<Felt252>,
-    /// List of the storage updates.
-    pub state_updates: Vec<Felt252>,
-    /// List of the newly declared contract classes.
-    pub contract_class_diff: Vec<Felt252>,
-}

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -49,7 +49,8 @@ impl StarknetOsOutput {
 /// Gets the output base segment and the output size from the VM return values and the VM
 /// output builtin.
 fn get_output_info(vm: &VirtualMachine) -> Result<(usize, usize), SnOsError> {
-    let builtin_end_ptrs = vm.get_return_values(8).map_err(|e| SnOsError::CatchAll(e.to_string()))?;
+    let n_builtins = vm.get_builtin_runners().len();
+    let builtin_end_ptrs = vm.get_return_values(n_builtins).map_err(|e| SnOsError::CatchAll(e.to_string()))?;
     let output_base = vm
         .get_builtin_runners()
         .iter()
@@ -84,7 +85,7 @@ fn get_raw_output(vm: &VirtualMachine, output_base: usize, output_size: usize) -
             if let MaybeRelocatable::Int(val) = x.clone().unwrap().into_owned() {
                 Ok(val)
             } else {
-                return Err(SnOsError::CatchAll("Output should be all integers".to_string()));
+                Err(SnOsError::CatchAll("Output should be all integers".to_string()))
             }
         })
         .collect();

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -2,83 +2,159 @@ use cairo_vm::types::relocatable::MaybeRelocatable;
 use cairo_vm::vm::runners::builtin_runner::BuiltinRunner;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_vm::Felt252;
+use num_traits::ToPrimitive;
 
 use crate::error::SnOsError;
-use crate::utils::felt_vm2usize;
 
 const PREVIOUS_MERKLE_UPDATE_OFFSET: usize = 0;
 const NEW_MERKLE_UPDATE_OFFSET: usize = 1;
 const BLOCK_NUMBER_OFFSET: usize = 2;
 const BLOCK_HASH_OFFSET: usize = 3;
 const CONFIG_HASH_OFFSET: usize = 4;
-const HEADER_SIZE: usize = 5;
+const USE_KZG_DA_OFFSET: usize = 5;
+const HEADER_SIZE: usize = 6;
 
 #[derive(Debug)]
 pub struct StarknetOsOutput {
     /// The state commitment before this block.
-    pub prev_state_root: Felt252,
+    pub initial_root: Felt252,
     /// The state commitment after this block.
-    pub new_state_root: Felt252,
+    pub final_root: Felt252,
     /// The number (height) of this block.
     pub block_number: Felt252,
     /// The hash of this block.
     pub block_hash: Felt252,
     /// The Starknet chain config hash
-    pub config_hash: Felt252,
+    pub starknet_os_config_hash: Felt252,
+    /// Whether KZG data availability was used.
+    pub use_kzg_da: Felt252,
     /// List of messages sent to L1 in this block
     pub messages_to_l1: Vec<Felt252>,
     /// List of messages from L1 handled in this block
     pub messages_to_l2: Vec<Felt252>,
     /// List of the storage updates.
-    pub state_updates: Vec<Felt252>,
+    pub contracts: Vec<Felt252>,
     /// List of the newly declared contract classes.
-    pub contract_class_diff: Vec<Felt252>,
+    pub classes: Vec<Felt252>,
 }
 
 impl StarknetOsOutput {
     pub fn from_run(vm: &VirtualMachine) -> Result<Self, SnOsError> {
-        let builtin_end_ptrs = vm.get_return_values(8).map_err(|e| SnOsError::CatchAll(e.to_string()))?;
-        let output_base = vm
-            .get_builtin_runners()
-            .iter()
-            .find(|&elt| matches!(elt, BuiltinRunner::Output(_)))
-            .expect("Os vm should have the output builtin")
-            .base();
-        let size_bound_up = match builtin_end_ptrs.last().unwrap() {
-            MaybeRelocatable::Int(val) => val,
-            _ => return Err(SnOsError::CatchAll("value should be an int".to_string())),
-        };
-
-        // Get is input and check that everything is an integer.
-        let size = felt_vm2usize(Some(&(*size_bound_up - Felt252::from(output_base))))?;
-        let raw_output = vm.get_range((output_base as isize, 0).into(), size);
-        let raw_output: Vec<Felt252> = raw_output
-            .iter()
-            .map(|x| {
-                if let MaybeRelocatable::Int(val) = x.clone().unwrap().into_owned() {
-                    val
-                } else {
-                    panic!("Output should be all integers")
-                }
-            })
-            .collect();
-
-        decode_output(raw_output)
+        let (output_base, output_size) = get_output_info(vm)?;
+        let raw_output = get_raw_output(vm, output_base, output_size)?;
+        decode_output(raw_output.into_iter())
     }
 }
 
-pub fn decode_output(mut os_output: Vec<Felt252>) -> Result<StarknetOsOutput, SnOsError> {
-    let header: Vec<Felt252> = os_output.drain(..HEADER_SIZE).collect();
+/// Gets the output base segment and the output size from the VM return values and the VM
+/// output builtin.
+fn get_output_info(vm: &VirtualMachine) -> Result<(usize, usize), SnOsError> {
+    let builtin_end_ptrs = vm.get_return_values(8).map_err(|e| SnOsError::CatchAll(e.to_string()))?;
+    let output_base = vm
+        .get_builtin_runners()
+        .iter()
+        .find(|&elt| matches!(elt, BuiltinRunner::Output(_)))
+        .expect("Os vm should have the output builtin")
+        .base();
+
+    let output_size = match builtin_end_ptrs[0] {
+        MaybeRelocatable::Int(_) => {
+            return Err(SnOsError::CatchAll("expected a relocatable as output builtin end pointer".to_string()));
+        }
+        MaybeRelocatable::RelocatableValue(address) => {
+            if address.segment_index as usize != output_base {
+                return Err(SnOsError::CatchAll(format!(
+                    "output builtin end pointer ({address}) is not on the expected segment ({output_base})"
+                )));
+            }
+            address.offset
+        }
+    };
+
+    Ok((output_base, output_size))
+}
+
+/// Gets the OS output as an array of felts based on the output base and size.
+fn get_raw_output(vm: &VirtualMachine, output_base: usize, output_size: usize) -> Result<Vec<Felt252>, SnOsError> {
+    // Get output and check that everything is an integer.
+    let raw_output = vm.get_range((output_base as isize, 0).into(), output_size);
+    let raw_output: Result<Vec<Felt252>, _> = raw_output
+        .iter()
+        .map(|x| {
+            if let MaybeRelocatable::Int(val) = x.clone().unwrap().into_owned() {
+                Ok(val)
+            } else {
+                return Err(SnOsError::CatchAll("Output should be all integers".to_string()));
+            }
+        })
+        .collect();
+
+    raw_output
+}
+
+pub fn decode_output<I: Iterator<Item = Felt252>>(mut output_iter: I) -> Result<StarknetOsOutput, SnOsError> {
+    /// Reads a section with a variable length from the iterator.
+    /// Some sections start with a length field N followed by N items.
+    fn read_variable_length_segment<I: Iterator<Item = Felt252>>(
+        output_iter: &mut I,
+        item_name: &str,
+    ) -> Result<Vec<Felt252>, SnOsError> {
+        let n_items = output_iter
+            .next()
+            .ok_or(SnOsError::CatchAll(format!("Could not read {item_name} segment size")))?
+            .to_usize()
+            .ok_or(SnOsError::CatchAll(format!("{item_name} segment size is too large")))?;
+        let items = output_iter.by_ref().take(n_items).collect();
+
+        Ok(items)
+    }
+
+    let header: Vec<Felt252> = output_iter.by_ref().take(HEADER_SIZE).collect();
+    if header.len() != HEADER_SIZE {
+        return Err(SnOsError::CatchAll(format!(
+            "Expected the header to have {} elements, could only read {}",
+            HEADER_SIZE,
+            header.len()
+        )));
+    }
+
+    let use_kzg_da = {
+        let use_kzg_da_felt = header[USE_KZG_DA_OFFSET];
+        if use_kzg_da_felt == Felt252::ZERO {
+            false
+        } else if use_kzg_da_felt == Felt252::ONE {
+            true
+        } else {
+            return Err(SnOsError::CatchAll(format!("Invalid KZG flag: {}", use_kzg_da_felt.to_biguint())));
+        }
+    };
+
+    if use_kzg_da {
+        // Skip KZG data.
+        _ = output_iter.by_ref().take(5);
+    }
+
+    let messages_to_l1 = read_variable_length_segment(&mut output_iter, "L1 messages")?;
+    let messages_to_l2 = read_variable_length_segment(&mut output_iter, "L2 messages")?;
+
+    let (contracts, classes) = if !use_kzg_da {
+        let contracts = read_variable_length_segment(&mut output_iter, "contracts")?;
+        let classes = read_variable_length_segment(&mut output_iter, "classes")?;
+        (contracts, classes)
+    } else {
+        (vec![], vec![])
+    };
 
     Ok(StarknetOsOutput {
-        prev_state_root: header[PREVIOUS_MERKLE_UPDATE_OFFSET],
-        new_state_root: header[NEW_MERKLE_UPDATE_OFFSET],
+        initial_root: header[PREVIOUS_MERKLE_UPDATE_OFFSET],
+        final_root: header[NEW_MERKLE_UPDATE_OFFSET],
         block_number: header[BLOCK_NUMBER_OFFSET],
         block_hash: header[BLOCK_HASH_OFFSET],
-        config_hash: header[CONFIG_HASH_OFFSET],
-        messages_to_l1: os_output.drain(1..felt_vm2usize(os_output.first())?).collect(),
-        messages_to_l2: os_output.drain(1..felt_vm2usize(os_output.first())?).collect(),
-        state_updates: os_output.drain(1..felt_vm2usize(os_output.first())?).collect(),
-        contract_class_diff: os_output.drain(1..felt_vm2usize(os_output.first())?).collect(),
+        starknet_os_config_hash: header[CONFIG_HASH_OFFSET],
+        use_kzg_da: header[USE_KZG_DA_OFFSET],
+        messages_to_l1,
+        messages_to_l2,
+        contracts,
+        classes,
     })
 }

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -56,7 +56,7 @@ pub fn load_output() -> StarknetOsOutput {
     let buf = fs::read_to_string("tests/integration/common/data/os_output.json").unwrap();
     let raw_output: serde_utils::RawOsOutput = serde_json::from_str(&buf).unwrap();
 
-    decode_output(raw_output.0).unwrap()
+    decode_output(raw_output.0.into_iter()).unwrap()
 }
 
 #[fixture]

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -186,9 +186,11 @@ pub async fn execute_txs_and_run_os(
                 log::error!("inst_location:\n{:?}", inst_location);
             }
         }
+        Err(_) => {
+            println!("exception:\n{:#?}", result);
+        }
         _ => {}
     }
-    println!("exception:\n{:#?}", result);
 
     result
 }

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,18 +41,15 @@ async fn return_result_cairo0_account(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let r = execute_txs_and_run_os(
+    let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
         vec![return_result_tx],
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
-    .await;
-
-    // temporarily expect test to break prematurely
-    let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"value should be an int"#), "{}", err_log);
+    .await
+    .expect("OS run failed");
 }
 
 #[rstest]
@@ -83,18 +80,15 @@ async fn return_result_cairo1_account(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let r = execute_txs_and_run_os(
+    let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
         vec![return_result_tx],
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
-    .await;
-
-    // temporarily expect test to break in the descent code
-    let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"value should be an int"#), "{}", err_log);
+    .await
+    .expect("OS run failed");
 }
 
 #[rstest]
@@ -190,16 +184,13 @@ async fn syscalls_cairo1(
         test_deploy_tx,
     ];
 
-    let r = execute_txs_and_run_os(
+    let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
         txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
-    .await;
-
-    // temporarily expect test to break in the descent code
-    let err_log = format!("{:?}", r);
-    assert!(err_log.contains(r#"value should be an int"#), "{}", err_log);
+    .await
+    .expect("OS run failed");
 }


### PR DESCRIPTION
Problem: the integration tests failed because the code to build the Starknet OS structure had never been used with real outputs.

Solution: reimplement the `from_run` method of `StarknetOsOutput`. The new version also supports KZG DA.

Issue Number: N/A

## Type

- [x] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
