### PR TITLE
Internal: move Blockifier compatibility from `SharedState` to `TestSharedState`

### DIFF
--- a/crates/starknet-os/src/starknet/business_logic/fact_state/mod.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/mod.rs
@@ -1,3 +1,4 @@
 pub mod contract_class_objects;
 pub mod contract_state_objects;
 pub mod state;
+pub mod test_shared_state;

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
@@ -1,8 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Deref;
 
 use blockifier::execution::contract_class::ContractClass;
-use blockifier::state::cached_state::CommitmentStateDiff;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
@@ -44,10 +43,7 @@ where
     /// Optional because some older states did not have class commitment.
     pub contract_classes: Option<PatriciaTree>,
     pub ffc: FactFetchingContext<S, H>,
-    ffc_for_class_hash: FactFetchingContext<S, PoseidonHash>,
-    /// Set of all the contracts in this state. Used to cache contract values to avoid
-    /// traversing the tree.
-    contract_addresses: HashSet<TreeIndex>,
+    pub ffc_for_class_hash: FactFetchingContext<S, PoseidonHash>,
 }
 
 // For some reason, derive(Clone) wants to have S: Clone and H: Clone.
@@ -63,7 +59,6 @@ where
             contract_classes: self.contract_classes.clone(),
             ffc: self.ffc.clone(),
             ffc_for_class_hash: self.ffc_for_class_hash.clone(),
-            contract_addresses: self.contract_addresses.clone(),
         }
     }
 }
@@ -106,13 +101,7 @@ where
             contract_classes: Some(empty_contract_classes),
             ffc,
             ffc_for_class_hash,
-            contract_addresses: Default::default(),
         })
-    }
-
-    /// Returns the set of all known contract addresses.
-    pub fn contract_addresses(&self) -> HashSet<TreeIndex> {
-        self.contract_addresses.clone()
     }
 
     /// Returns the state's contract class Patricia tree if it exists;
@@ -158,170 +147,6 @@ where
         // Return H(contract_state_root, contract_class_root, state_version).
         poseidon_hash_many_bytes(&[&Self::state_version().to_bytes_be(), contract_states_root, contract_classes_root])
             .map(|x| Felt252::from_bytes_be_slice(&x))
