### PR TITLE
Feature: library_call syscall for Cairo 0 and 1

### DIFF
--- a/src/cairo_types/new_syscalls.rs
+++ b/src/cairo_types/new_syscalls.rs
@@ -57,6 +57,17 @@ pub struct GetBlockHashRequest {
     pub block_number: Felt252,
 }
 
+#[derive(FieldOffsetGetters)]
+pub struct LibraryCallRequest {
+    /// The hash of the class to run.
+    pub class_hash: Felt252,
+    /// The selector of the function to call.
+    pub selector: Felt252,
+    /// The calldata.
+    pub calldata_start: Relocatable,
+    pub calldata_end: Relocatable,
+}
+
 #[allow(unused)]
 #[derive(FieldOffsetGetters)]
 pub struct SendMessageToL1Request {

--- a/src/cairo_types/syscalls.rs
+++ b/src/cairo_types/syscalls.rs
@@ -52,6 +52,27 @@ pub struct CallContract {
 }
 
 #[derive(FieldOffsetGetters)]
+pub struct LibraryCallRequest {
+    /// The system library call selector
+    /// (= LIBRARY_CALL_SELECTOR or LIBRARY_CALL_L1_HANDLER_SELECTOR).
+    pub selector: Felt252,
+    /// The hash of the class to run.
+    pub class_hash: Felt252,
+    /// The selector of the function to call.
+    pub function_selector: Felt252,
+    /// The size of the calldata.
+    pub calldata_size: Felt252,
+    /// The calldata.
+    pub calldata: Relocatable,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct LibraryCall {
+    pub request: LibraryCallRequest,
+    pub response: CallContractResponse,
+}
+
+#[derive(FieldOffsetGetters)]
 pub struct TxInfo {
     /// The version of the transaction. It is fixed (currently, 1) in the OS, and should be
     /// signed by the account contract.

--- a/src/hints/syscalls.rs
+++ b/src/hints/syscalls.rs
@@ -79,9 +79,7 @@ pub fn delegate_l1_handler(
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
-    syscall_handler.delegate_l1_handler(syscall_ptr);
-
-    Ok(())
+    execute_coroutine(syscall_handler.delegate_l1_handler(syscall_ptr, vm))?
 }
 
 pub const DEPLOY: &str = "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)";
@@ -262,9 +260,7 @@ pub fn library_call(
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
-    syscall_handler.library_call(syscall_ptr);
-
-    Ok(())
+    execute_coroutine(syscall_handler.library_call(syscall_ptr, vm))?
 }
 
 pub const LIBRARY_CALL_L1_HANDLER: &str =
@@ -280,9 +276,7 @@ pub fn library_call_l1_handler(
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
-    syscall_handler.library_call_l1_handler(syscall_ptr);
-
-    Ok(())
+    execute_coroutine(syscall_handler.library_call_l1_handler(syscall_ptr, vm))?
 }
 
 pub const REPLACE_CLASS: &str = "syscall_handler.replace_class(segments=segments, syscall_ptr=ids.syscall_ptr)";

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -3,3 +3,4 @@ mod declare_txn_tests;
 mod os;
 mod pie;
 mod sharp;
+mod syscalls_tests;

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -1,0 +1,114 @@
+use blockifier::abi::abi_utils::selector_from_name;
+use blockifier::context::BlockContext;
+use blockifier::invoke_tx_args;
+use blockifier::test_utils::{create_calldata, NonceManager};
+use blockifier::transaction::test_utils;
+use blockifier::transaction::test_utils::max_fee;
+use rstest::rstest;
+use starknet_api::hash::StarkFelt;
+use starknet_api::stark_felt;
+use starknet_api::transaction::{Fee, TransactionVersion};
+
+use crate::common::block_context;
+use crate::common::state::{initial_state_cairo1, initial_state_syscalls, StarknetTestState};
+use crate::common::transaction_utils::execute_txs_and_run_os;
+
+#[rstest]
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_syscall_library_call_cairo0(
+    #[future] initial_state_cairo1: StarknetTestState,
+    block_context: BlockContext,
+    max_fee: Fee,
+) {
+    let initial_state = initial_state_cairo1.await;
+
+    let tx_version = TransactionVersion::ZERO;
+    let mut nonce_manager = NonceManager::default();
+
+    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+
+    let contract_address = test_contract.address;
+
+    // Call the `return_result` method of the test contract class,
+    // i.e. the test contract will call its own class.
+    let test_contract_class_hash = test_contract.class_hash;
+    let selector_felt = selector_from_name("return_result");
+
+    let return_result_calldata = vec![stark_felt!(1u128), stark_felt!(42u128)];
+
+    let entrypoint_args = &[vec![test_contract_class_hash.0], vec![selector_felt.0], return_result_calldata].concat();
+
+    log::debug!("Entrypoint args: {entrypoint_args:?}");
+
+    let test_library_call = test_utils::account_invoke_tx(invoke_tx_args! {
+        max_fee,
+        sender_address: sender_address,
+        calldata: create_calldata(contract_address, "test_library_call", entrypoint_args),
+        version: tx_version,
+        nonce: nonce_manager.next(sender_address),
+    });
+
+    let txs = vec![test_library_call];
+
+    let _result = execute_txs_and_run_os(
+        initial_state.cached_state,
+        block_context,
+        txs,
+        initial_state.cairo0_compiled_classes,
+        initial_state.cairo1_compiled_classes,
+    )
+    .await
+    .expect("OS run failed");
+}
+
+#[rstest]
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_syscall_library_call_cairo1(
+    #[future] initial_state_syscalls: StarknetTestState,
+    block_context: BlockContext,
+    max_fee: Fee,
+) {
+    let initial_state = initial_state_syscalls.await;
+
+    let tx_version = TransactionVersion::ZERO;
+    let mut nonce_manager = NonceManager::default();
+
+    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.cairo1_contracts.get("test_contract").unwrap();
+
+    let contract_address = test_contract.address;
+
+    // Call the `return_result` method of the test contract class,
+    // i.e. the test contract will call its own class.
+    let test_contract_class_hash = test_contract.class_hash;
+    let selector_felt = selector_from_name("recurse");
+
+    let return_result_calldata = vec![stark_felt!(1u128), stark_felt!(42u128)];
+
+    let entrypoint_args = &[vec![test_contract_class_hash.0], vec![selector_felt.0], return_result_calldata].concat();
+
+    log::debug!("Entrypoint args: {entrypoint_args:?}");
+
+    let test_library_call = test_utils::account_invoke_tx(invoke_tx_args! {
+        max_fee,
+        sender_address: sender_address,
+        calldata: create_calldata(contract_address, "test_library_call", entrypoint_args),
+        version: tx_version,
+        nonce: nonce_manager.next(sender_address),
+    });
+
+    let txs = vec![test_library_call];
+
+    let _result = execute_txs_and_run_os(
+        initial_state.cached_state,
+        block_context,
+        txs,
+        initial_state.cairo0_compiled_classes,
+        initial_state.cairo1_compiled_classes,
+    )
+    .await
+    .expect("OS run failed");
+}


### PR DESCRIPTION
Added support and tests for the library_call syscall in deprecated and regular syscalls.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
