### PR TITLE
Internal: declare contracts in test states

### DIFF
--- a/tests/integration/deploy_txn_tests.rs
+++ b/tests/integration/deploy_txn_tests.rs
@@ -59,8 +59,8 @@ pub async fn initial_state_for_deploy_v1(
     .expect("Failed to calculate the contract address");
 
     let state = StarknetStateBuilder::new(&block_context)
-        .add_cairo0_contract(account_with_dummy_validate.0, account_with_dummy_validate.1)
-        .add_cairo0_contract(account_with_long_validate.0, account_with_long_validate.1)
+        .deploy_cairo0_contract(account_with_dummy_validate.0, account_with_dummy_validate.1)
+        .deploy_cairo0_contract(account_with_long_validate.0, account_with_long_validate.1)
         .fund_account(deployed_contract_address, BALANCE, BALANCE)
         .set_default_balance(BALANCE, BALANCE)
         .build()
@@ -142,12 +142,16 @@ pub async fn initial_state_for_deploy_v3(
     .expect("Failed to calculate the contract address");
 
     let state = StarknetStateBuilder::new(&block_context)
-        .add_cairo1_contract(
+        .deploy_cairo1_contract(
             account_with_dummy_validate.0,
             account_with_dummy_validate.1,
             account_with_dummy_validate.2,
         )
-        .add_cairo1_contract(account_with_long_validate.0, account_with_long_validate.1, account_with_long_validate.2)
+        .deploy_cairo1_contract(
+            account_with_long_validate.0,
+            account_with_long_validate.1,
+            account_with_long_validate.2,
+        )
         .fund_account(deployed_contract_address, BALANCE, BALANCE)
         .set_default_balance(BALANCE, BALANCE)
         .build()


### PR DESCRIPTION
Problem: for advanced integration tests, we need a way to add declared contracts to a test state without deploying them.

Solution: add two methods to declare Cairo 0/1 contracts in `StarknetStateBuilder`. Renamed the "add_*" methods to "deploy_*" to emphasize the difference.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [x] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
