### PR TITLE
Feature: get block number and timestamp Cairo 0 syscalls

### DIFF
--- a/src/cairo_types/syscalls.rs
+++ b/src/cairo_types/syscalls.rs
@@ -52,6 +52,22 @@ pub struct CallContract {
 }
 
 #[derive(FieldOffsetGetters)]
+pub struct GetBlockNumberRequest {
+    pub selector: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct GetBlockNumberResponse {
+    pub block_number: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct GetBlockNumber {
+    pub request: GetBlockNumberRequest,
+    pub response: GetBlockNumberResponse,
+}
+
+#[derive(FieldOffsetGetters)]
 pub struct LibraryCallRequest {
     /// The system library call selector
     /// (= LIBRARY_CALL_SELECTOR or LIBRARY_CALL_L1_HANDLER_SELECTOR).

--- a/src/hints/syscalls.rs
+++ b/src/hints/syscalls.rs
@@ -128,9 +128,7 @@ pub fn get_block_number(
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
-    syscall_handler.get_block_number(syscall_ptr);
-
-    Ok(())
+    execute_coroutine(syscall_handler.get_block_number(syscall_ptr, vm))?
 }
 
 pub const GET_BLOCK_TIMESTAMP: &str =
@@ -146,9 +144,7 @@ pub fn get_block_timestamp(
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
-    syscall_handler.get_block_timestamp(syscall_ptr);
-
-    Ok(())
+    execute_coroutine(syscall_handler.get_block_timestamp(syscall_ptr, vm))?
 }
 
 pub const GET_CALLER_ADDRESS: &str =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,11 @@ pub fn run_os(
     let end = cairo_runner.initialize(allow_missing_builtins).map_err(|e| SnOsError::Runner(e.into()))?;
 
     // Setup Depsyscall Handler
-    let deprecated_syscall_handler =
-        DeprecatedOsSyscallHandlerWrapper::new(execution_helper.clone(), cairo_runner.vm.add_memory_segment());
+    let deprecated_syscall_handler = DeprecatedOsSyscallHandlerWrapper::new(
+        execution_helper.clone(),
+        cairo_runner.vm.add_memory_segment(),
+        block_context.block_info().clone(),
+    );
 
     let syscall_handler = OsSyscallHandlerWrapper::new(execution_helper.clone());
 

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -112,3 +112,79 @@ async fn test_syscall_library_call_cairo1(
     .await
     .expect("OS run failed");
 }
+
+#[rstest]
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_syscall_get_block_number_cairo0(
+    #[future] initial_state_cairo1: StarknetTestState,
+    block_context: BlockContext,
+    max_fee: Fee,
+) {
+    let initial_state = initial_state_cairo1.await;
+
+    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+
+    let expected_block_number = stark_felt!(block_context.block_info().block_number.0);
+
+    let tx_version = TransactionVersion::ZERO;
+    let mut nonce_manager = NonceManager::default();
+    let test_get_block_number = test_utils::account_invoke_tx(invoke_tx_args! {
+        max_fee,
+        sender_address: sender_address,
+        calldata: create_calldata(contract_address, "test_get_block_number", &[expected_block_number]),
+        version: tx_version,
+        nonce: nonce_manager.next(sender_address),
+    });
+
+    let txs = vec![test_get_block_number];
+
+    let _result = execute_txs_and_run_os(
+        initial_state.cached_state,
+        block_context,
+        txs,
+        initial_state.cairo0_compiled_classes,
+        initial_state.cairo1_compiled_classes,
+    )
+    .await
+    .expect("OS run failed");
+}
+
+#[rstest]
+// We need to use the multi_thread runtime to use task::block_in_place for sync -> async calls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_syscall_get_block_timestamp_cairo0(
+    #[future] initial_state_cairo1: StarknetTestState,
+    block_context: BlockContext,
+    max_fee: Fee,
+) {
+    let initial_state = initial_state_cairo1.await;
+
+    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+
+    let expected_block_timestamp = stark_felt!(block_context.block_info().block_timestamp.0);
+
+    let tx_version = TransactionVersion::ZERO;
+    let mut nonce_manager = NonceManager::default();
+    let test_get_block_timestamp = test_utils::account_invoke_tx(invoke_tx_args! {
+        max_fee,
+        sender_address: sender_address,
+        calldata: create_calldata(contract_address, "test_get_block_timestamp", &[expected_block_timestamp]),
+        version: tx_version,
+        nonce: nonce_manager.next(sender_address),
+    });
+
+    let txs = vec![test_get_block_timestamp];
+
+    let _result = execute_txs_and_run_os(
+        initial_state.cached_state,
+        block_context,
+        txs,
+        initial_state.cairo0_compiled_classes,
+        initial_state.cairo1_compiled_classes,
+    )
+    .await
+    .expect("OS run failed");
+}


### PR DESCRIPTION
We now store a copy of `BlockInfo` in the deprecated syscall handler.
This copy can probably be removed in favor of a `Rc` or a reference,
this is out of scope for this PR.

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