-    }
-
-    pub async fn from_blockifier_state(
-        ffc: FactFetchingContext<S, H>,
-        blockifier_state: blockifier::test_utils::dict_state_reader::DictStateReader,
-    ) -> Result<Self, TreeError> {
-        let empty_state = Self::empty(ffc).await?;
-
-        let mut storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StarkFelt>> = HashMap::new();
-        for ((address, key), value) in blockifier_state.storage_view {
-            storage_updates.entry(address).or_default().insert(key, value);
-        }
-
-        let shared_state = empty_state
-            .apply_state_updates_starknet_api(
-                blockifier_state.address_to_class_hash,
-                blockifier_state.address_to_nonce,
-                blockifier_state.class_hash_to_compiled_class_hash,
-                storage_updates,
-            )
-            .await?;
-
-        Ok(shared_state)
-    }
-
-    /// Updates the global state using a state diff generated with Blockifier.
-    pub async fn apply_commitment_state_diff(self, state_diff: CommitmentStateDiff) -> Result<Self, TreeError> {
-        // TODO: find a better solution than creating new hashmaps
-        self.apply_state_updates_starknet_api(
-            state_diff.address_to_class_hash.into_iter().collect(),
-            state_diff.address_to_nonce.into_iter().collect(),
-            state_diff.class_hash_to_compiled_class_hash.into_iter().collect(),
-            state_diff
-                .storage_updates
-                .into_iter()
-                .map(|(address, updates)| (address, updates.into_iter().collect()))
-                .collect(),
-        )
-        .await
-    }
-
-    /// A compatibility function to apply state updates specified in the Starknet API types.
-    async fn apply_state_updates_starknet_api(
-        self,
-        address_to_class_hash: HashMap<ContractAddress, ClassHash>,
-        address_to_nonce: HashMap<ContractAddress, Nonce>,
-        class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
-        storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StarkFelt>>,
-    ) -> Result<Self, TreeError> {
-        let address_to_class_hash: HashMap<_, _> = address_to_class_hash
-            .into_iter()
-            .map(|(address, class_hash)| (felt_api2vm(*address.0.key()), felt_api2vm(class_hash.0)))
-            .collect();
-
-        let address_to_nonce: HashMap<_, _> = address_to_nonce
-            .into_iter()
-            .map(|(address, nonce)| (felt_api2vm(*address.0.key()), felt_api2vm(nonce.0)))
-            .collect();
-
-        let class_hash_to_compiled_class_hash: HashMap<_, _> = class_hash_to_compiled_class_hash
-            .into_iter()
-            .map(|(class_hash, compiled_class_hash)| (felt_api2vm(class_hash.0), felt_api2vm(compiled_class_hash.0)))
-            .collect();
-
-        let storage_updates: HashMap<_, HashMap<_, _>> = storage_updates
-            .into_iter()
-            .map(|(address, contract_storage_updates)| {
-                (
-                    felt_api2vm(*address.0.key()),
-                    contract_storage_updates
-                        .into_iter()
-                        .map(|(k, v)| (felt_api2vm(*k.0.key()), felt_api2vm(v)))
-                        .collect(),
-                )
-            })
-            .collect();
-
-        self.apply_state_updates(
-            address_to_class_hash,
-            address_to_nonce,
-            class_hash_to_compiled_class_hash,
-            storage_updates,
-        )
-        .await
-    }
-
-    /// Applies state updates and recomputes the per-contract and global trees.
-    async fn apply_state_updates(
-        mut self,
-        address_to_class_hash: HashMap<Felt252, Felt252>,
-        address_to_nonce: HashMap<Felt252, Felt252>,
-        class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252>,
-        storage_updates: HashMap<Felt252, HashMap<Felt252, Felt252>>,
-    ) -> Result<Self, TreeError> {
-        let accessed_addresses_felts: HashSet<_> = address_to_class_hash
-            .keys()
-            // .chain(address_to_class_hash.values()) // TODO: should this be included?
-            .chain(address_to_nonce.keys())
-            .chain(storage_updates.keys())
-            .collect();
-        let accessed_addresses: Vec<TreeIndex> = accessed_addresses_felts.iter().map(|x| x.to_biguint()).collect();
-
-        let mut facts = None;
-        let mut current_contract_states: HashMap<TreeIndex, ContractState> =
-            self.contract_states.get_leaves(&mut self.ffc, &accessed_addresses, &mut facts).await?;
-
-        // Update contract storage roots with cached changes.
-        let empty_updates = HashMap::new();
-        let mut updated_contract_states = HashMap::new();
-        for address in accessed_addresses_felts {
-            // unwrap() is safe as an entry is guaranteed to be present with `get_leaves()`.
-            let tree_index = address.to_biguint();
-            let updates = storage_updates.get(address).unwrap_or(&empty_updates);
-            let nonce = address_to_nonce.get(address).cloned();
-            let class_hash = address_to_class_hash.get(address).cloned();
-            let updated_contract_state = current_contract_states
-                .remove(&tree_index)
-                .unwrap()
-                .update(&mut self.ffc, updates, nonce, class_hash)
-                .await?;
-
-            updated_contract_states.insert(tree_index, updated_contract_state);
-        }
-
-        // Apply contract changes on global root.
-        log::debug!("Updating contract state tree with {} modifications...", accessed_addresses.len());
-        let global_state_modifications: Vec<_> = updated_contract_states.into_iter().collect();
-        let updated_global_contract_root =
-            self.contract_states.update(&mut self.ffc, global_state_modifications, &mut facts).await?;
-
-        let mut ffc_for_contract_class = get_ffc_for_contract_class_facts(&self.ffc);
-
-        let updated_contract_classes = match self.contract_classes {
-            Some(tree) => {
-                log::debug!(
-                    "Updating contract class tree with {} modifications...",
-                    class_hash_to_compiled_class_hash.len()
-                );
-                let modifications: Vec<_> = class_hash_to_compiled_class_hash
-                    .into_iter()
-                    .map(|(key, value)| (key.to_biguint(), ContractClassLeaf::create(value)))
-                    .collect();
-                Some(tree.update(&mut ffc_for_contract_class, modifications, &mut facts).await?)
-            }
-            None => {
-                assert_eq!(
-                    class_hash_to_compiled_class_hash.len(),
-                    0,
-                    "contract_classes must be concrete before update."
-                );
-                None
-            }
-        };
-
-        let accessed_addresses: HashSet<_> = accessed_addresses.into_iter().collect();
-        let contract_addresses: HashSet<_> = self.contract_addresses.union(&accessed_addresses).cloned().collect();
-
-        Ok(Self {
-            contract_states: updated_global_contract_root,
-            contract_classes: updated_contract_classes,
-            ffc: self.ffc,
-            ffc_for_class_hash: self.ffc_for_class_hash,
-            contract_addresses,
-        })
     }
 
     async fn get_contract_state_async(&self, contract_address: ContractAddress) -> StateResult<ContractState> {

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/test_shared_state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/test_shared_state.rs
@@ -1,0 +1,263 @@
+use std::collections::{HashMap, HashSet};
+
+use blockifier::execution::contract_class::ContractClass;
+use blockifier::state::cached_state::CommitmentStateDiff;
+use blockifier::state::state_api::{StateReader, StateResult};
+use cairo_vm::Felt252;
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::hash::StarkFelt;
+use starknet_api::state::StorageKey;
+
+use crate::starknet::business_logic::fact_state::contract_class_objects::{
+    get_ffc_for_contract_class_facts, ContractClassLeaf,
+};
+use crate::starknet::business_logic::fact_state::contract_state_objects::ContractState;
+use crate::starknet::business_logic::fact_state::state::SharedState;
+use crate::starkware_utils::commitment_tree::base_types::TreeIndex;
+use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
+use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
+use crate::utils::felt_api2vm;
+
+#[derive(Debug)]
+/// A Starknet shared state compatible with Blockifier and with some caching features
+/// to make life easier during integration tests.
+pub struct TestSharedState<S, H>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + Send + Sync + 'static,
+{
+    /// The Starknet state.
+    shared_state: SharedState<S, H>,
+    /// Set of all the contracts in this state. Used to cache contract values and avoid
+    /// traversing the tree.
+    contract_addresses: HashSet<TreeIndex>,
+}
+
+// For some reason, derive(Clone) wants to have S: Clone and H: Clone.
+// There is no reason to require that, so we implement Clone manually.
+impl<S, H> Clone for TestSharedState<S, H>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self { shared_state: self.shared_state.clone(), contract_addresses: self.contract_addresses.clone() }
+    }
+}
+
+impl<S, H> TestSharedState<S, H>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + Send + Sync + 'static,
+{
+    pub fn ffc(&self) -> &FactFetchingContext<S, H> {
+        &self.shared_state.ffc
+    }
+
+    pub fn shared_state(&self) -> &SharedState<S, H> {
+        &self.shared_state
+    }
+
+    pub fn contract_addresses(&self) -> &HashSet<TreeIndex> {
+        &self.contract_addresses
+    }
+
+    pub async fn empty(ffc: FactFetchingContext<S, H>) -> Result<Self, TreeError> {
+        Ok(Self { shared_state: SharedState::empty(ffc).await?, contract_addresses: Default::default() })
+    }
+
+    pub async fn from_blockifier_state(
+        ffc: FactFetchingContext<S, H>,
+        blockifier_state: blockifier::test_utils::dict_state_reader::DictStateReader,
+    ) -> Result<Self, TreeError> {
+        let empty_state = Self::empty(ffc).await?;
+
+        let mut storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StarkFelt>> = HashMap::new();
+        for ((address, key), value) in blockifier_state.storage_view {
+            storage_updates.entry(address).or_default().insert(key, value);
+        }
+
+        let updated_state = empty_state
+            .apply_state_updates_starknet_api(
+                blockifier_state.address_to_class_hash,
+                blockifier_state.address_to_nonce,
+                blockifier_state.class_hash_to_compiled_class_hash,
+                storage_updates,
+            )
+            .await?;
+
+        Ok(updated_state)
+    }
+
+    /// Updates the global state using a state diff generated with Blockifier.
+    pub async fn apply_commitment_state_diff(self, state_diff: CommitmentStateDiff) -> Result<Self, TreeError> {
+        // TODO: find a better solution than creating new hashmaps
+        self.apply_state_updates_starknet_api(
+            state_diff.address_to_class_hash.into_iter().collect(),
+            state_diff.address_to_nonce.into_iter().collect(),
+            state_diff.class_hash_to_compiled_class_hash.into_iter().collect(),
+            state_diff
+                .storage_updates
+                .into_iter()
+                .map(|(address, updates)| (address, updates.into_iter().collect()))
+                .collect(),
+        )
+        .await
+    }
+
+    /// A compatibility function to apply state updates specified in the Starknet API types.
+    async fn apply_state_updates_starknet_api(
+        self,
+        address_to_class_hash: HashMap<ContractAddress, ClassHash>,
+        address_to_nonce: HashMap<ContractAddress, Nonce>,
+        class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
+        storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StarkFelt>>,
+    ) -> Result<Self, TreeError> {
+        let address_to_class_hash: HashMap<_, _> = address_to_class_hash
+            .into_iter()
+            .map(|(address, class_hash)| (felt_api2vm(*address.0.key()), felt_api2vm(class_hash.0)))
+            .collect();
+
+        let address_to_nonce: HashMap<_, _> = address_to_nonce
+            .into_iter()
+            .map(|(address, nonce)| (felt_api2vm(*address.0.key()), felt_api2vm(nonce.0)))
+            .collect();
+
+        let class_hash_to_compiled_class_hash: HashMap<_, _> = class_hash_to_compiled_class_hash
+            .into_iter()
+            .map(|(class_hash, compiled_class_hash)| (felt_api2vm(class_hash.0), felt_api2vm(compiled_class_hash.0)))
+            .collect();
+
+        let storage_updates: HashMap<_, HashMap<_, _>> = storage_updates
+            .into_iter()
+            .map(|(address, contract_storage_updates)| {
+                (
+                    felt_api2vm(*address.0.key()),
+                    contract_storage_updates
+                        .into_iter()
+                        .map(|(k, v)| (felt_api2vm(*k.0.key()), felt_api2vm(v)))
+                        .collect(),
+                )
+            })
+            .collect();
+
+        self.apply_state_updates(
+            address_to_class_hash,
+            address_to_nonce,
+            class_hash_to_compiled_class_hash,
+            storage_updates,
+        )
+        .await
+    }
+
+    /// Applies state updates and recomputes the per-contract and global trees.
+    async fn apply_state_updates(
+        self,
+        address_to_class_hash: HashMap<Felt252, Felt252>,
+        address_to_nonce: HashMap<Felt252, Felt252>,
+        class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252>,
+        storage_updates: HashMap<Felt252, HashMap<Felt252, Felt252>>,
+    ) -> Result<Self, TreeError> {
+        let accessed_addresses_felts: HashSet<_> = address_to_class_hash
+            .keys()
+            // .chain(address_to_class_hash.values()) // TODO: should this be included?
+            .chain(address_to_nonce.keys())
+            .chain(storage_updates.keys())
+            .collect();
+        let accessed_addresses: Vec<TreeIndex> = accessed_addresses_felts.iter().map(|x| x.to_biguint()).collect();
+
+        let mut facts = None;
+        let mut ffc = self.shared_state.ffc;
+        let mut current_contract_states: HashMap<TreeIndex, ContractState> =
+            self.shared_state.contract_states.get_leaves(&mut ffc, &accessed_addresses, &mut facts).await?;
+
+        // Update contract storage roots with cached changes.
+        let empty_updates = HashMap::new();
+        let mut updated_contract_states = HashMap::new();
+        for address in accessed_addresses_felts {
+            // unwrap() is safe as an entry is guaranteed to be present with `get_leaves()`.
+            let tree_index = address.to_biguint();
+            let updates = storage_updates.get(address).unwrap_or(&empty_updates);
+            let nonce = address_to_nonce.get(address).cloned();
+            let class_hash = address_to_class_hash.get(address).cloned();
+            let updated_contract_state = current_contract_states
+                .remove(&tree_index)
+                .unwrap()
+                .update(&mut ffc, updates, nonce, class_hash)
+                .await?;
+
+            updated_contract_states.insert(tree_index, updated_contract_state);
+        }
+
+        // Apply contract changes on global root.
+        log::debug!("Updating contract state tree with {} modifications...", accessed_addresses.len());
+        let global_state_modifications: Vec<_> = updated_contract_states.into_iter().collect();
+
+        let updated_global_contract_root =
+            self.shared_state.contract_states.update(&mut ffc, global_state_modifications, &mut facts).await?;
+
+        let mut ffc_for_contract_class = get_ffc_for_contract_class_facts(&ffc);
+
+        let updated_contract_classes = match self.shared_state.contract_classes {
+            Some(tree) => {
+                log::debug!(
+                    "Updating contract class tree with {} modifications...",
+                    class_hash_to_compiled_class_hash.len()
+                );
+                let modifications: Vec<_> = class_hash_to_compiled_class_hash
+                    .into_iter()
+                    .map(|(key, value)| (key.to_biguint(), ContractClassLeaf::create(value)))
+                    .collect();
+                Some(tree.update(&mut ffc_for_contract_class, modifications, &mut facts).await?)
+            }
+            None => {
+                assert_eq!(
+                    class_hash_to_compiled_class_hash.len(),
+                    0,
+                    "contract_classes must be concrete before update."
+                );
+                None
+            }
+        };
+
+        let accessed_addresses: HashSet<_> = accessed_addresses.into_iter().collect();
+        let contract_addresses: HashSet<_> = self.contract_addresses.union(&accessed_addresses).cloned().collect();
+
+        Ok(Self {
+            shared_state: SharedState {
+                contract_states: updated_global_contract_root,
+                contract_classes: updated_contract_classes,
+                ffc,
+                ffc_for_class_hash: ffc_for_contract_class,
+            },
+            contract_addresses,
+        })
+    }
+}
+
+impl<S, H> StateReader for TestSharedState<S, H>
+where
+    S: Storage + 'static,
+    H: HashFunctionType + Send + Sync + 'static,
+{
+    fn get_storage_at(&mut self, contract_address: ContractAddress, key: StorageKey) -> StateResult<StarkFelt> {
+        self.shared_state.get_storage_at(contract_address, key)
+    }
+
+    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+        self.shared_state.get_nonce_at(contract_address)
+    }
+
+    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+        self.shared_state.get_class_hash_at(contract_address)
+    }
+
+    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+        self.shared_state.get_compiled_contract_class(class_hash)
+    }
+
+    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+        self.shared_state.get_compiled_class_hash(class_hash)
+    }
+}

