### PR TITLE
Fix: remove `SharedState.block_info`

### DIFF
--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -69,9 +69,7 @@ async fn unpack_blockifier_state_async<S: Storage + Send + Sync, H: HashFunction
 ) -> Result<(SharedState<S, H>, SharedState<S, H>), TreeError> {
     let final_state = {
         let state = blockifier_state.state.clone();
-        let block_info = state.block_info.clone();
-        // TODO: block_info seems useless in SharedState, get rid of it
-        state.apply_commitment_state_diff(blockifier_state.to_state_diff(), block_info).await?
+        state.apply_commitment_state_diff(blockifier_state.to_state_diff()).await?
     };
 
     let initial_state = blockifier_state.state;

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -10,7 +10,6 @@ use cairo_lang_starknet_classes::contract_class::ContractClass;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::fixture;
-use snos::config::StarknetGeneralConfig;
 use snos::crypto::pedersen::PedersenHash;
 use snos::starknet::business_logic::fact_state::state::SharedState;
 use snos::starknet::business_logic::utils::{write_class_facts, write_deprecated_compiled_class_fact};
@@ -309,13 +308,7 @@ impl<'a> StarknetStateBuilder<'a> {
         dict_state_reader: DictStateReader,
         ffc: FactFetchingContext<DictStorage, PedersenHash>,
     ) -> Result<SharedState<DictStorage, PedersenHash>, TreeError> {
-        // Build the shared state object
-        // TODO: block info is not really needed in SharedState, it's a relic of the Python code.
-        //       check how it can be removed.
-        let block_info = Default::default();
-
-        let default_general_config = StarknetGeneralConfig::default(); // TODO
-        SharedState::from_blockifier_state(ffc, dict_state_reader, block_info, &default_general_config).await
+        SharedState::from_blockifier_state(ffc, dict_state_reader).await
     }
 
     /// Add a Cairo 0 contract to the test state.


### PR DESCRIPTION
Problem: the `SharedState` struct has a `BlockInfo` member that is unused. This field is a relic of `cairo-lang`.

Solution: remove the field.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
