### PR TITLE
Fix: make `BinaryFactTree::update` take self and not &mut self

### DIFF
--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1871,7 +1871,7 @@ mod tests {
         let storage = DictStorage::default();
         let mut ffc = FactFetchingContext::<_, PedersenHash>::new(storage);
 
-        let mut tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
+        let tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
         let modifications = vec![(BigUint::from(42u32), StorageLeaf::new(Felt252::from(8000)))];
         let mut facts = None;
         let tree = tree.update(&mut ffc, modifications, &mut facts).await.unwrap();

--- a/src/starknet/business_logic/fact_state/contract_state_objects.rs
+++ b/src/starknet/business_logic/fact_state/contract_state_objects.rs
@@ -51,7 +51,7 @@ impl ContractState {
     /// storage root, according to the given updates of its leaves.
 
     pub async fn update<S, H>(
-        mut self,
+        self,
         ffc: &mut FactFetchingContext<S, H>,
         updates: &HashMap<Felt252, Felt252>,
         nonce: Option<Felt252>,

--- a/src/starknet/business_logic/fact_state/state.rs
+++ b/src/starknet/business_logic/fact_state/state.rs
@@ -306,7 +306,7 @@ where
         let mut ffc_for_contract_class = get_ffc_for_contract_class_facts(&self.ffc);
 
         let updated_contract_classes = match self.contract_classes {
-            Some(mut tree) => {
+            Some(tree) => {
                 log::debug!(
                     "Updating contract class tree with {} modifications...",
                     class_hash_to_compiled_class_hash.len()

--- a/src/starknet/starknet_storage.rs
+++ b/src/starknet/starknet_storage.rs
@@ -105,7 +105,7 @@ impl From<CommitmentInfoError> for HintError {
 impl CommitmentInfo {
     /// Returns a commitment info that corresponds to the given modifications.
     pub async fn create_from_modifications<S, H, LF>(
-        mut previous_tree: PatriciaTree,
+        previous_tree: PatriciaTree,
         expected_updated_root: Felt252,
         modifications: Vec<(TreeIndex, LF)>,
         ffc: &mut FactFetchingContext<S, H>,
@@ -116,6 +116,7 @@ impl CommitmentInfo {
         LF: LeafFact<S, H> + Send + 'static,
     {
         let previous_tree_root = Felt252::from_bytes_be_slice(&previous_tree.root);
+        let previous_tree_height = previous_tree.height;
 
         let mut commitment_facts = Some(BinaryFactDict::new());
         let actual_updated_tree = previous_tree.update(ffc, modifications, &mut commitment_facts).await?;
@@ -134,7 +135,7 @@ impl CommitmentInfo {
         Ok(Self {
             previous_root: previous_tree_root,
             updated_root: actual_updated_root,
-            tree_height: previous_tree.height.0 as usize,
+            tree_height: previous_tree_height.0 as usize,
             commitment_facts,
         })
     }

--- a/src/starkware_utils/commitment_tree/binary_fact_tree.rs
+++ b/src/starkware_utils/commitment_tree/binary_fact_tree.rs
@@ -53,7 +53,7 @@ where
     /// If facts argument is not None, this dictionary is filled during traversal through the tree
     /// by the facts of their paths from the leaves up.
     async fn update(
-        &mut self,
+        self,
         ffc: &mut FactFetchingContext<S, H>,
         modifications: Vec<(TreeIndex, LF)>,
         facts: &mut Option<BinaryFactDict>,

--- a/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -42,12 +42,12 @@ where
     }
 
     async fn update(
-        &mut self,
+        self,
         ffc: &mut FactFetchingContext<S, H>,
         modifications: Vec<(TreeIndex, LF)>,
         facts: &mut Option<BinaryFactDict>,
     ) -> Result<Self, TreeError> {
-        let virtual_root_node = VirtualPatriciaNode::from_hash(self.root.clone(), self.height);
+        let virtual_root_node = VirtualPatriciaNode::from_hash(self.root, self.height);
         let updated_virtual_root_node = update_tree::<
             S,
             H,
@@ -161,7 +161,7 @@ mod tests {
     async fn test_update_and_decommit(mut ffc: FFC, #[case] height: Height, #[case] n_leaves: usize) {
         let mut rng = rand::thread_rng();
 
-        let mut tree = PatriciaTree::empty_tree(&mut ffc, height, SimpleLeafFact::empty()).await.unwrap();
+        let tree = PatriciaTree::empty_tree(&mut ffc, height, SimpleLeafFact::empty()).await.unwrap();
 
         // Create some random modifications, store the facts and update the tree.
         // Note that leaves with value 0 are not modifications (hence, range(1, ...)).
@@ -198,7 +198,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_update_and_get_leaf(mut ffc: FFC) {
-        let mut tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
+        let tree = PatriciaTree::empty_tree(&mut ffc, Height(251), StorageLeaf::empty()).await.unwrap();
 
         let index = BigUint::from(1000u64);
         let leaf = StorageLeaf::new(Felt252::from(2000));

--- a/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -592,12 +592,12 @@ mod tests {
     #[tokio::test]
     async fn test_binary_fact_tree_node_create_diff(mut ffc: FFC) {
         let mut facts = None;
-        let mut empty_tree = PatriciaTree::empty_tree(&mut ffc, Height(251), SimpleLeafFact::empty()).await.unwrap();
+        let empty_tree = PatriciaTree::empty_tree(&mut ffc, Height(251), SimpleLeafFact::empty()).await.unwrap();
         let virtual_empty_tree_node = VPN::from_hash(empty_tree.root.clone(), empty_tree.height);
 
         // All tree values are zero except for the fifth leaf, which has a value of 8.
         let modifications = vec![(BigUint::from(5u64), SimpleLeafFact::new(Felt252::from(8)))];
-        let mut one_change_tree = empty_tree.update(&mut ffc, modifications, &mut facts).await.unwrap();
+        let one_change_tree = empty_tree.clone().update(&mut ffc, modifications, &mut facts).await.unwrap();
         let virtual_one_change_node = VPN::from_hash(one_change_tree.root.clone(), empty_tree.height);
 
         // All tree values are zero except for the fifth leaf, which has a value of 8.


### PR DESCRIPTION
Mutating the input and returning it is redundant. We now take ownership of the previous tree and return the updated one.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
