### PR TITLE
Fix: load contract and class changes in OS output

### DIFF
--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -124,8 +124,8 @@ fn parse_contract_changes<I: Iterator<Item = Felt252>>(output_iter: &mut I) -> R
     let addr = next_or_fail(output_iter, "contract change addr")?;
     let class_nonce_n_changes = next_or_fail(output_iter, "contract change class_nonce_n_changes")?;
 
-    // unwrap() is safe here, we now the value is non zero.
-    let two_exp_64 = Felt252::from(1u128 << 64).try_into().unwrap();
+    let two_exp_64 =
+        Felt252::from(1u128 << 64).try_into().expect("2**64 should be considered non-zero. Did you change the value?");
     let (class_nonce, n_changes) = class_nonce_n_changes.div_rem(&two_exp_64);
     let (class_updated, nonce) = class_nonce.div_rem(&two_exp_64);
 
@@ -135,9 +135,8 @@ fn parse_contract_changes<I: Iterator<Item = Felt252>>(output_iter: &mut I) -> R
         None
     };
 
-    // unwrap() is safe because we know that n_changes fits in 64 bits by definition
-    // of the format above.
-    let n_changes = n_changes.to_usize().unwrap();
+    let n_changes =
+        n_changes.to_usize().expect("n_changes should be 64-bit by definition. Did you modify the parsing above?");
     let mut storage_changes = HashMap::with_capacity(n_changes);
 
     for i in 0..n_changes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub fn run_os(
     os_input: StarknetOsInput,
     block_context: BlockContext,
     execution_helper: ExecutionHelperWrapper,
-) -> Result<CairoPie, SnOsError> {
+) -> Result<(CairoPie, StarknetOsOutput), SnOsError> {
     // Init CairoRunConfig
     let cairo_run_config = CairoRunConfig { layout, relocate_mem: true, trace_enabled: true, ..Default::default() };
     let allow_missing_builtins = cairo_run_config.allow_missing_builtins.unwrap_or(false);
@@ -103,5 +103,5 @@ pub fn run_os(
     // Parse the Cairo VM output
     let pie = cairo_runner.get_cairo_pie().map_err(|e| SnOsError::PieParsing(format!("{e}")))?;
 
-    Ok(pie)
+    Ok((pie, os_output))
 }

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -17,6 +17,7 @@ use snos::error::SnOsError;
 use snos::error::SnOsError::Runner;
 use snos::execution::helper::ExecutionHelperWrapper;
 use snos::io::input::StarknetOsInput;
+use snos::io::output::StarknetOsOutput;
 use snos::io::InternalTransaction;
 use snos::starknet::business_logic::fact_state::state::SharedState;
 use snos::storage::dict_storage::DictStorage;
@@ -212,7 +213,7 @@ pub async fn execute_txs_and_run_os(
     txs: Vec<AccountTransaction>,
     deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
     contract_classes: HashMap<ClassHash, CasmContractClass>,
-) -> Result<CairoPie, SnOsError> {
+) -> Result<(CairoPie, StarknetOsOutput), SnOsError> {
     let (os_input, execution_helper) =
         execute_txs(state, &block_context, txs, deprecated_contract_classes, contract_classes).await;
 


### PR DESCRIPTION
Problem: the `contracts` and `classes` fields of the OS output are not deserialized correctly. We need to deserialize a full structure and not just felts.

Solution: add specific deserializers for contract and class changes. Additionally, add the OS output to the return value when running the OS in order to check specific output values in changes.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes, the OS output format changed.
- [ ] no