--- a/crates/starknet-os/src/storage/storage_utils.rs
+++ b/crates/starknet-os/src/storage/storage_utils.rs
@@ -6,7 +6,7 @@ use cairo_vm::Felt252;
 
 use crate::execution::helper::ContractStorageMap;
 use crate::starknet::business_logic::fact_state::contract_state_objects::ContractState;
-use crate::starknet::business_logic::fact_state::state::SharedState;
+use crate::starknet::business_logic::fact_state::test_shared_state::TestSharedState;
 use crate::starknet::starknet_storage::OsSingleStarknetStorage;
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
@@ -65,8 +65,8 @@ where
 }
 
 pub async fn unpack_blockifier_state_async<S: Storage + Send + Sync, H: HashFunctionType + Send + Sync>(
-    mut blockifier_state: CachedState<SharedState<S, H>>,
-) -> Result<(SharedState<S, H>, SharedState<S, H>), TreeError> {
+    mut blockifier_state: CachedState<TestSharedState<S, H>>,
+) -> Result<(TestSharedState<S, H>, TestSharedState<S, H>), TreeError> {
     let final_state = {
         let state = blockifier_state.state.clone();
         state.apply_commitment_state_diff(blockifier_state.to_state_diff()).await?
@@ -83,24 +83,27 @@ pub async fn unpack_blockifier_state_async<S: Storage + Send + Sync, H: HashFunc
 /// object. The initial state is obtained through this read-only view while the final storage
 /// is obtained by extracting the state diff from the `CachedState` part.
 pub async fn build_starknet_storage_async<S: Storage + Send + Sync, H: HashFunctionType + Send + Sync>(
-    blockifier_state: CachedState<SharedState<S, H>>,
-) -> Result<(ContractStorageMap<S, H>, SharedState<S, H>, SharedState<S, H>), TreeError> {
+    blockifier_state: CachedState<TestSharedState<S, H>>,
+) -> Result<(ContractStorageMap<S, H>, TestSharedState<S, H>, TestSharedState<S, H>), TreeError> {
     let mut storage_by_address = ContractStorageMap::new();
 
+    let (initial_state, final_state) = unpack_blockifier_state_async(blockifier_state).await?;
+
+    let all_contracts = final_state.contract_addresses().clone();
+    let mut ffc = final_state.ffc().clone();
+
     // TODO: would be cleaner if `get_leaf()` took &ffc instead of &mut ffc
-    let (mut initial_state, mut final_state) = unpack_blockifier_state_async(blockifier_state).await?;
-
-    let all_contracts = final_state.contract_addresses();
-
     for contract_address in all_contracts {
         let initial_contract_state: ContractState = initial_state
+            .shared_state()
             .contract_states
-            .get_leaf(&mut initial_state.ffc, contract_address.clone())
+            .get_leaf(&mut ffc, contract_address.clone())
             .await?
             .expect("There should be an initial state");
         let final_contract_state: ContractState = final_state
+            .shared_state()
             .contract_states
-            .get_leaf(&mut final_state.ffc, contract_address.clone())
+            .get_leaf(&mut ffc, contract_address.clone())
             .await?
             .expect("There should be a final state");
 
@@ -108,7 +111,7 @@ pub async fn build_starknet_storage_async<S: Storage + Send + Sync, H: HashFunct
         let updated_tree = final_contract_state.storage_commitment_tree;
 
         let contract_storage =
-            OsSingleStarknetStorage::new(initial_tree, updated_tree, &[], final_state.ffc.clone()).await.unwrap();
+            OsSingleStarknetStorage::new(initial_tree, updated_tree, &[], ffc.clone()).await.unwrap();
         storage_by_address.insert(Felt252::from(contract_address), contract_storage);
     }
 

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -19,7 +19,7 @@ use starknet_os::io::input::StarknetOsInput;
 use starknet_os::io::InternalTransaction;
 use starknet_os::starknet::business_logic::fact_state::contract_class_objects::ContractClassLeaf;
 use starknet_os::starknet::business_logic::fact_state::contract_state_objects::ContractState;
-use starknet_os::starknet::business_logic::fact_state::state::SharedState;
+use starknet_os::starknet::business_logic::fact_state::test_shared_state::TestSharedState;
 use starknet_os::starknet::starknet_storage::CommitmentInfo;
 use starknet_os::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use starknet_os::storage::storage::Storage;
@@ -30,7 +30,7 @@ use crate::common::transaction_utils::to_felt252;
 
 pub async fn os_hints<S>(
     block_context: &BlockContext,
-    mut blockifier_state: CachedState<SharedState<S, PedersenHash>>,
+    mut blockifier_state: CachedState<TestSharedState<S, PedersenHash>>,
     transactions: Vec<InternalTransaction>,
     tx_execution_infos: Vec<TransactionExecutionInfo>,
     deprecated_compiled_classes: HashMap<ClassHash, DeprecatedContractClass>,
@@ -40,6 +40,7 @@ where
     S: Storage,
 {
     let mut compiled_class_hash_to_compiled_class: HashMap<Felt252, CasmContractClass> = HashMap::new();
+    let mut ffc = blockifier_state.state.ffc().clone();
 
     let mut contracts: HashMap<Felt252, ContractState> = blockifier_state
         .state
@@ -49,7 +50,7 @@ where
             // TODO: biguint is exacerbating the type conversion problem, ideas...?
             let address: ContractAddress =
                 ContractAddress(PatriciaKey::try_from(felt_vm2api(Felt252::from(address_biguint))).unwrap());
-            let contract_state = blockifier_state.state.get_contract_state(address).unwrap();
+            let contract_state = blockifier_state.state.shared_state().get_contract_state(address).unwrap();
             (to_felt252(address.0.key()), contract_state)
         })
         .collect();
@@ -58,10 +59,7 @@ where
     let state_diff = blockifier_state.to_state_diff();
     let deployed_addresses = state_diff.address_to_class_hash;
     for (address, _class_hash) in &deployed_addresses {
-        contracts.insert(
-            to_felt252(address.0.key()),
-            ContractState::empty(Height(251), &mut blockifier_state.state.ffc).await.unwrap(),
-        );
+        contracts.insert(to_felt252(address.0.key()), ContractState::empty(Height(251), &mut ffc).await.unwrap());
     }
 
     // Initialize class_hash_to_compiled_class_hash with zero so that newly declared contracts
@@ -89,10 +87,8 @@ where
         };
     }
 
-    contracts
-        .insert(Felt252::from(0), ContractState::empty(Height(251), &mut blockifier_state.state.ffc).await.unwrap());
-    contracts
-        .insert(Felt252::from(1), ContractState::empty(Height(251), &mut blockifier_state.state.ffc).await.unwrap());
+    contracts.insert(Felt252::from(0), ContractState::empty(Height(251), &mut ffc).await.unwrap());
+    contracts.insert(Felt252::from(1), ContractState::empty(Height(251), &mut ffc).await.unwrap());
 
     log::debug!(
         "contracts: {:?}\ndeprecated_compiled_classes: {:?}",
@@ -131,8 +127,6 @@ where
         ..default_general_config
     };
 
-    let mut ffc = blockifier_state.state.ffc.clone();
-
     // Convert the Blockifier storage into an OS-compatible one
     let (contract_storage_map, previous_state, updated_state) =
         build_starknet_storage_async(blockifier_state).await.unwrap();
@@ -144,8 +138,8 @@ where
 
     let contract_state_commitment_info =
         CommitmentInfo::create_from_expected_updated_tree::<S, PedersenHash, ContractState>(
-            previous_state.contract_states.clone(),
-            updated_state.contract_states.clone(),
+            previous_state.shared_state().contract_states.clone(),
+            updated_state.shared_state().contract_states.clone(),
             &contract_indices,
             &mut ffc,
         )
@@ -161,8 +155,8 @@ where
 
     let contract_class_commitment_info =
         CommitmentInfo::create_from_expected_updated_tree::<S, PoseidonHash, ContractClassLeaf>(
-            previous_state.contract_classes.clone().expect("previous state should have class trie"),
-            updated_state.contract_classes.clone().expect("updated state should have class trie"),
+            previous_state.shared_state().contract_classes.clone().expect("previous state should have class trie"),
+            updated_state.shared_state().contract_classes.clone().expect("updated state should have class trie"),
             &accessed_contracts,
             &mut ffc.clone_with_different_hash::<PoseidonHash>(),
         )

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -15,7 +15,7 @@ use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiled
 use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
 use starknet_os::crypto::pedersen::PedersenHash;
-use starknet_os::starknet::business_logic::fact_state::state::SharedState;
+use starknet_os::starknet::business_logic::fact_state::test_shared_state::TestSharedState;
 use starknet_os::starknet::business_logic::utils::{write_class_facts, write_deprecated_compiled_class_fact};
 use starknet_os::starkware_utils::commitment_tree::errors::TreeError;
 use starknet_os::storage::dict_storage::DictStorage;
@@ -46,7 +46,7 @@ pub struct StarknetTestState {
     /// `declare_cairo1_contract`.
     pub declared_cairo1_contracts: HashMap<String, DeclaredContract>,
     /// State initially created for blockifier execution
-    pub cached_state: CachedState<SharedState<DictStorage, PedersenHash>>,
+    pub cached_state: CachedState<TestSharedState<DictStorage, PedersenHash>>,
     /// All cairo0 compiled classes
     pub cairo0_compiled_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
     /// All cairo1 compiled classes
@@ -60,7 +60,7 @@ impl StarknetTestState {
     where
         NH: HashFunctionType,
     {
-        self.cached_state.state.ffc.clone_with_different_hash::<NH>()
+        self.cached_state.state.ffc().clone_with_different_hash::<NH>()
     }
 }
 
@@ -478,8 +478,8 @@ impl<'a> StarknetStateBuilder<'a> {
     async fn build_shared_state(
         dict_state_reader: DictStateReader,
         ffc: FactFetchingContext<DictStorage, PedersenHash>,
-    ) -> Result<SharedState<DictStorage, PedersenHash>, TreeError> {
-        SharedState::from_blockifier_state(ffc, dict_state_reader).await
+    ) -> Result<TestSharedState<DictStorage, PedersenHash>, TreeError> {
+        TestSharedState::from_blockifier_state(ffc, dict_state_reader).await
     }
 
     /// Declare a Cairo 1 contract in the test state.

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -35,7 +35,7 @@ use starknet_os::execution::helper::ExecutionHelperWrapper;
 use starknet_os::io::input::StarknetOsInput;
 use starknet_os::io::output::StarknetOsOutput;
 use starknet_os::io::InternalTransaction;
-use starknet_os::starknet::business_logic::fact_state::state::SharedState;
+use starknet_os::starknet::business_logic::fact_state::test_shared_state::TestSharedState;
 use starknet_os::starknet::core::os::transaction_hash::{L1_GAS, L2_GAS};
 use starknet_os::storage::storage::Storage;
 use starknet_os::utils::felt_api2vm;
@@ -773,7 +773,7 @@ pub fn to_internal_deploy_v3_tx(
 }
 
 async fn execute_txs<S>(
-    mut state: CachedState<SharedState<S, PedersenHash>>,
+    mut state: CachedState<TestSharedState<S, PedersenHash>>,
     block_context: &BlockContext,
     txs: Vec<Transaction>,
     deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
@@ -813,7 +813,7 @@ where
 }
 
 pub async fn execute_txs_and_run_os<S>(
-    state: CachedState<SharedState<S, PedersenHash>>,
+    state: CachedState<TestSharedState<S, PedersenHash>>,
     block_context: BlockContext,
     txs: Vec<Transaction>,
     deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,

--- a/tests/integration/run_os.rs
+++ b/tests/integration/run_os.rs
@@ -26,7 +26,7 @@ use starknet_api::transaction::{
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::execution::helper::GenCallIter;
 use starknet_os::io::output::StarknetOsOutput;
-use starknet_os::starknet::business_logic::fact_state::state::SharedState;
+use starknet_os::starknet::business_logic::fact_state::test_shared_state::TestSharedState;
 use starknet_os::storage::dict_storage::DictStorage;
 use starknet_os::storage::storage_utils::{deprecated_contract_class_api2vm, unpack_blockifier_state_async};
 use starknet_os::utils::felt_api2vm;
@@ -482,7 +482,7 @@ fn add_declare_and_deploy_contract_txs(
 
 fn execute_transaction(
     tx: Transaction,
-    cached_state: &mut CachedState<SharedState<DictStorage, PedersenHash>>,
+    cached_state: &mut CachedState<TestSharedState<DictStorage, PedersenHash>>,
     block_context: &BlockContext,
 ) -> TransactionExecutionInfo {
     let tx_result = tx.execute(cached_state, block_context, true, true);


### PR DESCRIPTION
Problem: the `SharedState` struct currently has a `contract_addresses` hashset that maps all the contracts in the state. We do not want to require an exhaustive set of all contracts when using real block data from Pathfinder.

Solution: isolate the Blockifier-related code of `SharedState` (state diff application + type conversions) to a new `TestSharedState` struct dedicated to the task. `SharedState` is now a base struct that aims to be compatible with all use cases (transaction reexecution for tests, fetch the trees from an RPC for production).

Ultimately, the goal is to remove the dependency to Blockifier from the SNOS library and only use it for testing, or hide it behind a feature flag if this is somehow requested by users. 

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes, several methods are dropped from the `SharedState` API
- [ ] no
