### PR TITLE
Internal: Clean up the transaction types passed to execution

### DIFF
--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -792,21 +792,15 @@ async fn execute_txs(
     os_hints(&block_context, state, internal_txs, execution_infos, deprecated_contract_classes, contract_classes).await
 }
 
-pub async fn execute_txs_and_run_os<T: Into<Transaction>>(
+pub async fn execute_txs_and_run_os(
     state: CachedState<SharedState<DictStorage, PedersenHash>>,
     block_context: BlockContext,
-    txs: Vec<T>,
+    txs: Vec<Transaction>,
     deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
     contract_classes: HashMap<ClassHash, CasmContractClass>,
 ) -> Result<(CairoPie, StarknetOsOutput), SnOsError> {
-    let (os_input, execution_helper) = execute_txs(
-        state,
-        &block_context,
-        txs.into_iter().map(Into::into).collect(),
-        deprecated_contract_classes,
-        contract_classes,
-    )
-    .await;
+    let (os_input, execution_helper) =
+        execute_txs(state, &block_context, txs, deprecated_contract_classes, contract_classes).await;
 
     let layout = config::default_layout();
     let result = run_os(config::DEFAULT_COMPILED_OS.to_string(), layout, os_input, block_context, execution_helper);

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -70,10 +70,11 @@ async fn declare_v3_cairo1_account(
         class_info,
     );
 
+    let txs = vec![declare_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![declare_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
@@ -127,10 +128,11 @@ async fn declare_cairo1_account(
         class_info,
     );
 
+    let txs = vec![declare_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![declare_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
@@ -172,10 +174,11 @@ async fn declare_v1_cairo0_account(
         class_info,
     );
 
+    let txs = vec![declare_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![declare_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )

--- a/tests/integration/deploy_txn_tests.rs
+++ b/tests/integration/deploy_txn_tests.rs
@@ -99,10 +99,11 @@ async fn deploy_cairo0_account(
         &mut nonce_manager,
     ));
 
+    let txs = vec![deploy_account_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![deploy_account_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
@@ -185,10 +186,11 @@ async fn deploy_cairo1_account(
         &mut nonce_manager,
     );
 
+    let txs = vec![AccountTransaction::DeployAccount(deploy_account_tx)].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![AccountTransaction::DeployAccount(deploy_account_tx)],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )

--- a/tests/integration/deprecated_syscalls_tests.rs
+++ b/tests/integration/deprecated_syscalls_tests.rs
@@ -14,6 +14,7 @@ use blockifier::test_utils::{create_calldata, NonceManager};
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::test_utils;
 use blockifier::transaction::test_utils::max_fee;
+use blockifier::transaction::transaction_execution::Transaction;
 use cairo_vm::Felt252;
 use num_traits::ToPrimitive;
 use rstest::rstest;
@@ -66,7 +67,7 @@ async fn test_syscall_library_call_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -106,7 +107,7 @@ async fn test_syscall_get_block_number_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -146,7 +147,7 @@ async fn test_syscall_get_block_timestamp_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -207,7 +208,7 @@ async fn test_syscall_get_tx_info_cairo0(
         AccountTransaction::Invoke(invoke_tx)
     };
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -267,7 +268,7 @@ async fn test_syscall_get_tx_signature_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -310,7 +311,7 @@ async fn test_syscall_replace_class_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     // TODO: use a different class hash and check that it is reflected in the OS output.
     let (_pie, _os_output) = execute_txs_and_run_os(
@@ -369,7 +370,7 @@ async fn test_syscall_deploy_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -420,7 +421,7 @@ async fn test_syscall_get_sequencer_address_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -475,7 +476,7 @@ async fn test_syscall_get_contract_address_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -526,7 +527,7 @@ async fn test_syscall_emit_event_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, _os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -573,7 +574,7 @@ async fn test_syscall_send_message_to_l1_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context.clone(),

--- a/tests/integration/deprecated_syscalls_tests.rs
+++ b/tests/integration/deprecated_syscalls_tests.rs
@@ -66,7 +66,7 @@ async fn test_syscall_library_call_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -106,7 +106,7 @@ async fn test_syscall_get_block_number_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -146,7 +146,7 @@ async fn test_syscall_get_block_timestamp_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -207,7 +207,7 @@ async fn test_syscall_get_tx_info_cairo0(
         AccountTransaction::Invoke(invoke_tx)
     };
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -267,7 +267,7 @@ async fn test_syscall_get_tx_signature_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -310,7 +310,7 @@ async fn test_syscall_replace_class_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     // TODO: use a different class hash and check that it is reflected in the OS output.
     let (_pie, _os_output) = execute_txs_and_run_os(
@@ -369,7 +369,7 @@ async fn test_syscall_deploy_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -420,7 +420,7 @@ async fn test_syscall_get_sequencer_address_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -475,7 +475,7 @@ async fn test_syscall_get_contract_address_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -526,7 +526,7 @@ async fn test_syscall_emit_event_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, _os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -573,7 +573,7 @@ async fn test_syscall_send_message_to_l1_cairo0(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context.clone(),

--- a/tests/integration/l1_handler_txn_tests.rs
+++ b/tests/integration/l1_handler_txn_tests.rs
@@ -61,10 +61,11 @@ async fn l1_handler<F>(
         },
         tx_hash: Default::default(),
     };
+    let txs = vec![l1_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![l1_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -41,10 +41,11 @@ async fn return_result_cairo0_account(
         nonce: nonce_manager.next(sender_address),
     });
 
+    let txs = vec![return_result_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![return_result_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
@@ -80,10 +81,11 @@ async fn return_result_cairo1_account(
         nonce: nonce_manager.next(sender_address),
     });
 
+    let txs = vec![return_result_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,
         block_context,
-        vec![return_result_tx],
+        txs,
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
     )
@@ -183,7 +185,10 @@ async fn syscalls_cairo1(
         test_get_block_hash_tx,
         test_send_message_to_l1_tx,
         test_deploy_tx,
-    ];
+    ]
+    .into_iter()
+    .map(Into::into)
+    .collect();
 
     let _result = execute_txs_and_run_os(
         initial_state.cached_state,

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -51,7 +51,7 @@ async fn test_syscall_library_call_cairo1(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -93,7 +93,7 @@ async fn test_syscall_replace_class_cairo1(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx];
+    let txs = vec![tx].into_iter().map(Into::into).collect();
 
     let (_pie, _os_output) = execute_txs_and_run_os(
         initial_state.cached_state,

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -4,6 +4,7 @@ use blockifier::invoke_tx_args;
 use blockifier::test_utils::{create_calldata, NonceManager};
 use blockifier::transaction::test_utils;
 use blockifier::transaction::test_utils::max_fee;
+use blockifier::transaction::transaction_execution::Transaction;
 use rstest::rstest;
 use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
@@ -51,7 +52,7 @@ async fn test_syscall_library_call_cairo1(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
         initial_state.cached_state,
@@ -93,7 +94,7 @@ async fn test_syscall_replace_class_cairo1(
         nonce: nonce_manager.next(sender_address),
     });
 
-    let txs = vec![tx].into_iter().map(Into::into).collect();
+    let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, _os_output) = execute_txs_and_run_os(
         initial_state.cached_state,


### PR DESCRIPTION
Problem: We need to be able to pass different types of txs as Transaction type

Solution: Pass the general type and convert

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
