### PR TITLE
Chore: bump cairo-vm to 1.0.0-rc5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,8 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.0-rc5"
-source = "git+https://github.com/lambdaclass/cairo-vm#309c8a7d3cdfd0bb766b4888be66ec4b482ecaf4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09134ea1e0be6c1fbd330f0945df0512fa70944fd0b3ecc2f74a6008f01e9da"
 dependencies = [
  "anyhow",
  "ark-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cairo-lang-starknet = { version = "2.6.3" }
 cairo-lang-starknet-classes = { version = "2.6.3" }
 cairo-lang-casm = { version = "2.6.3" }
 cairo-type-derive = { version = "0.1.0", path = "cairo-type-derive" }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", features = ["extensive_hints", "cairo-1-hints"] }
+cairo-vm = { version = "1.0.0-rc5", features = ["extensive_hints", "cairo-1-hints"] }
 env_logger = "0.11.3"
 futures = "0.3.30"
 futures-util = "0.3.30"

--- a/bin/hint_tool/Cargo.toml
+++ b/bin/hint_tool/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 blockifier = { git = "https://github.com/Moonsong-Labs/blockifier", branch = "msl/derive-clone", features = ["testing"] }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", features = ["extensive_hints", "cairo-1-hints"] }
+cairo-vm = { version = "1.0.0-rc5", features = ["extensive_hints", "cairo-1-hints"] }
 clap = { version = "4.5.4", features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = { version = "1.0.105", features = ["arbitrary_precision"] }


### PR DESCRIPTION
A release candidate finally incorporates all our changes, so we can stop using the git repository (at least for now).

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [x] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
