### PR TITLE
Internal: fix CI tests by pinning sympy version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - run: |
-          pip install cairo-lang==0.13.1a0
+      - name: "Run tests"
+        run: |
+          # We need to pin the version of sympy, 1.13.0 is incompatible with cairo-lang
+          pip install cairo-lang==0.13.1a0 "sympy<1.13.0"
           bash ./scripts/reset-tests.sh
           RUSTFLAGS="-D warnings" cargo test
 


### PR DESCRIPTION
Problem: sympy v1.13.0 moves some functions around, making it
incompatible with cairo-lang 0.13.1.

Solution: pin the version to any version before 1.13.0.

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [x] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
