### PR TITLE
Internal: support giving names to declared contracts in tests

### DIFF
--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -36,7 +36,7 @@ async fn declare_v3_cairo1_account(
     let tx_version = TransactionVersion::THREE;
     let mut nonce_manager = NonceManager::default();
 
-    let account_contract = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap();
+    let account_contract = initial_state.deployed_cairo1_contracts.get("account_with_dummy_validate").unwrap();
 
     // We want to declare a fresh (never-before-declared) contract, so we don't want to reuse
     // anything from the test fixtures, and we need to do it "by hand". The transaction will
@@ -95,7 +95,7 @@ async fn declare_cairo1_account(
     let tx_version = TransactionVersion::TWO;
     let mut nonce_manager = NonceManager::default();
 
-    let account_contract = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap();
+    let account_contract = initial_state.deployed_cairo1_contracts.get("account_with_dummy_validate").unwrap();
 
     // We want to declare a fresh (never-before-declared) contract, so we don't want to reuse
     // anything from the test fixtures, and we need to do it "by hand". The transaction will
@@ -152,14 +152,14 @@ async fn declare_v1_cairo0_account(
 
     let mut nonce_manager = NonceManager::default();
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
 
     let tx_version = TransactionVersion::ONE;
 
-    let class_hash = test_contract.class_hash;
+    let class_hash = test_contract.declaration.class_hash;
 
-    let class = deprecated_contract_class_api2vm(&test_contract.class).unwrap();
+    let class = deprecated_contract_class_api2vm(&test_contract.declaration.class).unwrap();
 
     let class_info = calculate_class_info_for_testing(class);
 

--- a/tests/integration/deploy_txn_tests.rs
+++ b/tests/integration/deploy_txn_tests.rs
@@ -81,9 +81,9 @@ async fn deploy_cairo0_account(
     let tx_version = TransactionVersion::ONE;
     let mut nonce_manager = NonceManager::default();
 
-    let account_with_long_validate = initial_state.cairo0_contracts.get("account_with_long_validate").unwrap();
+    let account_with_long_validate = initial_state.deployed_cairo0_contracts.get("account_with_long_validate").unwrap();
 
-    let deployed_account_class_hash = account_with_long_validate.class_hash;
+    let deployed_account_class_hash = account_with_long_validate.declaration.class_hash;
     // Sanity check, as we hardcode the class hash in the fixture we verify that we have
     // the right one.
     assert_eq!(deploy_args.class_hash, deployed_account_class_hash);
@@ -172,9 +172,9 @@ async fn deploy_cairo1_account(
 
     let tx_version = TransactionVersion::THREE;
     let mut nonce_manager = NonceManager::default();
-    let account_with_long_validate = initial_state.cairo1_contracts.get("account_with_long_validate").unwrap();
+    let account_with_long_validate = initial_state.deployed_cairo1_contracts.get("account_with_long_validate").unwrap();
 
-    let deployed_account_class_hash = account_with_long_validate.class_hash;
+    let deployed_account_class_hash = account_with_long_validate.declaration.class_hash;
     // Sanity check, as we hardcode the class hash in the fixture we verify that we have
     // the right one.
     assert_eq!(deploy_args.class_hash, deployed_account_class_hash);

--- a/tests/integration/deprecated_syscalls_tests.rs
+++ b/tests/integration/deprecated_syscalls_tests.rs
@@ -43,14 +43,14 @@ async fn test_syscall_library_call_cairo0(
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
 
     let contract_address = test_contract.address;
 
     // Call the `return_result` method of the test contract class,
     // i.e. the test contract will call its own class.
-    let test_contract_class_hash = test_contract.class_hash;
+    let test_contract_class_hash = test_contract.declaration.class_hash;
     let selector_felt = selector_from_name("return_result");
 
     let return_result_calldata = vec![stark_felt!(1u128), stark_felt!(42u128)];
@@ -92,8 +92,8 @@ async fn test_syscall_get_block_number_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let expected_block_number = stark_felt!(block_context.block_info().block_number.0);
 
@@ -132,8 +132,8 @@ async fn test_syscall_get_block_timestamp_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let expected_block_timestamp = stark_felt!(block_context.block_info().block_timestamp.0);
 
@@ -172,8 +172,8 @@ async fn test_syscall_get_tx_info_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let tx_version = TransactionVersion::ZERO;
 
@@ -253,8 +253,8 @@ async fn test_syscall_get_tx_signature_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let tx_version = TransactionVersion::ZERO;
 
@@ -293,14 +293,14 @@ async fn test_syscall_replace_class_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
     let contract_address = test_contract.address;
 
     let tx_version = TransactionVersion::ZERO;
 
     // We just test that the replace_class syscall goes through. Just use the same class hash.
-    let class_hash = test_contract.class_hash;
+    let class_hash = test_contract.declaration.class_hash;
 
     let mut nonce_manager = NonceManager::default();
     let tx = test_utils::account_invoke_tx(invoke_tx_args! {
@@ -335,13 +335,13 @@ async fn test_syscall_deploy_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
     let contract_address = test_contract.address;
 
     let tx_version = TransactionVersion::ZERO;
 
-    let class_hash = test_contract.class_hash;
+    let class_hash = test_contract.declaration.class_hash;
 
     let contract_address_salt = ContractAddressSalt::default();
     let constructor_args = vec![StarkFelt::from(100u64), StarkFelt::from(200u64)];
@@ -355,7 +355,7 @@ async fn test_syscall_deploy_cairo0(
 
     let expected_contract_address = calculate_contract_address(
         contract_address_salt,
-        test_contract.class_hash,
+        test_contract.declaration.class_hash,
         &Calldata(constructor_args.into()),
         contract_address,
     )
@@ -406,8 +406,8 @@ async fn test_syscall_get_sequencer_address_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let tx_version = TransactionVersion::ZERO;
     let expected_sequencer_address = block_context.block_info().sequencer_address;
@@ -446,11 +446,11 @@ async fn test_syscall_get_contract_address_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
     let contract_address = test_contract.address;
 
-    let class_hash = test_contract.class_hash;
+    let class_hash = test_contract.declaration.class_hash;
 
     let contract_address_salt = ContractAddressSalt::default();
     let constructor_args = vec![StarkFelt::from(100u64), StarkFelt::from(200u64)];
@@ -503,8 +503,8 @@ async fn test_syscall_emit_event_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
     let contract_address = test_contract.address;
 
     let tx_version = TransactionVersion::ZERO;
@@ -550,8 +550,8 @@ async fn test_syscall_send_message_to_l1_cairo0(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo0_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap();
     let contract_address = test_contract.address;
 
     // test constants

--- a/tests/integration/l1_handler_txn_tests.rs
+++ b/tests/integration/l1_handler_txn_tests.rs
@@ -20,7 +20,7 @@ async fn l1_initial_state_cairo1(
     #[from(init_logging)] _logging: (),
 ) -> (StarknetTestState, ContractAddress) {
     let state = initial_state_syscalls(block_context, ()).await;
-    let contract_address = state.cairo1_contracts.get("test_contract").unwrap().address;
+    let contract_address = state.deployed_cairo1_contracts.get("test_contract").unwrap().address;
     (state, contract_address)
 }
 
@@ -30,7 +30,7 @@ async fn l1_initial_state_cairo0(
     #[from(init_logging)] _logging: (),
 ) -> (StarknetTestState, ContractAddress) {
     let state = initial_state_cairo0(block_context, ()).await;
-    let contract_address = state.cairo0_contracts.get("test_contract").unwrap().address;
+    let contract_address = state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
     (state, contract_address)
 }
 

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -23,8 +23,8 @@ async fn return_result_cairo0_account(
 ) {
     let initial_state = initial_state_cairo0.await;
 
-    let sender_address = initial_state.cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo0_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
@@ -66,8 +66,8 @@ async fn return_result_cairo1_account(
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
 
-    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo0_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo0_contracts.get("test_contract").unwrap().address;
 
     let return_result_tx = test_utils::account_invoke_tx(invoke_tx_args! {
         max_fee,
@@ -107,8 +107,8 @@ async fn syscalls_cairo1(
     let initial_state = initial_state_syscalls.await;
     let mut nonce_manager = NonceManager::default();
 
-    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
-    let contract_address = initial_state.cairo1_contracts.get("test_contract").unwrap().address;
+    let sender_address = initial_state.deployed_cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let contract_address = initial_state.deployed_cairo1_contracts.get("test_contract").unwrap().address;
 
     // test_emit_event
     let keys = vec![stark_felt!(2019_u16), stark_felt!(2020_u16)];
@@ -161,7 +161,8 @@ async fn syscalls_cairo1(
     });
 
     // test_deploy
-    let test_contract_class_hash = initial_state.cairo1_contracts.get("test_contract").unwrap().class_hash.0;
+    let test_contract_class_hash =
+        initial_state.deployed_cairo1_contracts.get("test_contract").unwrap().declaration.class_hash.0;
     let entrypoint_args = &[
         test_contract_class_hash, // class hash
         stark_felt!(255_u8),      // contract_address_salt

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -28,14 +28,14 @@ async fn test_syscall_library_call_cairo1(
     let tx_version = TransactionVersion::ZERO;
     let mut nonce_manager = NonceManager::default();
 
-    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo1_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo1_contracts.get("test_contract").unwrap();
 
     let contract_address = test_contract.address;
 
     // Call the `return_result` method of the test contract class,
     // i.e. the test contract will call its own class.
-    let test_contract_class_hash = test_contract.class_hash;
+    let test_contract_class_hash = test_contract.declaration.class_hash;
     let selector_felt = selector_from_name("recurse");
 
     let return_result_calldata = vec![stark_felt!(1u128), stark_felt!(42u128)];
@@ -77,13 +77,13 @@ async fn test_syscall_replace_class_cairo1(
 ) {
     let initial_state = initial_state_syscalls.await;
 
-    let sender_address = initial_state.cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
-    let test_contract = initial_state.cairo1_contracts.get("test_contract").unwrap();
+    let sender_address = initial_state.deployed_cairo1_contracts.get("account_with_dummy_validate").unwrap().address;
+    let test_contract = initial_state.deployed_cairo1_contracts.get("test_contract").unwrap();
     let contract_address = test_contract.address;
 
     let tx_version = TransactionVersion::ZERO;
 
-    let class_hash = test_contract.class_hash;
+    let class_hash = test_contract.declaration.class_hash;
 
     let mut nonce_manager = NonceManager::default();
     let tx = test_utils::account_invoke_tx(invoke_tx_args! {


### PR DESCRIPTION
Problem: when declaring contracts with the state builder, there is no easy way to find the declared contracts from the test state.

Solution: reproduce what is done for deployed contracts, give the user the ability to define a name for each declared contract.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [x] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
