### PR TITLE
Internal: simplify the Storage trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,28 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,7 +3424,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "async-stream",
  "base64 0.21.7",
  "bitvec",
  "blockifier",
@@ -3483,7 +3460,6 @@ dependencies = [
  "starknet_api",
  "thiserror",
  "tokio",
- "tokio-stream",
  "uuid",
  "zip",
 ]
@@ -3920,17 +3896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.75"
 assert_matches = "1.5.0"
-async-stream = "0.3.5"
 base64 = "0.21.3"
 bitvec = { version = "1.0.1", features = ["serde"] }
 blockifier = { git = "https://github.com/Moonsong-Labs/blockifier", branch = "msl/derive-clone", features = ["testing"] }
@@ -41,7 +40,6 @@ starknet_api = { version = "=0.10", features = ["testing"] }
 starknet-crypto = "0.6.2"
 thiserror = "1.0.48"
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
-tokio-stream = "0.1.14"
 uuid = { version = "1.4.0", features = ["v4", "serde"] }
 zip = { version = "0.6.6", features = ["deflate-zlib"] }
 

--- a/src/storage/dict_storage.rs
+++ b/src/storage/dict_storage.rs
@@ -16,11 +16,8 @@ impl Storage for DictStorage {
         Ok(())
     }
 
-    fn get_value<K: AsRef<[u8]>>(
-        &self,
-        key: K,
-    ) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send {
-        let result = Ok(self.db.get(key.as_ref()).cloned());
+    fn get_value(&self, key: &[u8]) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send {
+        let result = Ok(self.db.get(key).cloned());
         async move { result }.boxed()
     }
 }
@@ -43,12 +40,12 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_get_value(#[from(storage_with_values)] storage: DictStorage) {
-        assert_eq!(Some(vec![0, 0, 1, 1, 0]), storage.get_value(vec![0]).await.unwrap());
-        assert_eq!(Some(vec![1, 1, 1]), storage.get_value(vec![1]).await.unwrap());
-        assert_eq!(Some(vec![255, 254, 253]), storage.get_value(vec![2]).await.unwrap());
+        assert_eq!(Some(vec![0, 0, 1, 1, 0]), storage.get_value(&[0]).await.unwrap());
+        assert_eq!(Some(vec![1, 1, 1]), storage.get_value(&[1]).await.unwrap());
+        assert_eq!(Some(vec![255, 254, 253]), storage.get_value(&[2]).await.unwrap());
 
-        assert_eq!(None, storage.get_value(vec![3]).await.unwrap());
-        assert_eq!(None, storage.get_value(vec![0, 1, 2]).await.unwrap());
+        assert_eq!(None, storage.get_value(&[3]).await.unwrap());
+        assert_eq!(None, storage.get_value(&[0, 1, 2]).await.unwrap());
     }
 
     #[rstest]
@@ -58,12 +55,12 @@ mod tests {
         let value = vec![7; 7];
 
         storage.set_value(key.clone(), value.clone()).await.unwrap();
-        assert_eq!(Some(value), storage.get_value(key).await.unwrap());
+        assert_eq!(Some(value), storage.get_value(&key).await.unwrap());
 
         // Overwrite an existing value
         let key = vec![2];
         let value = vec![8; 8];
         storage.set_value(key.clone(), value.clone()).await.unwrap();
-        assert_eq!(Some(value), storage.get_value(key).await.unwrap());
+        assert_eq!(Some(value), storage.get_value(&key).await.unwrap());
     }
 }

--- a/src/storage/dict_storage.rs
+++ b/src/storage/dict_storage.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use async_stream::stream;
-use futures_util::{FutureExt, Stream};
+use futures_util::FutureExt;
 
 use crate::storage::storage::{Storage, StorageError};
 
@@ -24,39 +23,11 @@ impl Storage for DictStorage {
         let result = Ok(self.db.get(key.as_ref()).cloned());
         async move { result }.boxed()
     }
