### PR TITLE
Fix: remove duplication in Cairo structs for deprecated syscalls

### DIFF
--- a/src/cairo_types/structs.rs
+++ b/src/cairo_types/structs.rs
@@ -1,5 +1,4 @@
 use cairo_type_derive::FieldOffsetGetters;
-use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::Felt252;
 
 #[allow(unused)]
@@ -49,39 +48,4 @@ pub struct EntryPointReturnValues {
 pub struct BuiltinParams {
     builtin_encodings: Felt252,
     builtin_instance_sizes: Felt252,
-}
-
-#[allow(unused)]
-#[derive(FieldOffsetGetters)]
-pub struct CallContractResponse {
-    retdata_start: Felt252,
-    retdata_end: Felt252,
-}
-
-pub mod deprecated {
-    use super::*;
-
-    #[allow(unused)]
-    #[derive(FieldOffsetGetters)]
-    pub struct CallContractRequest {
-        selector: Felt252,
-        contract_address: Felt252,
-        function_selector: Felt252,
-        calldata_size: Felt252,
-        calldata: Relocatable,
-    }
-
-    #[allow(unused)]
-    #[derive(FieldOffsetGetters)]
-    pub struct CallContractResponse {
-        retdata_size: Felt252,
-        retdata: Relocatable,
-    }
-
-    #[allow(unused)]
-    #[derive(FieldOffsetGetters)]
-    pub struct CallContract {
-        request: CallContractRequest,
-        response: CallContractResponse,
-    }
 }

--- a/src/cairo_types/syscalls.rs
+++ b/src/cairo_types/syscalls.rs
@@ -30,11 +30,25 @@ pub struct StorageWrite {
     pub value: Felt252,
 }
 
-#[allow(unused)]
+#[derive(FieldOffsetGetters)]
+pub struct CallContractRequest {
+    pub selector: Felt252,
+    pub contract_address: Felt252,
+    pub function_selector: Felt252,
+    pub calldata_size: Felt252,
+    pub calldata: Relocatable,
+}
+
 #[derive(FieldOffsetGetters)]
 pub struct CallContractResponse {
     pub retdata_size: Felt252,
     pub retdata: Relocatable,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct CallContract {
+    pub request: CallContractRequest,
+    pub response: CallContractResponse,
 }
 
 #[derive(FieldOffsetGetters)]

--- a/src/execution/deprecated_syscall_handler.rs
+++ b/src/execution/deprecated_syscall_handler.rs
@@ -7,7 +7,7 @@ use cairo_vm::vm::vm_core::VirtualMachine;
 use tokio::sync::RwLock;
 
 use super::helper::ExecutionHelperWrapper;
-use crate::cairo_types::structs::deprecated::{CallContract, CallContractResponse};
+use crate::cairo_types::syscalls::{CallContract, CallContractResponse};
 use crate::utils::felt_api2vm;
 
 /// DeprecatedSyscallHandler implementation for execution of system calls in the StarkNet OS

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -22,9 +22,8 @@ use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
 use crate::cairo_types::new_syscalls;
-use crate::cairo_types::structs::deprecated::CallContractResponse;
 use crate::cairo_types::structs::{EntryPointReturnValues, ExecutionContext};
-use crate::cairo_types::syscalls::{StorageRead, StorageReadRequest, StorageWrite, TxInfo};
+use crate::cairo_types::syscalls::{CallContractResponse, StorageRead, StorageReadRequest, StorageWrite, TxInfo};
 use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;


### PR DESCRIPTION
Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
