### PR TITLE
Fix: Remove panicking `unwrap`s in hints execution

### DIFF
--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1522,9 +1522,7 @@ pub async fn write_syscall_result_async(
     execution_helper
         .write_storage_for_address(contract_address, storage_write_address, storage_write_value)
         .await
-        .map_err(|_| {
-            custom_hint_error(&format!("Storage not found for contract {}", contract_address))
-        })?;
+        .map_err(|_| custom_hint_error(&format!("Storage not found for contract {}", contract_address)))?;
 
     let contract_state_changes = get_ptr_from_var_name(vars::ids::CONTRACT_STATE_CHANGES, vm, ids_data, ap_tracking)?;
     get_state_entry_and_set_new_state_entry(

--- a/src/hints/execution.rs
+++ b/src/hints/execution.rs
@@ -1183,7 +1183,7 @@ async fn cache_contract_storage(
     let value = execution_helper
         .read_storage_for_address(contract_address, key)
         .await
-        .map_err(|_| custom_hint_error(&format!("No storage found for contract {}", contract_address)))?;
+        .map_err(|_| custom_hint_error(format!("No storage found for contract {}", contract_address)))?;
 
     let ids_value = get_integer_from_var_name(vars::ids::VALUE, vm, ids_data, ap_tracking)?;
     if ids_value != value {
@@ -1456,7 +1456,7 @@ pub async fn write_syscall_result_deprecated_async(
     let prev_value = execution_helper
         .read_storage_for_address(contract_address, storage_write_address)
         .await
-        .map_err(|_| custom_hint_error(&format!("Storage not found for contract {}", contract_address)))?;
+        .map_err(|_| custom_hint_error(format!("Storage not found for contract {}", contract_address)))?;
     insert_value_from_var_name(vars::ids::PREV_VALUE, prev_value, vm, ids_data, ap_tracking)?;
 
     // storage.write(key=ids.syscall_ptr.address, value=ids.syscall_ptr.value)
@@ -1464,7 +1464,7 @@ pub async fn write_syscall_result_deprecated_async(
     execution_helper
         .write_storage_for_address(contract_address, storage_write_address, storage_write_value)
         .await
-        .map_err(|_| custom_hint_error(&format!("Storage not found for contract {}", contract_address)))?;
+        .map_err(|_| custom_hint_error(format!("Storage not found for contract {}", contract_address)))?;
 
     let contract_state_changes = get_ptr_from_var_name(vars::ids::CONTRACT_STATE_CHANGES, vm, ids_data, ap_tracking)?;
     get_state_entry_and_set_new_state_entry(
@@ -1522,7 +1522,7 @@ pub async fn write_syscall_result_async(
     execution_helper
         .write_storage_for_address(contract_address, storage_write_address, storage_write_value)
         .await
-        .map_err(|_| custom_hint_error(&format!("Storage not found for contract {}", contract_address)))?;
+        .map_err(|_| custom_hint_error(format!("Storage not found for contract {}", contract_address)))?;
 
     let contract_state_changes = get_ptr_from_var_name(vars::ids::CONTRACT_STATE_CHANGES, vm, ids_data, ap_tracking)?;
     get_state_entry_and_set_new_state_entry(
@@ -1622,7 +1622,7 @@ pub async fn write_old_block_to_storage_async(
     execution_helper
         .write_storage_for_address(*block_hash_contract_address, old_block_number, old_block_hash)
         .await
-        .map_err(|_| custom_hint_error(&format!("Storage not found for contract {}", block_hash_contract_address)))?;
+        .map_err(|_| custom_hint_error(format!("Storage not found for contract {}", block_hash_contract_address)))?;
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -278,8 +278,8 @@ where
 }
 
 /// Builds a custom hint error
-pub fn custom_hint_error(error: &str) -> HintError {
-    HintError::CustomHint(error.to_string().into_boxed_str())
+pub fn custom_hint_error<S: Into<String>>(error: S) -> HintError {
+    HintError::CustomHint(error.into().into_boxed_str())
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -277,6 +277,11 @@ where
         .ok_or(HintError::VariableNotInScopeError(name.to_string().into_boxed_str()))
 }
 
+/// Builds a custom hint error
+pub fn custom_hint_error(error: &str) -> HintError {
+    HintError::CustomHint(error.to_string().into_boxed_str())
+}
+
 #[cfg(test)]
 mod tests {
     use bitvec::prelude::*;


### PR DESCRIPTION
Problem: Some hints would unwrap `Option`s instead of returning an error.

Solution: Replace unwraps with early error returns

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