-
-    async fn has_key<K: AsRef<[u8]>>(&self, key: K) -> bool {
-        self.db.contains_key(key.as_ref())
-    }
-
-    async fn del_value<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), StorageError> {
-        self.db.remove(key.as_ref());
-        Ok(())
-    }
-
-    async fn mset(&mut self, updates: HashMap<Vec<u8>, Vec<u8>>) -> Result<(), StorageError> {
-        for (key, value) in updates {
-            self.db.insert(key, value);
-        }
-        Ok(())
-    }
-    fn mget<K, I>(&self, keys: I) -> impl Stream<Item = Result<Option<Vec<u8>>, StorageError>>
-    where
-        K: AsRef<[u8]>,
-        I: Iterator<Item = K>,
-    {
-        stream! {
-            for key in keys {
-                yield Ok(self.db.get(key.as_ref()).cloned())
-            }
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use rstest::{fixture, rstest};
-    use tokio_stream::StreamExt;
 
     use super::*;
 
@@ -67,17 +38,6 @@ mod tests {
         let storage = DictStorage { db };
 
         storage
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_has_key(#[from(storage_with_values)] storage: DictStorage) {
-        assert!(storage.has_key(vec![0]).await);
-        assert!(storage.has_key(vec![1]).await);
-        assert!(storage.has_key(vec![2]).await);
-
-        assert!(!storage.has_key(vec![3]).await);
-        assert!(!storage.has_key(vec![0, 1, 2]).await);
     }
 
     #[rstest]
@@ -105,57 +65,5 @@ mod tests {
         let value = vec![8; 8];
         storage.set_value(key.clone(), value.clone()).await.unwrap();
         assert_eq!(Some(value), storage.get_value(key).await.unwrap());
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_del_value(#[from(storage_with_values)] mut storage: DictStorage) {
-        // Delete existing key
-        let key = vec![2];
-        storage.del_value(&key).await.unwrap();
-        assert_eq!(None, storage.get_value(&key).await.unwrap());
-
-        // Delete nonexistent key
-        let key = vec![1, 2, 3, 4];
-        storage.del_value(&key).await.unwrap();
-        assert_eq!(None, storage.get_value(&key).await.unwrap());
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_mset(#[from(storage_with_values)] mut storage: DictStorage) {
-        let mut old_values = storage.db.clone();
-        let new_values = HashMap::from([(vec![1, 2, 3, 4], vec![3; 3]), (vec![3], vec![32]), (vec![0], vec![0; 100])]);
-        storage.mset(new_values.clone()).await.unwrap();
-
-        for (key, value) in new_values.iter() {
-            assert_eq!(Some(value), storage.get_value(key).await.unwrap().as_ref());
-        }
-
-        // Check that the previous values (minus the ones that were replaced) are still present
-        let remaining_values = {
-            for key in new_values.keys() {
-                old_values.remove(key);
-            }
-            old_values
-        };
-        for (key, value) in remaining_values {
-            assert_eq!(Some(value), storage.get_value(key).await.unwrap());
-        }
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_mget(#[from(storage_with_values)] storage: DictStorage) {
-        let storage_content = storage.db.clone();
-
-        let keys = storage_content.keys();
-        let values: Vec<_> = storage.mget(keys.clone()).collect().await;
-
-        assert_eq!(keys.len(), values.len());
-        for (key, value) in keys.zip(values) {
-            let value = value.unwrap();
-            assert_eq!(value, storage_content.get(key).cloned());
-        }
     }
 }

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -38,10 +38,7 @@ impl From<StorageError> for StateError {
 pub trait Storage: Sync + Send {
     async fn set_value(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), StorageError>;
 
-    fn get_value<K: AsRef<[u8]>>(
-        &self,
-        key: K,
-    ) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send;
+    fn get_value(&self, key: &[u8]) -> impl futures::Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send;
 }
 
 /// Starknet hash type.
@@ -162,7 +159,7 @@ pub trait DbObject: Serializable {
     ) -> impl futures::Future<Output = Result<Option<Self>, StorageError>> + Send {
         async move {
             let key = Self::db_key(suffix);
-            match storage.get_value(key).await {
+            match storage.get_value(&key).await {
                 Ok(Some(data)) => {
                     let value = Self::deserialize(&data)?;
                     Ok(Some(value))


### PR DESCRIPTION
Numerous methods of the trait are unused, and the API of `get_value` leaves to be desired when implementing complex storage types.

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes
- [ ] no
