### PR TITLE
Feature: make the OS generic on the storage type

### DIFF
--- a/crates/bin/hint_tool/src/main.rs
+++ b/crates/bin/hint_tool/src/main.rs
@@ -14,6 +14,7 @@ use cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager;
 use clap::Parser;
 use serde::Deserialize;
 use starknet_os::hints::SnosHintProcessor;
+use starknet_os::storage::dict_storage::DictStorage;
 
 #[derive(Clone, Copy, Debug, Default, clap::ValueEnum, PartialEq)]
 enum HintFilter {
@@ -71,7 +72,7 @@ fn main() -> std::io::Result<()> {
     let args = Args::parse();
     let subset = args.subset.unwrap_or_default();
 
-    let mut hint_processor = SnosHintProcessor::default();
+    let mut hint_processor = SnosHintProcessor::<DictStorage>::default();
     let snos_hints = hint_processor.hints();
 
     let mut result = Vec::new();

--- a/crates/starknet-os/src/execution/helper.rs
+++ b/crates/starknet-os/src/execution/helper.rs
@@ -16,15 +16,17 @@ use tokio::sync::RwLock;
 use crate::config::STORED_BLOCK_HASH_BUFFER;
 use crate::crypto::pedersen::PedersenHash;
 use crate::starknet::starknet_storage::{CommitmentInfo, CommitmentInfoError, OsSingleStarknetStorage};
-use crate::storage::dict_storage::DictStorage;
-use crate::storage::storage::StorageError;
+use crate::storage::storage::{Storage, StorageError};
 
 // TODO: make the execution helper generic over the storage and hash function types.
 pub type ContractStorageMap<S, H> = HashMap<Felt252, OsSingleStarknetStorage<S, H>>;
 
 /// Maintains the info for executing txns in the OS
 #[derive(Debug)]
-pub struct ExecutionHelper {
+pub struct ExecutionHelper<S>
+where
+    S: Storage,
+{
     pub _prev_block_context: Option<BlockContext>,
     // Pointer tx execution info
     pub tx_execution_info_iter: IntoIter<TransactionExecutionInfo>,
@@ -51,19 +53,31 @@ pub struct ExecutionHelper {
     // Iter to the read_values array consumed when tx code is executed
     pub execute_code_read_iter: IntoIter<Felt252>,
     // Per-contract storage
-    pub storage_by_address: ContractStorageMap<DictStorage, PedersenHash>,
+    pub storage_by_address: ContractStorageMap<S, PedersenHash>,
 }
 
 /// ExecutionHelper is wrapped in Rc<RefCell<_>> in order
 /// to clone the refrence when entering and exiting vm scopes
-#[derive(Clone, Debug)]
-pub struct ExecutionHelperWrapper {
-    pub execution_helper: Rc<RwLock<ExecutionHelper>>,
+#[derive(Debug)]
+pub struct ExecutionHelperWrapper<S: Storage> {
+    pub execution_helper: Rc<RwLock<ExecutionHelper<S>>>,
 }
 
-impl ExecutionHelperWrapper {
+impl<S> Clone for ExecutionHelperWrapper<S>
+where
+    S: Storage,
+{
+    fn clone(&self) -> Self {
+        Self { execution_helper: self.execution_helper.clone() }
+    }
+}
+
+impl<S> ExecutionHelperWrapper<S>
+where
+    S: Storage + 'static,
+{
     pub fn new(
-        contract_storage_map: ContractStorageMap<DictStorage, PedersenHash>,
+        contract_storage_map: ContractStorageMap<S, PedersenHash>,
         tx_execution_infos: Vec<TransactionExecutionInfo>,
         block_context: &BlockContext,
         old_block_number_and_hash: (Felt252, Felt252),
@@ -212,7 +226,6 @@ impl ExecutionHelperWrapper {
 
         let mut commitments = HashMap::new();
         for (key, storage) in storage_by_address.iter_mut() {
-            log::debug!("key: {} ({})", key.to_hex_string(), key.to_string());
             let commitment_info = storage.compute_commitment().await?;
             commitments.insert(*key, commitment_info);
         }
@@ -221,7 +234,7 @@ impl ExecutionHelperWrapper {
     }
 }
 
-fn assert_iterators_exhausted(eh_ref: &ExecutionHelper) {
+fn assert_iterators_exhausted<S: Storage>(eh_ref: &ExecutionHelper<S>) {
     assert!(eh_ref.deployed_contracts_iter.clone().peekable().peek().is_none());
     assert!(eh_ref.result_iter.clone().peekable().peek().is_none());
     assert!(eh_ref.execute_code_read_iter.clone().peekable().peek().is_none());

--- a/crates/starknet-os/src/execution/helper.rs
+++ b/crates/starknet-os/src/execution/helper.rs
@@ -234,7 +234,10 @@ where
     }
 }
 
-fn assert_iterators_exhausted<S: Storage>(eh_ref: &ExecutionHelper<S>) {
+fn assert_iterators_exhausted<S>(eh_ref: &ExecutionHelper<S>)
+where
+    S: Storage,
+{
     assert!(eh_ref.deployed_contracts_iter.clone().peekable().peek().is_none());
     assert!(eh_ref.result_iter.clone().peekable().peek().is_none());
     assert!(eh_ref.execute_code_read_iter.clone().peekable().peek().is_none());

--- a/crates/starknet-os/src/execution/syscall_handler.rs
+++ b/crates/starknet-os/src/execution/syscall_handler.rs
@@ -18,25 +18,41 @@ use crate::execution::syscall_handler_utils::{
     felt_from_ptr, run_handler, write_felt, write_maybe_relocatable, write_segment, EmptyRequest, EmptyResponse,
     ReadOnlySegment, SyscallExecutionError, SyscallHandler, SyscallResult, SyscallSelector, WriteResponseResult,
 };
+use crate::storage::storage::Storage;
 use crate::utils::felt_api2vm;
 
 /// DeprecatedSyscallHandler implementation for execution of system calls in the StarkNet OS
 #[derive(Debug)]
-pub struct OsSyscallHandler {
-    pub exec_wrapper: ExecutionHelperWrapper,
+pub struct OsSyscallHandler<S: Storage>
+where
+    S: Storage,
+{
+    pub exec_wrapper: ExecutionHelperWrapper<S>,
     pub syscall_ptr: Option<Relocatable>,
     pub segments: ReadOnlySegments,
 }
 
 /// OsSyscallHandler is wrapped in Rc<RefCell<_>> in order
 /// to clone the reference when entering and exiting vm scopes
-#[derive(Clone, Debug)]
-pub struct OsSyscallHandlerWrapper {
-    pub syscall_handler: Rc<RwLock<OsSyscallHandler>>,
+#[derive(Debug)]
+pub struct OsSyscallHandlerWrapper<S>
+where
+    S: Storage,
+{
+    pub syscall_handler: Rc<RwLock<OsSyscallHandler<S>>>,
 }
 
-impl OsSyscallHandlerWrapper {
-    pub fn new(exec_wrapper: ExecutionHelperWrapper) -> Self {
+impl<S> Clone for OsSyscallHandlerWrapper<S>
+where
+    S: Storage,
+{
+    fn clone(&self) -> Self {
+        Self { syscall_handler: self.syscall_handler.clone() }
+    }
+}
+
+impl<S: Storage + 'static> OsSyscallHandlerWrapper<S> {
+    pub fn new(exec_wrapper: ExecutionHelperWrapper<S>) -> Self {
         Self {
             syscall_handler: Rc::new(RwLock::new(OsSyscallHandler {
                 exec_wrapper,
@@ -75,33 +91,33 @@ impl OsSyscallHandlerWrapper {
 
         match selector {
             SyscallSelector::CallContract => {
-                run_handler::<CallContractHandler>(ptr, vm, ehw, CALL_CONTRACT_GAS_COST).await
+                run_handler::<CallContractHandler, S>(ptr, vm, ehw, CALL_CONTRACT_GAS_COST).await
             }
-            SyscallSelector::Deploy => run_handler::<DeployHandler>(ptr, vm, ehw, DEPLOY_GAS_COST).await,
-            SyscallSelector::EmitEvent => run_handler::<EmitEventHandler>(ptr, vm, ehw, EMIT_EVENT_GAS_COST).await,
+            SyscallSelector::Deploy => run_handler::<DeployHandler, S>(ptr, vm, ehw, DEPLOY_GAS_COST).await,
+            SyscallSelector::EmitEvent => run_handler::<EmitEventHandler, S>(ptr, vm, ehw, EMIT_EVENT_GAS_COST).await,
             SyscallSelector::GetBlockHash => {
-                run_handler::<GetBlockHashHandler>(ptr, vm, ehw, GET_BLOCK_HASH_GAS_COST).await
+                run_handler::<GetBlockHashHandler, S>(ptr, vm, ehw, GET_BLOCK_HASH_GAS_COST).await
             }
             SyscallSelector::LibraryCall => {
-                run_handler::<LibraryCallHandler>(ptr, vm, ehw, LIBRARY_CALL_GAS_COST).await
+                run_handler::<LibraryCallHandler, S>(ptr, vm, ehw, LIBRARY_CALL_GAS_COST).await
             }
             SyscallSelector::GetExecutionInfo => {
-                run_handler::<GetExecutionInfoHandler>(ptr, vm, ehw, GET_EXECUTION_INFO_GAS_COST).await
+                run_handler::<GetExecutionInfoHandler, S>(ptr, vm, ehw, GET_EXECUTION_INFO_GAS_COST).await
             }
             SyscallSelector::StorageRead => {
-                run_handler::<StorageReadHandler>(ptr, vm, ehw, STORAGE_READ_GAS_COST).await
+                run_handler::<StorageReadHandler, S>(ptr, vm, ehw, STORAGE_READ_GAS_COST).await
             }
             SyscallSelector::StorageWrite => {
-                run_handler::<StorageWriteHandler>(ptr, vm, ehw, STORAGE_WRITE_GAS_COST).await
+                run_handler::<StorageWriteHandler, S>(ptr, vm, ehw, STORAGE_WRITE_GAS_COST).await
             }
             SyscallSelector::SendMessageToL1 => {
-                run_handler::<SendMessageToL1Handler>(ptr, vm, ehw, SEND_MESSAGE_TO_L1_GAS_COST).await
+                run_handler::<SendMessageToL1Handler, S>(ptr, vm, ehw, SEND_MESSAGE_TO_L1_GAS_COST).await
             }
             SyscallSelector::ReplaceClass => {
-                run_handler::<ReplaceClassHandler>(ptr, vm, ehw, REPLACE_CLASS_GAS_COST).await
+                run_handler::<ReplaceClassHandler, S>(ptr, vm, ehw, REPLACE_CLASS_GAS_COST).await
             }
             SyscallSelector::LibraryCallL1Handler => {
-                run_handler::<LibraryCallHandler>(ptr, vm, ehw, LIBRARY_CALL_GAS_COST).await
+                run_handler::<LibraryCallHandler, S>(ptr, vm, ehw, LIBRARY_CALL_GAS_COST).await
             }
             _ => Err(HintError::CustomHint(format!("Unknown syscall selector: {:?}", selector).into())),
         }?;
@@ -122,10 +138,10 @@ impl SyscallHandler for CallContractHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: EmptyRequest,
         vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
     ) -> SyscallResult<ReadOnlySegment> {
         let mut eh_ref = exec_wrapper.execution_helper.write().await;
@@ -172,10 +188,10 @@ impl SyscallHandler for DeployHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: Self::Request,
         vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         let mut execution_helper = exec_wrapper.execution_helper.write().await;
@@ -223,10 +239,10 @@ impl SyscallHandler for EmitEventHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
-        _exec_wrapper: &mut ExecutionHelperWrapper,
+        _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         Ok(crate::execution::syscall_handler_utils::EmptyResponse {})
@@ -260,10 +276,10 @@ impl SyscallHandler for GetBlockHashHandler {
         Ok(GetBlockHashRequest { block_number })
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         request: GetBlockHashRequest,
         _vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         // # The syscall handler should not directly read from the storage during the execution of
@@ -297,10 +313,10 @@ impl SyscallHandler for GetExecutionInfoHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         let eh_ref = exec_wrapper.execution_helper.read().await;
@@ -325,10 +341,10 @@ impl SyscallHandler for LibraryCallHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: Self::Request,
         vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         let mut eh_ref = exec_wrapper.execution_helper.write().await;
@@ -366,10 +382,10 @@ impl SyscallHandler for ReplaceClassHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
-        _exec_wrapper: &mut ExecutionHelperWrapper,
+        _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         Ok(crate::execution::syscall_handler_utils::EmptyResponse {})
@@ -395,10 +411,10 @@ impl SyscallHandler for SendMessageToL1Handler {
         Ok(EmptyRequest)
     }
 
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
-        _exec_wrapper: &mut ExecutionHelperWrapper,
+        _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response> {
         Ok(crate::execution::syscall_handler_utils::EmptyResponse {})
@@ -430,10 +446,10 @@ impl SyscallHandler for StorageReadHandler {
         *ptr = (*ptr + new_syscalls::StorageReadRequest::cairo_size())?;
         Ok(EmptyRequest)
     }
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: EmptyRequest,
         _vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<StorageReadResponse> {
         let mut eh_ref = exec_wrapper.execution_helper.write().await;
@@ -466,10 +482,10 @@ impl SyscallHandler for StorageWriteHandler {
         *ptr = (*ptr + new_syscalls::StorageWriteRequest::cairo_size())?;
         Ok(EmptyRequest)
     }
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         _request: EmptyRequest,
         _vm: &mut VirtualMachine,
-        _exec_wrapper: &mut ExecutionHelperWrapper,
+        _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
     ) -> SyscallResult<EmptyResponse> {
         Ok(EmptyResponse {})

--- a/crates/starknet-os/src/execution/syscall_handler.rs
+++ b/crates/starknet-os/src/execution/syscall_handler.rs
@@ -51,7 +51,10 @@ where
     }
 }
 
-impl<S: Storage + 'static> OsSyscallHandlerWrapper<S> {
+impl<S> OsSyscallHandlerWrapper<S>
+where
+    S: Storage + 'static,
+{
     pub fn new(exec_wrapper: ExecutionHelperWrapper<S>) -> Self {
         Self {
             syscall_handler: Rc::new(RwLock::new(OsSyscallHandler {
@@ -138,12 +141,15 @@ impl SyscallHandler for CallContractHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: EmptyRequest,
         vm: &mut VirtualMachine,
         exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
-    ) -> SyscallResult<ReadOnlySegment> {
+    ) -> SyscallResult<ReadOnlySegment>
+    where
+        S: Storage + 'static,
+    {
         let mut eh_ref = exec_wrapper.execution_helper.write().await;
         let result_iter = &mut eh_ref.result_iter;
         let result = result_iter
@@ -188,12 +194,15 @@ impl SyscallHandler for DeployHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: Self::Request,
         vm: &mut VirtualMachine,
         exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response> {
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static,
+    {
         let mut execution_helper = exec_wrapper.execution_helper.write().await;
 
         let result = execution_helper
@@ -239,12 +248,15 @@ impl SyscallHandler for EmitEventHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
         _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response> {
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static,
+    {
         Ok(crate::execution::syscall_handler_utils::EmptyResponse {})
     }
 
@@ -313,12 +325,15 @@ impl SyscallHandler for GetExecutionInfoHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
         exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response> {
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static,
+    {
         let eh_ref = exec_wrapper.execution_helper.read().await;
         let execution_info_ptr = eh_ref.call_execution_info_ptr.unwrap();
         Ok(GetExecutionInfoResponse { execution_info_ptr })
@@ -341,12 +356,15 @@ impl SyscallHandler for LibraryCallHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: Self::Request,
         vm: &mut VirtualMachine,
         exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response> {
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static,
+    {
         let mut eh_ref = exec_wrapper.execution_helper.write().await;
         let result_iter = &mut eh_ref.result_iter;
         let result = result_iter
@@ -382,12 +400,15 @@ impl SyscallHandler for ReplaceClassHandler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
         _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response> {
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static,
+    {
         Ok(crate::execution::syscall_handler_utils::EmptyResponse {})
     }
 
@@ -411,12 +432,15 @@ impl SyscallHandler for SendMessageToL1Handler {
         Ok(EmptyRequest)
     }
 
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: Self::Request,
         _vm: &mut VirtualMachine,
         _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response> {
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static,
+    {
         Ok(crate::execution::syscall_handler_utils::EmptyResponse {})
     }
 
@@ -446,12 +470,15 @@ impl SyscallHandler for StorageReadHandler {
         *ptr = (*ptr + new_syscalls::StorageReadRequest::cairo_size())?;
         Ok(EmptyRequest)
     }
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: EmptyRequest,
         _vm: &mut VirtualMachine,
         exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
-    ) -> SyscallResult<StorageReadResponse> {
+    ) -> SyscallResult<StorageReadResponse>
+    where
+        S: Storage + 'static,
+    {
         let mut eh_ref = exec_wrapper.execution_helper.write().await;
 
         let value = eh_ref.execute_code_read_iter.next().ok_or(HintError::SyscallError(
@@ -482,12 +509,15 @@ impl SyscallHandler for StorageWriteHandler {
         *ptr = (*ptr + new_syscalls::StorageWriteRequest::cairo_size())?;
         Ok(EmptyRequest)
     }
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         _request: EmptyRequest,
         _vm: &mut VirtualMachine,
         _exec_wrapper: &mut ExecutionHelperWrapper<S>,
         _remaining_gas: &mut u64,
-    ) -> SyscallResult<EmptyResponse> {
+    ) -> SyscallResult<EmptyResponse>
+    where
+        S: Storage + 'static,
+    {
         Ok(EmptyResponse {})
     }
     fn write_response(

--- a/crates/starknet-os/src/execution/syscall_handler_utils.rs
+++ b/crates/starknet-os/src/execution/syscall_handler_utils.rs
@@ -227,12 +227,14 @@ pub trait SyscallHandler {
     type Request;
     type Response;
     fn read_request(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<Self::Request>;
-    async fn execute<S: Storage + 'static>(
+    async fn execute<S>(
         request: Self::Request,
         vm: &mut VirtualMachine,
         exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
-    ) -> SyscallResult<Self::Response>;
+    ) -> SyscallResult<Self::Response>
+    where
+        S: Storage + 'static;
     fn write_response(response: Self::Response, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult;
 }
 
@@ -259,12 +261,16 @@ fn write_failure(
 
 pub const OUT_OF_GAS_ERROR: &str = "0x000000000000000000000000000000000000000000004f7574206f6620676173";
 
-pub async fn run_handler<SH: SyscallHandler, S: Storage + 'static>(
+pub async fn run_handler<SH, S>(
     syscall_ptr: &mut Relocatable,
     vm: &mut VirtualMachine,
     exec_wrapper: &mut ExecutionHelperWrapper<S>,
     syscall_gas_cost: u64,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    SH: SyscallHandler,
+    S: Storage + 'static,
+{
     // Refund `SYSCALL_BASE_GAS_COST` as it was pre-charged.
     let required_gas = syscall_gas_cost - SYSCALL_BASE_GAS_COST;
 

--- a/crates/starknet-os/src/execution/syscall_handler_utils.rs
+++ b/crates/starknet-os/src/execution/syscall_handler_utils.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::execution::constants::SYSCALL_BASE_GAS_COST;
 use crate::execution::helper::ExecutionHelperWrapper;
-use crate::storage::storage::StorageError;
+use crate::storage::storage::{Storage, StorageError};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SyscallSelector {
@@ -227,10 +227,10 @@ pub trait SyscallHandler {
     type Request;
     type Response;
     fn read_request(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<Self::Request>;
-    async fn execute(
+    async fn execute<S: Storage + 'static>(
         request: Self::Request,
         vm: &mut VirtualMachine,
-        exec_wrapper: &mut ExecutionHelperWrapper,
+        exec_wrapper: &mut ExecutionHelperWrapper<S>,
         remaining_gas: &mut u64,
     ) -> SyscallResult<Self::Response>;
     fn write_response(response: Self::Response, vm: &mut VirtualMachine, ptr: &mut Relocatable) -> WriteResponseResult;
@@ -259,10 +259,10 @@ fn write_failure(
 
 pub const OUT_OF_GAS_ERROR: &str = "0x000000000000000000000000000000000000000000004f7574206f6620676173";
 
-pub async fn run_handler<S: SyscallHandler>(
+pub async fn run_handler<SH: SyscallHandler, S: Storage + 'static>(
     syscall_ptr: &mut Relocatable,
     vm: &mut VirtualMachine,
-    exec_wrapper: &mut ExecutionHelperWrapper,
+    exec_wrapper: &mut ExecutionHelperWrapper<S>,
     syscall_gas_cost: u64,
 ) -> Result<(), HintError> {
     // Refund `SYSCALL_BASE_GAS_COST` as it was pre-charged.
@@ -281,19 +281,19 @@ pub async fn run_handler<S: SyscallHandler>(
         return Ok(());
     }
 
-    let request = S::read_request(vm, syscall_ptr)?;
+    let request = SH::read_request(vm, syscall_ptr)?;
 
     // Execute.
     let mut remaining_gas = gas_counter - required_gas;
 
-    let syscall_result = S::execute(request, vm, exec_wrapper, &mut remaining_gas).await;
+    let syscall_result = SH::execute(request, vm, exec_wrapper, &mut remaining_gas).await;
 
     match syscall_result {
         Ok(response) => {
             write_felt(vm, syscall_ptr, Felt252::from(remaining_gas))?;
             // 0 to indicate success.
             write_felt(vm, syscall_ptr, Felt252::ZERO)?;
-            S::write_response(response, vm, syscall_ptr)?
+            SH::write_response(response, vm, syscall_ptr)?
         }
         Err(SyscallExecutionError::SyscallError { error_data: data }) => {
             write_failure(remaining_gas, data, vm, syscall_ptr)?;

--- a/crates/starknet-os/src/hints/execute_transactions.rs
+++ b/crates/starknet-os/src/hints/execute_transactions.rs
@@ -12,6 +12,7 @@ use indoc::indoc;
 use crate::cairo_types::structs::ExecutionContext;
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::hints::vars;
+use crate::storage::storage::Storage;
 use crate::utils::execute_coroutine;
 
 pub const START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = indoc! {r#"
@@ -19,13 +20,13 @@ pub const START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = indoc! {r#"
         tx_info_ptr=ids.validate_declare_execution_context.deprecated_tx_info.address_
     )"#
 };
-pub async fn start_tx_validate_declare_execution_context_async(
+pub async fn start_tx_validate_declare_execution_context_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let execution_context_ptr =
         get_relocatable_from_var_name(vars::ids::VALIDATE_DECLARE_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
     let deprecated_tx_info_ptr = (execution_context_ptr + ExecutionContext::deprecated_tx_info_offset())?;
@@ -35,12 +36,12 @@ pub async fn start_tx_validate_declare_execution_context_async(
     Ok(())
 }
 
-pub fn start_tx_validate_declare_execution_context(
+pub fn start_tx_validate_declare_execution_context<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(start_tx_validate_declare_execution_context_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(start_tx_validate_declare_execution_context_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }

--- a/crates/starknet-os/src/hints/execute_transactions.rs
+++ b/crates/starknet-os/src/hints/execute_transactions.rs
@@ -20,12 +20,15 @@ pub const START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = indoc! {r#"
         tx_info_ptr=ids.validate_declare_execution_context.deprecated_tx_info.address_
     )"#
 };
-pub async fn start_tx_validate_declare_execution_context_async<S: Storage + 'static>(
+pub async fn start_tx_validate_declare_execution_context_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let execution_context_ptr =
         get_relocatable_from_var_name(vars::ids::VALIDATE_DECLARE_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
@@ -36,12 +39,15 @@ pub async fn start_tx_validate_declare_execution_context_async<S: Storage + 'sta
     Ok(())
 }
 
-pub fn start_tx_validate_declare_execution_context<S: Storage + 'static>(
+pub fn start_tx_validate_declare_execution_context<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(start_tx_validate_declare_execution_context_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -187,13 +187,16 @@ pub fn assert_transaction_hash(
 
 pub const ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER: &str =
     "vm_enter_scope({'syscall_handler': deprecated_syscall_handler})";
-pub fn enter_scope_deprecated_syscall_handler<S: Storage + 'static>(
+pub fn enter_scope_deprecated_syscall_handler<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let dep_sys = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?;
     let deprecated_syscall_handler: Box<dyn Any> = Box::new(dep_sys);
     exec_scopes
@@ -202,13 +205,16 @@ pub fn enter_scope_deprecated_syscall_handler<S: Storage + 'static>(
 }
 
 pub const ENTER_SCOPE_SYSCALL_HANDLER: &str = "vm_enter_scope({'syscall_handler': syscall_handler})";
-pub fn enter_scope_syscall_handler<S: Storage + 'static>(
+pub fn enter_scope_syscall_handler<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let sys = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_handler: Box<dyn Any> = Box::new(sys);
     exec_scopes.enter_scope(HashMap::from_iter([(String::from(vars::scopes::SYSCALL_HANDLER), syscall_handler)]));
@@ -417,13 +423,16 @@ pub const ENTER_SYSCALL_SCOPES: &str = indoc! {r#"
          '__dict_manager': __dict_manager,
     })"#
 };
-pub fn enter_syscall_scopes<S: Storage + 'static>(
+pub fn enter_syscall_scopes<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let os_input = exec_scopes.get::<StarknetOsInput>(vars::scopes::OS_INPUT)?;
     let deprecated_class_hashes: Box<dyn Any> =
         Box::new(exec_scopes.get::<HashSet<Felt252>>(vars::scopes::DEPRECATED_CLASS_HASHES)?);
@@ -447,19 +456,25 @@ pub fn enter_syscall_scopes<S: Storage + 'static>(
 }
 
 pub const END_TX: &str = "execution_helper.end_tx()";
-pub async fn end_tx_async<S: Storage + 'static>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+pub async fn end_tx_async<S>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.end_tx().await;
     Ok(())
 }
 
-pub fn end_tx<S: Storage + 'static>(
+pub fn end_tx<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(end_tx_async::<S>(exec_scopes))?
 }
 
@@ -467,12 +482,15 @@ pub const ENTER_CALL: &str = indoc! {r#"
     execution_helper.enter_call(
         execution_info_ptr=ids.execution_context.execution_info.address_)"#
 };
-pub async fn enter_call_async<S: Storage + 'static>(
+pub async fn enter_call_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let execution_info_ptr = vm.get_relocatable(
         (get_ptr_from_var_name(vars::ids::EXECUTION_CONTEXT, vm, ids_data, ap_tracking)? + 4i32).unwrap(),
     )?;
@@ -482,30 +500,39 @@ pub async fn enter_call_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn enter_call<S: Storage + 'static>(
+pub fn enter_call<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(enter_call_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const EXIT_CALL: &str = "execution_helper.exit_call()";
-pub async fn exit_call_async<S: Storage + 'static>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+pub async fn exit_call_async<S>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.exit_call().await;
     Ok(())
 }
 
-pub fn exit_call<S: Storage + 'static>(
+pub fn exit_call<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(exit_call_async::<S>(exec_scopes))?
 }
 
@@ -835,12 +862,15 @@ pub const START_TX: &str = indoc! {r#"
     tx_info_ptr = ids.tx_execution_context.deprecated_tx_info.address_
     execution_helper.start_tx(tx_info_ptr=tx_info_ptr)"#
 };
-pub async fn start_tx_async<S: Storage + 'static>(
+pub async fn start_tx_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let tx_execution_context = get_ptr_from_var_name(vars::ids::TX_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
     let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
 
@@ -850,13 +880,16 @@ pub async fn start_tx_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn start_tx<S: Storage + 'static>(
+pub fn start_tx<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(start_tx_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
@@ -906,12 +939,15 @@ pub const CHECK_EXECUTION: &str = indoc! {r#"
 
 // implement check_execution according to the pythonic version given in the CHECK_EXECUTION const
 // above
-pub async fn check_execution_async<S: Storage + 'static>(
+pub async fn check_execution_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let return_values_ptr = get_ptr_from_var_name(vars::ids::ENTRY_POINT_RETURN_VALUES, vm, ids_data, ap_tracking)?;
 
     let failure_flag = vm.get_integer((return_values_ptr + EntryPointReturnValues::failure_flag_offset())?)?;
@@ -953,13 +989,16 @@ pub async fn check_execution_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn check_execution<S: Storage + 'static>(
+pub fn check_execution<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(check_execution_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
@@ -1172,13 +1211,16 @@ pub fn check_response_return_value(
     Ok(())
 }
 
-async fn cache_contract_storage<S: Storage + 'static>(
+async fn cache_contract_storage<S>(
     key: Felt252,
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
@@ -1443,12 +1485,15 @@ pub const WRITE_SYSCALL_RESULT_DEPRECATED: &str = indoc! {r#"
 	ids.new_state_entry = segments.add()"#
 };
 
-pub async fn write_syscall_result_deprecated_async<S: Storage + 'static>(
+pub async fn write_syscall_result_deprecated_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
@@ -1482,13 +1527,16 @@ pub async fn write_syscall_result_deprecated_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn write_syscall_result_deprecated<S: Storage + 'static>(
+pub fn write_syscall_result_deprecated<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(write_syscall_result_deprecated_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
@@ -1502,12 +1550,15 @@ pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
     ids.new_state_entry = segments.add()"#
 };
 
-pub async fn write_syscall_result_async<S: Storage + 'static>(
+pub async fn write_syscall_result_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
@@ -1540,13 +1591,16 @@ pub async fn write_syscall_result_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn write_syscall_result<S: Storage + 'static>(
+pub fn write_syscall_result<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(write_syscall_result_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
@@ -1608,13 +1662,16 @@ pub const WRITE_OLD_BLOCK_TO_STORAGE: &str = indoc! {r#"
 	storage.write(key=ids.old_block_number, value=ids.old_block_hash)"#
 };
 
-pub async fn write_old_block_to_storage_async<S: Storage + 'static>(
+pub async fn write_old_block_to_storage_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let block_hash_contract_address = get_constant(vars::constants::BLOCK_HASH_CONTRACT_ADDRESS, constants)?;
@@ -1630,13 +1687,16 @@ pub async fn write_old_block_to_storage_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn write_old_block_to_storage<S: Storage + 'static>(
+pub fn write_old_block_to_storage<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(write_old_block_to_storage_async::<S>(vm, exec_scopes, ids_data, ap_tracking, constants))?
 }
 
@@ -1647,13 +1707,16 @@ pub const CACHE_CONTRACT_STORAGE_REQUEST_KEY: &str = indoc! {r#"
 	assert ids.value == value, "Inconsistent storage value.""#
 };
 
-pub fn cache_contract_storage_request_key<S: Storage + 'static>(
+pub fn cache_contract_storage_request_key<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let request_ptr = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
     let key = vm.get_integer((request_ptr + new_syscalls::StorageReadRequest::key_offset())?)?.into_owned();
 
@@ -1669,13 +1732,16 @@ pub const CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS: &str = indoc! {r#"
 	assert ids.value == value, "Inconsistent storage value.""#
 };
 
-pub fn cache_contract_storage_syscall_request_address<S: Storage + 'static>(
+pub fn cache_contract_storage_syscall_request_address<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
     let offset = StorageRead::request_offset() + StorageReadRequest::address_offset();
     let key = vm.get_integer((syscall_ptr + offset)?)?.into_owned();
@@ -1693,12 +1759,15 @@ pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	ids.old_block_hash = old_block_hash"#
 };
 
-pub async fn get_old_block_number_and_hash_async<S: Storage + 'static>(
+pub async fn get_old_block_number_and_hash_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let (old_block_number, old_block_hash) = execution_helper.get_old_block_number_and_hash().await?;
 
@@ -1717,13 +1786,16 @@ pub async fn get_old_block_number_and_hash_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn get_old_block_number_and_hash<S: Storage + 'static>(
+pub fn get_old_block_number_and_hash<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(get_old_block_number_and_hash_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -36,6 +36,7 @@ use crate::starknet::core::os::transaction_hash::create_resource_bounds_list;
 use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::base_types::DescentMap;
 use crate::starkware_utils::commitment_tree::update_tree::{DecodeNodeCase, TreeUpdate, UpdateTree};
+use crate::storage::storage::Storage;
 use crate::utils::{custom_hint_error, execute_coroutine, get_constant};
 
 pub const LOAD_NEXT_TX: &str = indoc! {r#"
@@ -186,14 +187,14 @@ pub fn assert_transaction_hash(
 
 pub const ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER: &str =
     "vm_enter_scope({'syscall_handler': deprecated_syscall_handler})";
-pub fn enter_scope_deprecated_syscall_handler(
+pub fn enter_scope_deprecated_syscall_handler<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let dep_sys = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?;
+    let dep_sys = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?;
     let deprecated_syscall_handler: Box<dyn Any> = Box::new(dep_sys);
     exec_scopes
         .enter_scope(HashMap::from_iter([(String::from(vars::scopes::SYSCALL_HANDLER), deprecated_syscall_handler)]));
@@ -201,14 +202,14 @@ pub fn enter_scope_deprecated_syscall_handler(
 }
 
 pub const ENTER_SCOPE_SYSCALL_HANDLER: &str = "vm_enter_scope({'syscall_handler': syscall_handler})";
-pub fn enter_scope_syscall_handler(
+pub fn enter_scope_syscall_handler<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let sys = exec_scopes.get::<OsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let sys = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_handler: Box<dyn Any> = Box::new(sys);
     exec_scopes.enter_scope(HashMap::from_iter([(String::from(vars::scopes::SYSCALL_HANDLER), syscall_handler)]));
     Ok(())
@@ -416,7 +417,7 @@ pub const ENTER_SYSCALL_SCOPES: &str = indoc! {r#"
          '__dict_manager': __dict_manager,
     })"#
 };
-pub fn enter_syscall_scopes(
+pub fn enter_syscall_scopes<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -428,11 +429,11 @@ pub fn enter_syscall_scopes(
         Box::new(exec_scopes.get::<HashSet<Felt252>>(vars::scopes::DEPRECATED_CLASS_HASHES)?);
     let transactions: Box<dyn Any> = Box::new(os_input.transactions.into_iter());
     let execution_helper: Box<dyn Any> =
-        Box::new(exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?);
+        Box::new(exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?);
     let deprecated_syscall_handler: Box<dyn Any> =
-        Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?);
+        Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?);
     let syscall_handler: Box<dyn Any> =
-        Box::new(exec_scopes.get::<OsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?);
+        Box::new(exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?);
     let dict_manager: Box<dyn Any> = Box::new(exec_scopes.get_dict_manager()?);
     exec_scopes.enter_scope(HashMap::from_iter([
         (String::from(vars::scopes::DEPRECATED_CLASS_HASHES), deprecated_class_hashes),
@@ -446,27 +447,27 @@ pub fn enter_syscall_scopes(
 }
 
 pub const END_TX: &str = "execution_helper.end_tx()";
-pub async fn end_tx_async(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+pub async fn end_tx_async<S: Storage + 'static>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.end_tx().await;
     Ok(())
 }
 
-pub fn end_tx(
+pub fn end_tx<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(end_tx_async(exec_scopes))?
+    execute_coroutine(end_tx_async::<S>(exec_scopes))?
 }
 
 pub const ENTER_CALL: &str = indoc! {r#"
     execution_helper.enter_call(
         execution_info_ptr=ids.execution_context.execution_info.address_)"#
 };
-pub async fn enter_call_async(
+pub async fn enter_call_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -476,36 +477,36 @@ pub async fn enter_call_async(
         (get_ptr_from_var_name(vars::ids::EXECUTION_CONTEXT, vm, ids_data, ap_tracking)? + 4i32).unwrap(),
     )?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.enter_call(Some(execution_info_ptr)).await;
     Ok(())
 }
 
-pub fn enter_call(
+pub fn enter_call<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(enter_call_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(enter_call_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const EXIT_CALL: &str = "execution_helper.exit_call()";
-pub async fn exit_call_async(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+pub async fn exit_call_async<S: Storage + 'static>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.exit_call().await;
     Ok(())
 }
 
-pub fn exit_call(
+pub fn exit_call<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(exit_call_async(exec_scopes))?
+    execute_coroutine(exit_call_async::<S>(exec_scopes))?
 }
 
 pub const CONTRACT_ADDRESS: &str = indoc! {r#"
@@ -834,14 +835,14 @@ pub const START_TX: &str = indoc! {r#"
     tx_info_ptr = ids.tx_execution_context.deprecated_tx_info.address_
     execution_helper.start_tx(tx_info_ptr=tx_info_ptr)"#
 };
-pub async fn start_tx_async(
+pub async fn start_tx_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
     let tx_execution_context = get_ptr_from_var_name(vars::ids::TX_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
 
     let tx_info_ptr = vm.get_relocatable((tx_execution_context + ExecutionContext::deprecated_tx_info_offset())?)?;
 
@@ -849,14 +850,14 @@ pub async fn start_tx_async(
     Ok(())
 }
 
-pub fn start_tx(
+pub fn start_tx<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(start_tx_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(start_tx_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const IS_REVERTED: &str = "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.is_reverted)";
@@ -905,7 +906,7 @@ pub const CHECK_EXECUTION: &str = indoc! {r#"
 
 // implement check_execution according to the pythonic version given in the CHECK_EXECUTION const
 // above
-pub async fn check_execution_async(
+pub async fn check_execution_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -930,7 +931,7 @@ pub async fn check_execution_async(
         log::debug!("  Error (at most 100 elements): {:?}", error);
     }
 
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     // TODO: make sure it is necessary to check the gas costs
     // if execution_helper.debug_mode {
     //     let actual = get_integer_from_var_name("remaining_gas", vm, ids_data, ap_tracking)?;
@@ -945,21 +946,21 @@ pub async fn check_execution_async(
     // }
 
     let syscall_ptr_end = vm.get_relocatable((return_values_ptr + EntryPointReturnValues::syscall_ptr_offset())?)?;
-    let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     execute_coroutine(syscall_handler.validate_and_discard_syscall_ptr(syscall_ptr_end))??;
     execution_helper.exit_call().await;
 
     Ok(())
 }
 
-pub fn check_execution(
+pub fn check_execution<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(check_execution_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(check_execution_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 fn assert_memory_ranges_equal(
@@ -1171,14 +1172,14 @@ pub fn check_response_return_value(
     Ok(())
 }
 
-async fn cache_contract_storage(
+async fn cache_contract_storage<S: Storage + 'static>(
     key: Felt252,
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
 
@@ -1442,13 +1443,13 @@ pub const WRITE_SYSCALL_RESULT_DEPRECATED: &str = indoc! {r#"
 	ids.new_state_entry = segments.add()"#
 };
 
-pub async fn write_syscall_result_deprecated_async(
+pub async fn write_syscall_result_deprecated_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
@@ -1481,14 +1482,14 @@ pub async fn write_syscall_result_deprecated_async(
     Ok(())
 }
 
-pub fn write_syscall_result_deprecated(
+pub fn write_syscall_result_deprecated<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(write_syscall_result_deprecated_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(write_syscall_result_deprecated_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
@@ -1501,13 +1502,13 @@ pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
     ids.new_state_entry = segments.add()"#
 };
 
-pub async fn write_syscall_result_async(
+pub async fn write_syscall_result_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let request = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
@@ -1539,14 +1540,14 @@ pub async fn write_syscall_result_async(
     Ok(())
 }
 
-pub fn write_syscall_result(
+pub fn write_syscall_result<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(write_syscall_result_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(write_syscall_result_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const GEN_CLASS_HASH_ARG: &str = indoc! {r#"
@@ -1607,14 +1608,14 @@ pub const WRITE_OLD_BLOCK_TO_STORAGE: &str = indoc! {r#"
 	storage.write(key=ids.old_block_number, value=ids.old_block_hash)"#
 };
 
-pub async fn write_old_block_to_storage_async(
+pub async fn write_old_block_to_storage_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let mut execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let block_hash_contract_address = get_constant(vars::constants::BLOCK_HASH_CONTRACT_ADDRESS, constants)?;
     let old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
@@ -1629,14 +1630,14 @@ pub async fn write_old_block_to_storage_async(
     Ok(())
 }
 
-pub fn write_old_block_to_storage(
+pub fn write_old_block_to_storage<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(write_old_block_to_storage_async(vm, exec_scopes, ids_data, ap_tracking, constants))?
+    execute_coroutine(write_old_block_to_storage_async::<S>(vm, exec_scopes, ids_data, ap_tracking, constants))?
 }
 
 pub const CACHE_CONTRACT_STORAGE_REQUEST_KEY: &str = indoc! {r#"
@@ -1646,7 +1647,7 @@ pub const CACHE_CONTRACT_STORAGE_REQUEST_KEY: &str = indoc! {r#"
 	assert ids.value == value, "Inconsistent storage value.""#
 };
 
-pub fn cache_contract_storage_request_key(
+pub fn cache_contract_storage_request_key<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1656,7 +1657,7 @@ pub fn cache_contract_storage_request_key(
     let request_ptr = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
     let key = vm.get_integer((request_ptr + new_syscalls::StorageReadRequest::key_offset())?)?.into_owned();
 
-    execute_coroutine(cache_contract_storage(key, vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(cache_contract_storage::<S>(key, vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS: &str = indoc! {r#"
@@ -1668,7 +1669,7 @@ pub const CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS: &str = indoc! {r#"
 	assert ids.value == value, "Inconsistent storage value.""#
 };
 
-pub fn cache_contract_storage_syscall_request_address(
+pub fn cache_contract_storage_syscall_request_address<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1679,7 +1680,7 @@ pub fn cache_contract_storage_syscall_request_address(
     let offset = StorageRead::request_offset() + StorageReadRequest::address_offset();
     let key = vm.get_integer((syscall_ptr + offset)?)?.into_owned();
 
-    execute_coroutine(cache_contract_storage(key, vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(cache_contract_storage::<S>(key, vm, exec_scopes, ids_data, ap_tracking))?
 }
 pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	(
@@ -1692,17 +1693,18 @@ pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	ids.old_block_hash = old_block_hash"#
 };
 
-pub async fn get_old_block_number_and_hash_async(
+pub async fn get_old_block_number_and_hash_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let (old_block_number, old_block_hash) = execution_helper.get_old_block_number_and_hash().await?;
 
     let ids_old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
     if old_block_number != ids_old_block_number {
+        log::warn!("old_block_number ({}) != ids_old_block_number ({})", old_block_number, ids_old_block_number);
         return Err(HintError::AssertionFailed(
             "Inconsistent block number. The constant STORED_BLOCK_HASH_BUFFER is probably out of sync."
                 .to_string()
@@ -1715,14 +1717,14 @@ pub async fn get_old_block_number_and_hash_async(
     Ok(())
 }
 
-pub fn get_old_block_number_and_hash(
+pub fn get_old_block_number_and_hash<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(get_old_block_number_and_hash_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(get_old_block_number_and_hash_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const FETCH_RESULT: &str = indoc! {r#"
@@ -1801,7 +1803,7 @@ mod tests {
     fn execution_helper(
         block_context: BlockContext,
         old_block_number_and_hash: (Felt252, Felt252),
-    ) -> ExecutionHelperWrapper {
+    ) -> ExecutionHelperWrapper<DictStorage> {
         ExecutionHelperWrapper::new(ContractStorageMap::default(), vec![], &block_context, old_block_number_and_hash)
     }
 
@@ -1812,9 +1814,9 @@ mod tests {
 
     #[fixture]
     async fn execution_helper_with_storage(
-        execution_helper: ExecutionHelperWrapper,
+        execution_helper: ExecutionHelperWrapper<DictStorage>,
         contract_address: Felt252,
-    ) -> ExecutionHelperWrapper {
+    ) -> ExecutionHelperWrapper<DictStorage> {
         let storage = DictStorage::default();
         let mut ffc = FactFetchingContext::<_, PedersenHash>::new(storage);
 
@@ -1837,7 +1839,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // TODO: fix
     async fn test_cache_contract_storage_request_key(
-        #[future] execution_helper_with_storage: ExecutionHelperWrapper,
+        #[future] execution_helper_with_storage: ExecutionHelperWrapper<DictStorage>,
         contract_address: Felt252,
     ) {
         let execution_helper_with_storage = execution_helper_with_storage.await;
@@ -1871,8 +1873,14 @@ mod tests {
 
         // Just make sure that the hint goes through, all meaningful assertions are
         // in the implementation of the hint
-        cache_contract_storage_request_key(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
-            .expect("Hint should not fail");
+        cache_contract_storage_request_key::<DictStorage>(
+            &mut vm,
+            &mut exec_scopes,
+            &ids_data,
+            &ap_tracking,
+            &constants,
+        )
+        .expect("Hint should not fail");
     }
 
     #[test]
@@ -1926,7 +1934,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // TODO: fix
     async fn test_write_syscall_result(
-        #[future] execution_helper_with_storage: ExecutionHelperWrapper,
+        #[future] execution_helper_with_storage: ExecutionHelperWrapper<DictStorage>,
         contract_address: Felt252,
     ) {
         let mut execution_helper_with_storage = execution_helper_with_storage.await;
@@ -1981,7 +1989,7 @@ mod tests {
 
         // Just make sure that the hint goes through, all meaningful assertions are
         // in the implementation of the hint
-        write_syscall_result_deprecated(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
+        write_syscall_result_deprecated::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
             .expect("Hint should not fail");
 
         // Check that the storage was updated

--- a/crates/starknet-os/src/hints/mod.rs
+++ b/crates/starknet-os/src/hints/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::marker::PhantomData;
 
 use cairo_lang_casm::hints::{Hint, StarknetHint};
 use cairo_lang_casm::operand::{BinOpOperand, DerefOrImmediate, Operation, Register, ResOperand};
@@ -25,6 +26,8 @@ use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::block_context::is_leaf;
 use crate::io::input::StarknetOsInput;
+use crate::storage::dict_storage::DictStorage;
+use crate::storage::storage::Storage;
 use crate::utils::execute_coroutine;
 
 pub mod block_context;
@@ -55,180 +58,182 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-static HINTS: [(&str, HintImpl); 172] = [
-    (BREAKPOINT, breakpoint),
-    (INITIALIZE_CLASS_HASHES, initialize_class_hashes),
-    (INITIALIZE_STATE_CHANGES, initialize_state_changes),
-    (IS_ON_CURVE, is_on_curve),
-    (OS_INPUT_TRANSACTIONS, os_input_transactions),
-    (SEGMENTS_ADD, segments_add),
-    (SEGMENTS_ADD_TEMP, segments_add_temp),
-    (SET_AP_TO_ACTUAL_FEE, set_ap_to_actual_fee),
-    (SKIP_CALL, skip_call),
-    (SKIP_TX, skip_tx),
-    (STARKNET_OS_INPUT, starknet_os_input),
-    (START_TX, start_tx),
-    (block_context::BLOCK_NUMBER, block_context::block_number),
-    (block_context::BLOCK_TIMESTAMP, block_context::block_timestamp),
-    (block_context::BYTECODE_SEGMENT_STRUCTURE, block_context::bytecode_segment_structure),
-    (block_context::CHAIN_ID, block_context::chain_id),
-    (block_context::DEPRECATED_FEE_TOKEN_ADDRESS, block_context::deprecated_fee_token_address),
-    (block_context::ELEMENTS_GE_10, block_context::elements_ge_10),
-    (block_context::ELEMENTS_GE_2, block_context::elements_ge_2),
-    (block_context::FEE_TOKEN_ADDRESS, block_context::fee_token_address),
-    (block_context::GET_BLOCK_MAPPING, block_context::get_block_mapping),
-    (block_context::IS_LEAF, is_leaf),
-    (block_context::LOAD_CLASS_FACTS, block_context::load_class_facts),
-    (block_context::LOAD_CLASS_INNER, block_context::load_class_inner),
-    (block_context::SEQUENCER_ADDRESS, block_context::sequencer_address),
-    (bls_field::COMPUTE_IDS_LOW, bls_field::compute_ids_low),
-    (builtins::SELECTED_BUILTINS, builtins::selected_builtins),
-    (builtins::SELECT_BUILTIN, builtins::select_builtin),
-    (builtins::UPDATE_BUILTIN_PTRS, builtins::update_builtin_ptrs),
-    (compiled_class::ASSIGN_BYTECODE_SEGMENTS, compiled_class::assign_bytecode_segments),
-    (compiled_class::ASSERT_END_OF_BYTECODE_SEGMENTS, compiled_class::assert_end_of_bytecode_segments),
-    (deprecated_compiled_class::LOAD_DEPRECATED_CLASS_FACTS, deprecated_compiled_class::load_deprecated_class_facts),
-    (deprecated_compiled_class::LOAD_DEPRECATED_CLASS_INNER, deprecated_compiled_class::load_deprecated_class_inner),
-    (execute_syscalls::IS_BLOCK_NUMBER_IN_BLOCK_HASH_BUFFER, execute_syscalls::is_block_number_in_block_hash_buffer),
-    (execute_transactions::START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT, execute_transactions::start_tx_validate_declare_execution_context),
-    (execution::ADD_RELOCATION_RULE, execution::add_relocation_rule),
-    (execution::ASSERT_TRANSACTION_HASH, execution::assert_transaction_hash),
-    (execution::CACHE_CONTRACT_STORAGE_REQUEST_KEY, execution::cache_contract_storage_request_key),
-    (execution::CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS, execution::cache_contract_storage_syscall_request_address),
-    (execution::CHECK_EXECUTION, execution::check_execution),
-    (execution::CHECK_IS_DEPRECATED, execution::check_is_deprecated),
-    (execution::CHECK_NEW_DEPLOY_RESPONSE, execution::check_new_deploy_response),
-    (execution::CHECK_NEW_SYSCALL_RESPONSE, execution::check_new_syscall_response),
-    (execution::CHECK_SYSCALL_RESPONSE, execution::check_syscall_response),
-    (execution::CONTRACT_ADDRESS, execution::contract_address),
-    (execution::END_TX, execution::end_tx),
-    (execution::ENTER_CALL, execution::enter_call),
-    (execution::ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER, execution::enter_scope_deprecated_syscall_handler),
-    (execution::ENTER_SCOPE_DESCEND_EDGE, execution::enter_scope_descend_edge),
-    (execution::ENTER_SCOPE_LEFT_CHILD, execution::enter_scope_left_child),
-    (execution::ENTER_SCOPE_NEW_NODE, execution::enter_scope_new_node),
-    (execution::ENTER_SCOPE_NEXT_NODE_BIT_0, execution::enter_scope_next_node_bit_0),
-    (execution::ENTER_SCOPE_NEXT_NODE_BIT_1, execution::enter_scope_next_node_bit_1),
-    (execution::ENTER_SCOPE_NODE, execution::enter_scope_node_hint),
-    (execution::ENTER_SCOPE_RIGHT_CHILD, execution::enter_scope_right_child),
-    (execution::ENTER_SCOPE_SYSCALL_HANDLER, execution::enter_scope_syscall_handler),
-    (execution::ENTER_SYSCALL_SCOPES, execution::enter_syscall_scopes),
-    (execution::EXIT_CALL, execution::exit_call),
-    (execution::EXIT_TX, execution::exit_tx),
-    (execution::FETCH_RESULT, execution::fetch_result),
-    (execution::GEN_CLASS_HASH_ARG, execution::gen_class_hash_arg),
-    (execution::GEN_SIGNATURE_ARG, execution::gen_signature_arg),
-    (execution::GET_BLOCK_HASH_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY, execution::get_block_hash_contract_address_state_entry_and_set_new_state_entry),
-    (execution::GET_CONTRACT_ADDRESS_STATE_ENTRY, execution::get_contract_address_state_entry),
-    (execution::GET_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY, execution::get_contract_address_state_entry_and_set_new_state_entry),
-    (execution::GET_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY_2, execution::get_contract_address_state_entry_and_set_new_state_entry),
-    (execution::GET_OLD_BLOCK_NUMBER_AND_HASH, execution::get_old_block_number_and_hash),
-    (execution::INITIAL_GE_REQUIRED_GAS, execution::initial_ge_required_gas),
-    (execution::IS_DEPRECATED, execution::is_deprecated),
-    (execution::IS_REVERTED, execution::is_reverted),
-    (execution::LOAD_NEXT_TX, execution::load_next_tx),
-    (execution::LOG_ENTER_SYSCALL, execution::log_enter_syscall),
-    (execution::OS_CONTEXT_SEGMENTS, execution::os_context_segments),
-    (execution::PREPARE_CONSTRUCTOR_EXECUTION, execution::prepare_constructor_execution),
-    (execution::RESOURCE_BOUNDS, execution::resource_bounds),
-    (execution::SET_AP_TO_TX_NONCE, execution::set_ap_to_tx_nonce),
-    (execution::SET_FP_PLUS_4_TO_TX_NONCE, execution::set_fp_plus_4_to_tx_nonce),
-    (execution::SET_STATE_ENTRY_TO_ACCOUNT_CONTRACT_ADDRESS, execution::set_state_entry_to_account_contract_address),
-    (execution::START_TX, execution::start_tx),
-    (execution::TRANSACTION_VERSION, execution::transaction_version),
-    (execution::TX_ACCOUNT_DEPLOYMENT_DATA, execution::tx_account_deployment_data),
-    (execution::TX_ACCOUNT_DEPLOYMENT_DATA_LEN, execution::tx_account_deployment_data_len),
-    (execution::TX_CALLDATA, execution::tx_calldata),
-    (execution::TX_CALLDATA_LEN, execution::tx_calldata_len),
-    (execution::TX_ENTRY_POINT_SELECTOR, execution::tx_entry_point_selector),
-    (execution::TX_FEE_DATA_AVAILABILITY_MODE, execution::tx_fee_data_availability_mode),
-    (execution::TX_MAX_FEE, execution::tx_max_fee),
-    (execution::TX_NONCE, execution::tx_nonce),
-    (execution::TX_NONCE_DATA_AVAILABILITY_MODE, execution::tx_nonce_data_availability_mode),
-    (execution::TX_PAYMASTER_DATA, execution::tx_paymaster_data),
-    (execution::TX_PAYMASTER_DATA_LEN, execution::tx_paymaster_data_len),
-    (execution::TX_RESOURCE_BOUNDS_LEN, execution::tx_resource_bounds_len),
-    (execution::TX_TIP, execution::tx_tip),
-    (execution::WRITE_OLD_BLOCK_TO_STORAGE, execution::write_old_block_to_storage),
-    (execution::WRITE_SYSCALL_RESULT, execution::write_syscall_result),
-    (execution::WRITE_SYSCALL_RESULT_DEPRECATED, execution::write_syscall_result_deprecated),
-    (output::SET_AP_TO_BLOCK_HASH, output::set_ap_to_block_hash),
-    (output::SET_STATE_UPDATES_START, output::set_state_updates_start),
-    (output::SET_TREE_STRUCTURE, output::set_tree_structure),
-    (patricia::ASSERT_CASE_IS_RIGHT, patricia::assert_case_is_right),
-    (patricia::BUILD_DESCENT_MAP, patricia::build_descent_map),
-    (patricia::HEIGHT_IS_ZERO_OR_LEN_NODE_PREIMAGE_IS_TWO, patricia::height_is_zero_or_len_node_preimage_is_two),
-    (patricia::IS_CASE_RIGHT, patricia::is_case_right),
-    (patricia::PREPARE_PREIMAGE_VALIDATION_NON_DETERMINISTIC_HASHES, patricia::prepare_preimage_validation_non_deterministic_hashes),
-    (patricia::SET_AP_TO_DESCEND, patricia::set_ap_to_descend),
-    (patricia::SET_BIT, patricia::set_bit),
-    (patricia::SET_SIBLINGS, patricia::set_siblings),
-    (patricia::SPLIT_DESCEND, patricia::split_descend),
-    (patricia::WRITE_CASE_NOT_LEFT_TO_AP, patricia::write_case_not_left_to_ap),
-    (state::DECODE_NODE, state::decode_node_hint),
-    (state::DECODE_NODE_2, state::decode_node_hint),
-    (state::ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS, state::enter_scope_commitment_info_by_address),
-    (state::LOAD_BOTTOM, state::load_bottom),
-    (state::LOAD_EDGE, state::load_edge),
-    (state::SET_PREIMAGE_FOR_CLASS_COMMITMENTS, state::set_preimage_for_class_commitments),
-    (state::SET_PREIMAGE_FOR_CURRENT_COMMITMENT_INFO, state::set_preimage_for_current_commitment_info),
-    (state::SET_PREIMAGE_FOR_STATE_COMMITMENTS, state::set_preimage_for_state_commitments),
-    (state::WRITE_SPLIT_RESULT, state::write_split_result),
-    (syscalls::CALL_CONTRACT, syscalls::call_contract),
-    (syscalls::DELEGATE_CALL, syscalls::delegate_call),
-    (syscalls::DELEGATE_L1_HANDLER, syscalls::delegate_l1_handler),
-    (syscalls::DEPLOY, syscalls::deploy),
-    (syscalls::EMIT_EVENT, syscalls::emit_event),
-    (syscalls::EXIT_CALL_CONTRACT_SYSCALL, syscalls::exit_call_contract_syscall),
-    (syscalls::EXIT_DELEGATE_CALL_SYSCALL, syscalls::exit_delegate_call_syscall),
-    (syscalls::EXIT_DELEGATE_L1_HANDLER_SYSCALL, syscalls::exit_delegate_l1_handler_syscall),
-    (syscalls::EXIT_DEPLOY_SYSCALL, syscalls::exit_deploy_syscall),
-    (syscalls::EXIT_EMIT_EVENT_SYSCALL, syscalls::exit_emit_event_syscall),
-    (syscalls::EXIT_GET_BLOCK_HASH_SYSCALL, syscalls::exit_get_block_hash_syscall),
-    (syscalls::EXIT_GET_BLOCK_NUMBER_SYSCALL, syscalls::exit_get_block_number_syscall),
-    (syscalls::EXIT_GET_BLOCK_TIMESTAMP_SYSCALL, syscalls::exit_get_block_timestamp_syscall),
-    (syscalls::EXIT_GET_CALLER_ADDRESS_SYSCALL, syscalls::exit_get_caller_address_syscall),
-    (syscalls::EXIT_GET_CONTRACT_ADDRESS_SYSCALL, syscalls::exit_get_contract_address_syscall),
-    (syscalls::EXIT_GET_EXECUTION_INFO_SYSCALL, syscalls::exit_get_execution_info_syscall),
-    (syscalls::EXIT_GET_SEQUENCER_ADDRESS_SYSCALL, syscalls::exit_get_sequencer_address_syscall),
-    (syscalls::EXIT_GET_TX_INFO_SYSCALL, syscalls::exit_get_tx_info_syscall),
-    (syscalls::EXIT_GET_TX_SIGNATURE_SYSCALL, syscalls::exit_get_tx_signature_syscall),
-    (syscalls::EXIT_KECCAK_SYSCALL, syscalls::exit_keccak_syscall),
-    (syscalls::EXIT_LIBRARY_CALL_L1_HANDLER_SYSCALL, syscalls::exit_library_call_l1_handler_syscall),
-    (syscalls::EXIT_LIBRARY_CALL_SYSCALL, syscalls::exit_library_call_syscall),
-    (syscalls::EXIT_REPLACE_CLASS_SYSCALL, syscalls::exit_replace_class_syscall),
-    (syscalls::EXIT_SECP256K1_ADD_SYSCALL, syscalls::exit_secp256k1_add_syscall),
-    (syscalls::EXIT_SECP256K1_GET_POINT_FROM_X_SYSCALL, syscalls::exit_secp256k1_get_point_from_x_syscall),
-    (syscalls::EXIT_SECP256K1_GET_XY_SYSCALL, syscalls::exit_secp256k1_get_xy_syscall),
-    (syscalls::EXIT_SECP256K1_MUL_SYSCALL, syscalls::exit_secp256k1_mul_syscall),
-    (syscalls::EXIT_SECP256K1_NEW_SYSCALL, syscalls::exit_secp256k1_new_syscall),
-    (syscalls::EXIT_SECP256R1_ADD_SYSCALL, syscalls::exit_secp256r1_add_syscall),
-    (syscalls::EXIT_SECP256R1_GET_POINT_FROM_X_SYSCALL, syscalls::exit_secp256r1_get_point_from_x_syscall),
-    (syscalls::EXIT_SECP256R1_GET_XY_SYSCALL, syscalls::exit_secp256r1_get_xy_syscall),
-    (syscalls::EXIT_SECP256R1_MUL_SYSCALL, syscalls::exit_secp256r1_mul_syscall),
-    (syscalls::EXIT_SECP256R1_NEW_SYSCALL, syscalls::exit_secp256r1_new_syscall),
-    (syscalls::EXIT_SEND_MESSAGE_TO_L1_SYSCALL, syscalls::exit_send_message_to_l1_syscall),
-    (syscalls::EXIT_STORAGE_READ_SYSCALL, syscalls::exit_storage_read_syscall),
-    (syscalls::EXIT_STORAGE_WRITE_SYSCALL, syscalls::exit_storage_write_syscall),
-    (syscalls::GET_BLOCK_NUMBER, syscalls::get_block_number),
-    (syscalls::GET_BLOCK_TIMESTAMP, syscalls::get_block_timestamp),
-    (syscalls::GET_CALLER_ADDRESS, syscalls::get_caller_address),
-    (syscalls::GET_CONTRACT_ADDRESS, syscalls::get_contract_address),
-    (syscalls::GET_SEQUENCER_ADDRESS, syscalls::get_sequencer_address),
-    (syscalls::GET_TX_INFO, syscalls::get_tx_info),
-    (syscalls::GET_TX_SIGNATURE, syscalls::get_tx_signature),
-    (syscalls::LIBRARY, syscalls::library_call),
-    (syscalls::LIBRARY_CALL_L1_HANDLER, syscalls::library_call_l1_handler),
-    (syscalls::OS_LOGGER_ENTER_SYSCALL_PREPRARE_EXIT_SYSCALL, syscalls::os_logger_enter_syscall_preprare_exit_syscall),
-    (syscalls::REPLACE_CLASS, syscalls::replace_class),
-    (syscalls::SEND_MESSAGE_TO_L1, syscalls::send_message_to_l1),
-    (syscalls::SET_SYSCALL_PTR, syscalls::set_syscall_ptr),
-    (syscalls::STORAGE_READ, syscalls::storage_read),
-    (syscalls::STORAGE_WRITE, syscalls::storage_write),
-    (transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT, transaction_hash::additional_data_new_segment),
-    (transaction_hash::DATA_TO_HASH_NEW_SEGMENT, transaction_hash::data_to_hash_new_segment),
-    (block_context::WRITE_USE_ZKG_DA_TO_MEM, block_context::write_use_zkg_da_to_mem),
-];
+fn hints<S: Storage + 'static>() -> HashMap<String, HintImpl> {
+    let mut hints = HashMap::<String, HintImpl>::new();
+    hints.insert(BREAKPOINT.into(), breakpoint);
+    hints.insert(INITIALIZE_CLASS_HASHES.into(), initialize_class_hashes);
+    hints.insert(INITIALIZE_STATE_CHANGES.into(), initialize_state_changes);
+    hints.insert(IS_ON_CURVE.into(), is_on_curve);
+    hints.insert(OS_INPUT_TRANSACTIONS.into(), os_input_transactions);
+    hints.insert(SEGMENTS_ADD.into(), segments_add);
+    hints.insert(SEGMENTS_ADD_TEMP.into(), segments_add_temp);
+    hints.insert(SET_AP_TO_ACTUAL_FEE.into(), set_ap_to_actual_fee::<DictStorage>);
+    hints.insert(SKIP_CALL.into(), skip_call::<S>);
+    hints.insert(SKIP_TX.into(), skip_tx::<S>);
+    hints.insert(STARKNET_OS_INPUT.into(), starknet_os_input);
+    hints.insert(START_TX.into(), start_tx::<S>);
+    hints.insert(block_context::BLOCK_NUMBER.into(), block_context::block_number);
+    hints.insert(block_context::BLOCK_TIMESTAMP.into(), block_context::block_timestamp);
+    hints.insert(block_context::BYTECODE_SEGMENT_STRUCTURE.into(), block_context::bytecode_segment_structure);
+    hints.insert(block_context::CHAIN_ID.into(), block_context::chain_id);
+    hints.insert(block_context::DEPRECATED_FEE_TOKEN_ADDRESS.into(), block_context::deprecated_fee_token_address);
+    hints.insert(block_context::ELEMENTS_GE_10.into(), block_context::elements_ge_10);
+    hints.insert(block_context::ELEMENTS_GE_2.into(), block_context::elements_ge_2);
+    hints.insert(block_context::FEE_TOKEN_ADDRESS.into(), block_context::fee_token_address);
+    hints.insert(block_context::GET_BLOCK_MAPPING.into(), block_context::get_block_mapping);
+    hints.insert(block_context::IS_LEAF.into(), is_leaf);
+    hints.insert(block_context::LOAD_CLASS_FACTS.into(), block_context::load_class_facts);
+    hints.insert(block_context::LOAD_CLASS_INNER.into(), block_context::load_class_inner);
+    hints.insert(block_context::SEQUENCER_ADDRESS.into(), block_context::sequencer_address);
+    hints.insert(bls_field::COMPUTE_IDS_LOW.into(), bls_field::compute_ids_low);
+    hints.insert(builtins::SELECTED_BUILTINS.into(), builtins::selected_builtins);
+    hints.insert(builtins::SELECT_BUILTIN.into(), builtins::select_builtin);
+    hints.insert(builtins::UPDATE_BUILTIN_PTRS.into(), builtins::update_builtin_ptrs);
+    hints.insert(compiled_class::ASSIGN_BYTECODE_SEGMENTS.into(), compiled_class::assign_bytecode_segments);
+    hints.insert(compiled_class::ASSERT_END_OF_BYTECODE_SEGMENTS.into(), compiled_class::assert_end_of_bytecode_segments);
+    hints.insert(deprecated_compiled_class::LOAD_DEPRECATED_CLASS_FACTS.into(), deprecated_compiled_class::load_deprecated_class_facts);
+    hints.insert(deprecated_compiled_class::LOAD_DEPRECATED_CLASS_INNER.into(), deprecated_compiled_class::load_deprecated_class_inner);
+    hints.insert(execute_syscalls::IS_BLOCK_NUMBER_IN_BLOCK_HASH_BUFFER.into(), execute_syscalls::is_block_number_in_block_hash_buffer);
+    hints.insert(execute_transactions::START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT.into(), execute_transactions::start_tx_validate_declare_execution_context::<S>);
+    hints.insert(execution::ADD_RELOCATION_RULE.into(), execution::add_relocation_rule);
+    hints.insert(execution::ASSERT_TRANSACTION_HASH.into(), execution::assert_transaction_hash);
+    hints.insert(execution::CACHE_CONTRACT_STORAGE_REQUEST_KEY.into(), execution::cache_contract_storage_request_key::<S>);
+    hints.insert(execution::CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS.into(), execution::cache_contract_storage_syscall_request_address::<S>);
+    hints.insert(execution::CHECK_EXECUTION.into(), execution::check_execution::<S>);
+    hints.insert(execution::CHECK_IS_DEPRECATED.into(), execution::check_is_deprecated);
+    hints.insert(execution::CHECK_NEW_DEPLOY_RESPONSE.into(), execution::check_new_deploy_response);
+    hints.insert(execution::CHECK_NEW_SYSCALL_RESPONSE.into(), execution::check_new_syscall_response);
+    hints.insert(execution::CHECK_SYSCALL_RESPONSE.into(), execution::check_syscall_response);
+    hints.insert(execution::CONTRACT_ADDRESS.into(), execution::contract_address);
+    hints.insert(execution::END_TX.into(), execution::end_tx::<S>);
+    hints.insert(execution::ENTER_CALL.into(), execution::enter_call::<S>);
+    hints.insert(execution::ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER.into(), execution::enter_scope_deprecated_syscall_handler::<S>);
+    hints.insert(execution::ENTER_SCOPE_DESCEND_EDGE.into(), execution::enter_scope_descend_edge);
+    hints.insert(execution::ENTER_SCOPE_LEFT_CHILD.into(), execution::enter_scope_left_child);
+    hints.insert(execution::ENTER_SCOPE_NEW_NODE.into(), execution::enter_scope_new_node);
+    hints.insert(execution::ENTER_SCOPE_NEXT_NODE_BIT_0.into(), execution::enter_scope_next_node_bit_0);
+    hints.insert(execution::ENTER_SCOPE_NEXT_NODE_BIT_1.into(), execution::enter_scope_next_node_bit_1);
+    hints.insert(execution::ENTER_SCOPE_NODE.into(), execution::enter_scope_node_hint);
+    hints.insert(execution::ENTER_SCOPE_RIGHT_CHILD.into(), execution::enter_scope_right_child);
+    hints.insert(execution::ENTER_SCOPE_SYSCALL_HANDLER.into(), execution::enter_scope_syscall_handler::<S>);
+    hints.insert(execution::ENTER_SYSCALL_SCOPES.into(), execution::enter_syscall_scopes::<S>);
+    hints.insert(execution::EXIT_CALL.into(), execution::exit_call::<S>);
+    hints.insert(execution::EXIT_TX.into(), execution::exit_tx);
+    hints.insert(execution::FETCH_RESULT.into(), execution::fetch_result);
+    hints.insert(execution::GEN_CLASS_HASH_ARG.into(), execution::gen_class_hash_arg);
+    hints.insert(execution::GEN_SIGNATURE_ARG.into(), execution::gen_signature_arg);
+    hints.insert(execution::GET_BLOCK_HASH_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY.into(), execution::get_block_hash_contract_address_state_entry_and_set_new_state_entry);
+    hints.insert(execution::GET_CONTRACT_ADDRESS_STATE_ENTRY.into(), execution::get_contract_address_state_entry);
+    hints.insert(execution::GET_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY.into(), execution::get_contract_address_state_entry_and_set_new_state_entry);
+    hints.insert(execution::GET_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY_2.into(), execution::get_contract_address_state_entry_and_set_new_state_entry);
+    hints.insert(execution::GET_OLD_BLOCK_NUMBER_AND_HASH.into(), execution::get_old_block_number_and_hash::<S>);
+    hints.insert(execution::INITIAL_GE_REQUIRED_GAS.into(), execution::initial_ge_required_gas);
+    hints.insert(execution::IS_DEPRECATED.into(), execution::is_deprecated);
+    hints.insert(execution::IS_REVERTED.into(), execution::is_reverted);
+    hints.insert(execution::LOAD_NEXT_TX.into(), execution::load_next_tx);
+    hints.insert(execution::LOG_ENTER_SYSCALL.into(), execution::log_enter_syscall);
+    hints.insert(execution::OS_CONTEXT_SEGMENTS.into(), execution::os_context_segments);
+    hints.insert(execution::PREPARE_CONSTRUCTOR_EXECUTION.into(), execution::prepare_constructor_execution);
+    hints.insert(execution::RESOURCE_BOUNDS.into(), execution::resource_bounds);
+    hints.insert(execution::SET_AP_TO_TX_NONCE.into(), execution::set_ap_to_tx_nonce);
+    hints.insert(execution::SET_FP_PLUS_4_TO_TX_NONCE.into(), execution::set_fp_plus_4_to_tx_nonce);
+    hints.insert(execution::SET_STATE_ENTRY_TO_ACCOUNT_CONTRACT_ADDRESS.into(), execution::set_state_entry_to_account_contract_address);
+    hints.insert(execution::START_TX.into(), execution::start_tx::<S>);
+    hints.insert(execution::TRANSACTION_VERSION.into(), execution::transaction_version);
+    hints.insert(execution::TX_ACCOUNT_DEPLOYMENT_DATA.into(), execution::tx_account_deployment_data);
+    hints.insert(execution::TX_ACCOUNT_DEPLOYMENT_DATA_LEN.into(), execution::tx_account_deployment_data_len);
+    hints.insert(execution::TX_CALLDATA.into(), execution::tx_calldata);
+    hints.insert(execution::TX_CALLDATA_LEN.into(), execution::tx_calldata_len);
+    hints.insert(execution::TX_ENTRY_POINT_SELECTOR.into(), execution::tx_entry_point_selector);
+    hints.insert(execution::TX_FEE_DATA_AVAILABILITY_MODE.into(), execution::tx_fee_data_availability_mode);
+    hints.insert(execution::TX_MAX_FEE.into(), execution::tx_max_fee);
+    hints.insert(execution::TX_NONCE.into(), execution::tx_nonce);
+    hints.insert(execution::TX_NONCE_DATA_AVAILABILITY_MODE.into(), execution::tx_nonce_data_availability_mode);
+    hints.insert(execution::TX_PAYMASTER_DATA.into(), execution::tx_paymaster_data);
+    hints.insert(execution::TX_PAYMASTER_DATA_LEN.into(), execution::tx_paymaster_data_len);
+    hints.insert(execution::TX_RESOURCE_BOUNDS_LEN.into(), execution::tx_resource_bounds_len);
+    hints.insert(execution::TX_TIP.into(), execution::tx_tip);
+    hints.insert(execution::WRITE_OLD_BLOCK_TO_STORAGE.into(), execution::write_old_block_to_storage::<S>);
+    hints.insert(execution::WRITE_SYSCALL_RESULT.into(), execution::write_syscall_result::<S>);
+    hints.insert(execution::WRITE_SYSCALL_RESULT_DEPRECATED.into(), execution::write_syscall_result_deprecated::<S>);
+    hints.insert(output::SET_AP_TO_BLOCK_HASH.into(), output::set_ap_to_block_hash);
+    hints.insert(output::SET_STATE_UPDATES_START.into(), output::set_state_updates_start);
+    hints.insert(output::SET_TREE_STRUCTURE.into(), output::set_tree_structure);
+    hints.insert(patricia::ASSERT_CASE_IS_RIGHT.into(), patricia::assert_case_is_right);
+    hints.insert(patricia::BUILD_DESCENT_MAP.into(), patricia::build_descent_map);
+    hints.insert(patricia::HEIGHT_IS_ZERO_OR_LEN_NODE_PREIMAGE_IS_TWO.into(), patricia::height_is_zero_or_len_node_preimage_is_two);
+    hints.insert(patricia::IS_CASE_RIGHT.into(), patricia::is_case_right);
+    hints.insert(patricia::PREPARE_PREIMAGE_VALIDATION_NON_DETERMINISTIC_HASHES.into(), patricia::prepare_preimage_validation_non_deterministic_hashes);
+    hints.insert(patricia::SET_AP_TO_DESCEND.into(), patricia::set_ap_to_descend);
+    hints.insert(patricia::SET_BIT.into(), patricia::set_bit);
+    hints.insert(patricia::SET_SIBLINGS.into(), patricia::set_siblings);
+    hints.insert(patricia::SPLIT_DESCEND.into(), patricia::split_descend);
+    hints.insert(patricia::WRITE_CASE_NOT_LEFT_TO_AP.into(), patricia::write_case_not_left_to_ap);
+    hints.insert(state::DECODE_NODE.into(), state::decode_node_hint);
+    hints.insert(state::DECODE_NODE_2.into(), state::decode_node_hint);
+    hints.insert(state::ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS.into(), state::enter_scope_commitment_info_by_address::<S>);
+    hints.insert(state::LOAD_BOTTOM.into(), state::load_bottom);
+    hints.insert(state::LOAD_EDGE.into(), state::load_edge);
+    hints.insert(state::SET_PREIMAGE_FOR_CLASS_COMMITMENTS.into(), state::set_preimage_for_class_commitments);
+    hints.insert(state::SET_PREIMAGE_FOR_CURRENT_COMMITMENT_INFO.into(), state::set_preimage_for_current_commitment_info);
+    hints.insert(state::SET_PREIMAGE_FOR_STATE_COMMITMENTS.into(), state::set_preimage_for_state_commitments);
+    hints.insert(state::WRITE_SPLIT_RESULT.into(), state::write_split_result);
+    hints.insert(syscalls::CALL_CONTRACT.into(), syscalls::call_contract::<S>);
+    hints.insert(syscalls::DELEGATE_CALL.into(), syscalls::delegate_call::<S>);
+    hints.insert(syscalls::DELEGATE_L1_HANDLER.into(), syscalls::delegate_l1_handler::<S>);
+    hints.insert(syscalls::DEPLOY.into(), syscalls::deploy::<S>);
+    hints.insert(syscalls::EMIT_EVENT.into(), syscalls::emit_event::<S>);
+    hints.insert(syscalls::EXIT_CALL_CONTRACT_SYSCALL.into(), syscalls::exit_call_contract_syscall);
+    hints.insert(syscalls::EXIT_DELEGATE_CALL_SYSCALL.into(), syscalls::exit_delegate_call_syscall);
+    hints.insert(syscalls::EXIT_DELEGATE_L1_HANDLER_SYSCALL.into(), syscalls::exit_delegate_l1_handler_syscall);
+    hints.insert(syscalls::EXIT_DEPLOY_SYSCALL.into(), syscalls::exit_deploy_syscall);
+    hints.insert(syscalls::EXIT_EMIT_EVENT_SYSCALL.into(), syscalls::exit_emit_event_syscall);
+    hints.insert(syscalls::EXIT_GET_BLOCK_HASH_SYSCALL.into(), syscalls::exit_get_block_hash_syscall);
+    hints.insert(syscalls::EXIT_GET_BLOCK_NUMBER_SYSCALL.into(), syscalls::exit_get_block_number_syscall);
+    hints.insert(syscalls::EXIT_GET_BLOCK_TIMESTAMP_SYSCALL.into(), syscalls::exit_get_block_timestamp_syscall);
+    hints.insert(syscalls::EXIT_GET_CALLER_ADDRESS_SYSCALL.into(), syscalls::exit_get_caller_address_syscall);
+    hints.insert(syscalls::EXIT_GET_CONTRACT_ADDRESS_SYSCALL.into(), syscalls::exit_get_contract_address_syscall);
+    hints.insert(syscalls::EXIT_GET_EXECUTION_INFO_SYSCALL.into(), syscalls::exit_get_execution_info_syscall);
+    hints.insert(syscalls::EXIT_GET_SEQUENCER_ADDRESS_SYSCALL.into(), syscalls::exit_get_sequencer_address_syscall);
+    hints.insert(syscalls::EXIT_GET_TX_INFO_SYSCALL.into(), syscalls::exit_get_tx_info_syscall);
+    hints.insert(syscalls::EXIT_GET_TX_SIGNATURE_SYSCALL.into(), syscalls::exit_get_tx_signature_syscall);
+    hints.insert(syscalls::EXIT_KECCAK_SYSCALL.into(), syscalls::exit_keccak_syscall);
+    hints.insert(syscalls::EXIT_LIBRARY_CALL_L1_HANDLER_SYSCALL.into(), syscalls::exit_library_call_l1_handler_syscall);
+    hints.insert(syscalls::EXIT_LIBRARY_CALL_SYSCALL.into(), syscalls::exit_library_call_syscall);
+    hints.insert(syscalls::EXIT_REPLACE_CLASS_SYSCALL.into(), syscalls::exit_replace_class_syscall);
+    hints.insert(syscalls::EXIT_SECP256K1_ADD_SYSCALL.into(), syscalls::exit_secp256k1_add_syscall);
+    hints.insert(syscalls::EXIT_SECP256K1_GET_POINT_FROM_X_SYSCALL.into(), syscalls::exit_secp256k1_get_point_from_x_syscall);
+    hints.insert(syscalls::EXIT_SECP256K1_GET_XY_SYSCALL.into(), syscalls::exit_secp256k1_get_xy_syscall);
+    hints.insert(syscalls::EXIT_SECP256K1_MUL_SYSCALL.into(), syscalls::exit_secp256k1_mul_syscall);
+    hints.insert(syscalls::EXIT_SECP256K1_NEW_SYSCALL.into(), syscalls::exit_secp256k1_new_syscall);
+    hints.insert(syscalls::EXIT_SECP256R1_ADD_SYSCALL.into(), syscalls::exit_secp256r1_add_syscall);
+    hints.insert(syscalls::EXIT_SECP256R1_GET_POINT_FROM_X_SYSCALL.into(), syscalls::exit_secp256r1_get_point_from_x_syscall);
+    hints.insert(syscalls::EXIT_SECP256R1_GET_XY_SYSCALL.into(), syscalls::exit_secp256r1_get_xy_syscall);
+    hints.insert(syscalls::EXIT_SECP256R1_MUL_SYSCALL.into(), syscalls::exit_secp256r1_mul_syscall);
+    hints.insert(syscalls::EXIT_SECP256R1_NEW_SYSCALL.into(), syscalls::exit_secp256r1_new_syscall);
+    hints.insert(syscalls::EXIT_SEND_MESSAGE_TO_L1_SYSCALL.into(), syscalls::exit_send_message_to_l1_syscall);
+    hints.insert(syscalls::EXIT_STORAGE_READ_SYSCALL.into(), syscalls::exit_storage_read_syscall);
+    hints.insert(syscalls::EXIT_STORAGE_WRITE_SYSCALL.into(), syscalls::exit_storage_write_syscall);
+    hints.insert(syscalls::GET_BLOCK_NUMBER.into(), syscalls::get_block_number::<S>);
+    hints.insert(syscalls::GET_BLOCK_TIMESTAMP.into(), syscalls::get_block_timestamp::<S>);
+    hints.insert(syscalls::GET_CALLER_ADDRESS.into(), syscalls::get_caller_address::<S>);
+    hints.insert(syscalls::GET_CONTRACT_ADDRESS.into(), syscalls::get_contract_address::<S>);
+    hints.insert(syscalls::GET_SEQUENCER_ADDRESS.into(), syscalls::get_sequencer_address::<S>);
+    hints.insert(syscalls::GET_TX_INFO.into(), syscalls::get_tx_info::<S>);
+    hints.insert(syscalls::GET_TX_SIGNATURE.into(), syscalls::get_tx_signature::<S>);
+    hints.insert(syscalls::LIBRARY.into(), syscalls::library_call::<S>);
+    hints.insert(syscalls::LIBRARY_CALL_L1_HANDLER.into(), syscalls::library_call_l1_handler::<S>);
+    hints.insert(syscalls::OS_LOGGER_ENTER_SYSCALL_PREPRARE_EXIT_SYSCALL.into(), syscalls::os_logger_enter_syscall_preprare_exit_syscall);
+    hints.insert(syscalls::REPLACE_CLASS.into(), syscalls::replace_class::<S>);
+    hints.insert(syscalls::SEND_MESSAGE_TO_L1.into(), syscalls::send_message_to_l1::<S>);
+    hints.insert(syscalls::SET_SYSCALL_PTR.into(), syscalls::set_syscall_ptr::<S>);
+    hints.insert(syscalls::STORAGE_READ.into(), syscalls::storage_read::<S>);
+    hints.insert(syscalls::STORAGE_WRITE.into(), syscalls::storage_write::<S>);
+    hints.insert(transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT.into(), transaction_hash::additional_data_new_segment);
+    hints.insert(transaction_hash::DATA_TO_HASH_NEW_SEGMENT.into(), transaction_hash::data_to_hash_new_segment);
+    hints.insert(block_context::WRITE_USE_ZKG_DA_TO_MEM.into(), block_context::write_use_zkg_da_to_mem);
+    return hints;
+}
 
 /// Hint Extensions extend the current map of hints used by the VM.
 /// This behaviour achieves what the `vm_load_data` primitive does for cairo-lang
@@ -246,15 +251,22 @@ static EXTENSIVE_HINTS: [(&str, ExtensiveHintImpl); 2] = [
     (deprecated_compiled_class::LOAD_DEPRECATED_CLASS, deprecated_compiled_class::load_deprecated_class),
 ];
 
-pub struct SnosHintProcessor {
+pub struct SnosHintProcessor<S>
+where
+    S: Storage,
+{
     builtin_hint_proc: BuiltinHintProcessor,
     cairo1_builtin_hint_proc: Cairo1HintProcessor,
     hints: HashMap<String, HintImpl>,
     extensive_hints: HashMap<String, ExtensiveHintImpl>,
     run_resources: RunResources,
+    _phantom: PhantomData<S>,
 }
 
-impl ResourceTracker for SnosHintProcessor {
+impl<S: Storage> ResourceTracker for SnosHintProcessor<S>
+where
+    S: Storage,
+{
     fn consumed(&self) -> bool {
         self.run_resources.consumed()
     }
@@ -272,9 +284,9 @@ impl ResourceTracker for SnosHintProcessor {
     }
 }
 
-impl Default for SnosHintProcessor {
+impl<S: Storage + 'static> Default for SnosHintProcessor<S> {
     fn default() -> Self {
-        let hints = HINTS.into_iter().map(|(h, i)| (h.to_string(), i)).collect();
+        let hints = hints::<S>();
         let extensive_hints = EXTENSIVE_HINTS.into_iter().map(|(h, i)| (h.to_string(), i)).collect();
         Self {
             builtin_hint_proc: BuiltinHintProcessor::new_empty(),
@@ -282,6 +294,7 @@ impl Default for SnosHintProcessor {
             hints,
             extensive_hints,
             run_resources: Default::default(),
+            _phantom: Default::default(),
         }
     }
 }
@@ -309,7 +322,7 @@ fn get_ptr_from_res_operand(vm: &mut VirtualMachine, res: &ResOperand) -> Result
     (vm.get_relocatable(cell_reloc)? + &base_offset).map_err(|e| e.into())
 }
 
-impl SnosHintProcessor {
+impl<S: Storage> SnosHintProcessor<S> {
     pub fn hints(&self) -> HashSet<String> {
         self.hints
             .keys()
@@ -321,7 +334,7 @@ impl SnosHintProcessor {
     }
 }
 
-impl HintProcessorLogic for SnosHintProcessor {
+impl<S: Storage + 'static> HintProcessorLogic for SnosHintProcessor<S> {
     // stub for trait impl
     fn execute_hint(
         &mut self,
@@ -361,7 +374,8 @@ impl HintProcessorLogic for SnosHintProcessor {
         if let Some(hint) = hint_data.downcast_ref::<Hint>() {
             if let Hint::Starknet(StarknetHint::SystemCall { system }) = hint {
                 let syscall_ptr = get_ptr_from_res_operand(vm, system)?;
-                let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+                // TODO: need to be generic here
+                let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
 
                 return execute_coroutine(syscall_handler.execute_syscall(vm, syscall_ptr))?
                     .map(|_| HintExtension::default());
@@ -523,14 +537,14 @@ pub fn breakpoint(
 pub const SET_AP_TO_ACTUAL_FEE: &str =
     "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.actual_fee)";
 
-pub fn set_ap_to_actual_fee(
+pub fn set_ap_to_actual_fee<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     let actual_fee = execute_coroutine(async {
         let eh_ref = execution_helper.execution_helper.read().await;
         eh_ref
@@ -564,7 +578,7 @@ pub fn is_on_curve(
 
 const START_TX: &str = "execution_helper.start_tx(tx_info_ptr=ids.deprecated_tx_info.address_)";
 
-pub async fn start_tx_async(
+pub async fn start_tx_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -573,58 +587,58 @@ pub async fn start_tx_async(
     let deprecated_tx_info_ptr =
         get_relocatable_from_var_name(vars::ids::DEPRECATED_TX_INFO, vm, ids_data, ap_tracking)?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.start_tx(Some(deprecated_tx_info_ptr)).await;
 
     Ok(())
 }
 
-pub fn start_tx(
+pub fn start_tx<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(start_tx_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(start_tx_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 const SKIP_TX: &str = "execution_helper.skip_tx()";
 
-pub async fn skip_tx_async(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+pub async fn skip_tx_async<S: Storage + 'static>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.skip_tx().await;
 
     Ok(())
 }
 
-pub fn skip_tx(
+pub fn skip_tx<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(skip_tx_async(exec_scopes))?
+    execute_coroutine(skip_tx_async::<S>(exec_scopes))?
 }
 
 const SKIP_CALL: &str = "execution_helper.skip_call()";
 
-pub async fn skip_call_async(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper>(vars::scopes::EXECUTION_HELPER)?;
+pub async fn skip_call_async<S: Storage + 'static>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError> {
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.skip_call().await;
 
     Ok(())
 }
 
-pub fn skip_call(
+pub fn skip_call<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(skip_call_async(exec_scopes))?
+    execute_coroutine(skip_call_async::<S>(exec_scopes))?
 }
 
 const OS_INPUT_TRANSACTIONS: &str = "memory[fp + 8] = to_felt_or_relocatable(len(os_input.transactions))";

--- a/crates/starknet-os/src/hints/mod.rs
+++ b/crates/starknet-os/src/hints/mod.rs
@@ -233,7 +233,8 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT.into(), transaction_hash::additional_data_new_segment);
     hints.insert(transaction_hash::DATA_TO_HASH_NEW_SEGMENT.into(), transaction_hash::data_to_hash_new_segment);
     hints.insert(block_context::WRITE_USE_ZKG_DA_TO_MEM.into(), block_context::write_use_zkg_da_to_mem);
-    return hints;
+
+    hints
 }
 
 /// Hint Extensions extend the current map of hints used by the VM.

--- a/crates/starknet-os/src/hints/state.rs
+++ b/crates/starknet-os/src/hints/state.rs
@@ -310,13 +310,16 @@ pub const ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS: &str = indoc! {r#"
 	))"#
 };
 
-pub fn enter_scope_commitment_info_by_address<S: Storage + 'static>(
+pub fn enter_scope_commitment_info_by_address<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let os_input: StarknetOsInput = exec_scopes.get(vars::scopes::OS_INPUT)?;
 

--- a/crates/starknet-os/src/hints/state.rs
+++ b/crates/starknet-os/src/hints/state.rs
@@ -22,6 +22,7 @@ use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 use crate::starknet::starknet_storage::{CommitmentInfo, StorageLeaf};
 use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, UpdateTree};
+use crate::storage::storage::Storage;
 use crate::utils::{execute_coroutine, get_constant};
 
 fn assert_tree_height_eq_merkle_height(tree_height: Felt252, merkle_height: Felt252) -> Result<(), HintError> {
@@ -309,14 +310,14 @@ pub const ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS: &str = indoc! {r#"
 	))"#
 };
 
-pub fn enter_scope_commitment_info_by_address(
+pub fn enter_scope_commitment_info_by_address<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let execution_helper: ExecutionHelperWrapper = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let os_input: StarknetOsInput = exec_scopes.get(vars::scopes::OS_INPUT)?;
 
     let commitment_info_by_address = execute_coroutine(execution_helper.compute_storage_commitments())??;

--- a/crates/starknet-os/src/hints/syscalls.rs
+++ b/crates/starknet-os/src/hints/syscalls.rs
@@ -17,12 +17,15 @@ use crate::utils::execute_coroutine;
 
 pub const CALL_CONTRACT: &str = "syscall_handler.call_contract(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn call_contract_async<S: Storage + 'static>(
+pub async fn call_contract_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -31,24 +34,30 @@ pub async fn call_contract_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn call_contract<S: Storage + 'static>(
+pub fn call_contract<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(call_contract_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const DELEGATE_CALL: &str = "syscall_handler.delegate_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn delegate_call_async<S: Storage + 'static>(
+pub async fn delegate_call_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -57,26 +66,32 @@ pub async fn delegate_call_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn delegate_call<S: Storage + 'static>(
+pub fn delegate_call<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(delegate_call_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const DELEGATE_L1_HANDLER: &str =
     "syscall_handler.delegate_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn delegate_l1_handler<S: Storage + 'static>(
+pub fn delegate_l1_handler<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -85,13 +100,16 @@ pub fn delegate_l1_handler<S: Storage + 'static>(
 
 pub const DEPLOY: &str = "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn deploy<S: Storage + 'static>(
+pub fn deploy<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -100,13 +118,16 @@ pub fn deploy<S: Storage + 'static>(
 
 pub const EMIT_EVENT: &str = "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn emit_event<S: Storage + 'static>(
+pub fn emit_event<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     syscall_handler.emit_event();
 
@@ -115,13 +136,16 @@ pub fn emit_event<S: Storage + 'static>(
 
 pub const GET_BLOCK_NUMBER: &str = "syscall_handler.get_block_number(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_block_number<S: Storage + 'static>(
+pub fn get_block_number<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -131,13 +155,16 @@ pub fn get_block_number<S: Storage + 'static>(
 pub const GET_BLOCK_TIMESTAMP: &str =
     "syscall_handler.get_block_timestamp(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_block_timestamp<S: Storage + 'static>(
+pub fn get_block_timestamp<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -147,12 +174,15 @@ pub fn get_block_timestamp<S: Storage + 'static>(
 pub const GET_CALLER_ADDRESS: &str =
     "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn get_caller_address_async<S: Storage + 'static>(
+pub async fn get_caller_address_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -161,26 +191,32 @@ pub async fn get_caller_address_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn get_caller_address<S: Storage + 'static>(
+pub fn get_caller_address<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(get_caller_address_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const GET_CONTRACT_ADDRESS: &str =
     "syscall_handler.get_contract_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_contract_address<S: Storage + 'static>(
+pub fn get_contract_address<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -190,13 +226,16 @@ pub fn get_contract_address<S: Storage + 'static>(
 pub const GET_SEQUENCER_ADDRESS: &str =
     "syscall_handler.get_sequencer_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_sequencer_address<S: Storage + 'static>(
+pub fn get_sequencer_address<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -205,13 +244,16 @@ pub fn get_sequencer_address<S: Storage + 'static>(
 
 pub const GET_TX_INFO: &str = "syscall_handler.get_tx_info(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_tx_info<S: Storage + 'static>(
+pub fn get_tx_info<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -220,13 +262,16 @@ pub fn get_tx_info<S: Storage + 'static>(
 
 pub const GET_TX_SIGNATURE: &str = "syscall_handler.get_tx_signature(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_tx_signature<S: Storage + 'static>(
+pub fn get_tx_signature<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -235,13 +280,16 @@ pub fn get_tx_signature<S: Storage + 'static>(
 
 pub const LIBRARY: &str = "syscall_handler.library_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn library_call<S: Storage + 'static>(
+pub fn library_call<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -251,13 +299,16 @@ pub fn library_call<S: Storage + 'static>(
 pub const LIBRARY_CALL_L1_HANDLER: &str =
     "syscall_handler.library_call_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn library_call_l1_handler<S: Storage + 'static>(
+pub fn library_call_l1_handler<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -266,13 +317,16 @@ pub fn library_call_l1_handler<S: Storage + 'static>(
 
 pub const REPLACE_CLASS: &str = "syscall_handler.replace_class(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn replace_class<S: Storage + 'static>(
+pub fn replace_class<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
 
     syscall_handler.replace_class();
@@ -283,13 +337,16 @@ pub fn replace_class<S: Storage + 'static>(
 pub const SEND_MESSAGE_TO_L1: &str =
     "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn send_message_to_l1<S: Storage + 'static>(
+pub fn send_message_to_l1<S>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
 
     syscall_handler.send_message_to_l1();
@@ -299,12 +356,15 @@ pub fn send_message_to_l1<S: Storage + 'static>(
 
 pub const STORAGE_READ: &str = "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn storage_read_async<S: Storage + 'static>(
+pub async fn storage_read_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -313,24 +373,30 @@ pub async fn storage_read_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn storage_read<S: Storage + 'static>(
+pub fn storage_read<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(storage_read_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const STORAGE_WRITE: &str = "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn storage_write_async<S: Storage + 'static>(
+pub async fn storage_write_async<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
@@ -339,13 +405,16 @@ pub async fn storage_write_async<S: Storage + 'static>(
     Ok(())
 }
 
-pub fn storage_write<S: Storage + 'static>(
+pub fn storage_write<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     execute_coroutine(storage_write_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
@@ -356,13 +425,16 @@ pub const SET_SYSCALL_PTR: &str = indoc! {r#"
 	syscall_handler.set_syscall_ptr(syscall_ptr=ids.syscall_ptr)"#
 };
 
-pub fn set_syscall_ptr<S: Storage + 'static>(
+pub fn set_syscall_ptr<S>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
-) -> Result<(), HintError> {
+) -> Result<(), HintError>
+where
+    S: Storage + 'static,
+{
     let os_context = vm.add_memory_segment();
     let syscall_ptr = vm.add_memory_segment();
 

--- a/crates/starknet-os/src/hints/syscalls.rs
+++ b/crates/starknet-os/src/hints/syscalls.rs
@@ -12,17 +12,18 @@ use indoc::indoc;
 use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::vars;
+use crate::storage::storage::Storage;
 use crate::utils::execute_coroutine;
 
 pub const CALL_CONTRACT: &str = "syscall_handler.call_contract(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn call_contract_async(
+pub async fn call_contract_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.call_contract(syscall_ptr, vm).await?;
@@ -30,25 +31,25 @@ pub async fn call_contract_async(
     Ok(())
 }
 
-pub fn call_contract(
+pub fn call_contract<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(call_contract_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(call_contract_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const DELEGATE_CALL: &str = "syscall_handler.delegate_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn delegate_call_async(
+pub async fn delegate_call_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.storage_write(syscall_ptr).await?;
@@ -56,27 +57,27 @@ pub async fn delegate_call_async(
     Ok(())
 }
 
-pub fn delegate_call(
+pub fn delegate_call<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(delegate_call_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(delegate_call_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const DELEGATE_L1_HANDLER: &str =
     "syscall_handler.delegate_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn delegate_l1_handler(
+pub fn delegate_l1_handler<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.delegate_l1_handler(syscall_ptr, vm))?
@@ -84,14 +85,14 @@ pub fn delegate_l1_handler(
 
 pub const DEPLOY: &str = "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn deploy(
+pub fn deploy<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.deploy(syscall_ptr, vm))?
@@ -99,14 +100,14 @@ pub fn deploy(
 
 pub const EMIT_EVENT: &str = "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn emit_event(
+pub fn emit_event<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     syscall_handler.emit_event();
 
     Ok(())
@@ -114,14 +115,14 @@ pub fn emit_event(
 
 pub const GET_BLOCK_NUMBER: &str = "syscall_handler.get_block_number(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_block_number(
+pub fn get_block_number<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_block_number(syscall_ptr, vm))?
@@ -130,14 +131,14 @@ pub fn get_block_number(
 pub const GET_BLOCK_TIMESTAMP: &str =
     "syscall_handler.get_block_timestamp(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_block_timestamp(
+pub fn get_block_timestamp<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_block_timestamp(syscall_ptr, vm))?
@@ -146,13 +147,13 @@ pub fn get_block_timestamp(
 pub const GET_CALLER_ADDRESS: &str =
     "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn get_caller_address_async(
+pub async fn get_caller_address_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.get_caller_address(syscall_ptr, vm).await;
@@ -160,27 +161,27 @@ pub async fn get_caller_address_async(
     Ok(())
 }
 
-pub fn get_caller_address(
+pub fn get_caller_address<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(get_caller_address_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(get_caller_address_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const GET_CONTRACT_ADDRESS: &str =
     "syscall_handler.get_contract_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_contract_address(
+pub fn get_contract_address<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_contract_address(syscall_ptr, vm))?
@@ -189,14 +190,14 @@ pub fn get_contract_address(
 pub const GET_SEQUENCER_ADDRESS: &str =
     "syscall_handler.get_sequencer_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_sequencer_address(
+pub fn get_sequencer_address<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_sequencer_address(syscall_ptr, vm))?
@@ -204,14 +205,14 @@ pub fn get_sequencer_address(
 
 pub const GET_TX_INFO: &str = "syscall_handler.get_tx_info(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_tx_info(
+pub fn get_tx_info<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_tx_info(syscall_ptr, vm))?
@@ -219,14 +220,14 @@ pub fn get_tx_info(
 
 pub const GET_TX_SIGNATURE: &str = "syscall_handler.get_tx_signature(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_tx_signature(
+pub fn get_tx_signature<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_tx_signature(syscall_ptr, vm))?
@@ -234,14 +235,14 @@ pub fn get_tx_signature(
 
 pub const LIBRARY: &str = "syscall_handler.library_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn library_call(
+pub fn library_call<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.library_call(syscall_ptr, vm))?
@@ -250,14 +251,14 @@ pub fn library_call(
 pub const LIBRARY_CALL_L1_HANDLER: &str =
     "syscall_handler.library_call_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn library_call_l1_handler(
+pub fn library_call_l1_handler<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.library_call_l1_handler(syscall_ptr, vm))?
@@ -265,14 +266,14 @@ pub fn library_call_l1_handler(
 
 pub const REPLACE_CLASS: &str = "syscall_handler.replace_class(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn replace_class(
+pub fn replace_class<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
 
     syscall_handler.replace_class();
 
@@ -282,14 +283,14 @@ pub fn replace_class(
 pub const SEND_MESSAGE_TO_L1: &str =
     "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn send_message_to_l1(
+pub fn send_message_to_l1<S: Storage + 'static>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
     _ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
 
     syscall_handler.send_message_to_l1();
 
@@ -298,13 +299,13 @@ pub fn send_message_to_l1(
 
 pub const STORAGE_READ: &str = "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn storage_read_async(
+pub async fn storage_read_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.storage_read(syscall_ptr, vm).await?;
@@ -312,25 +313,25 @@ pub async fn storage_read_async(
     Ok(())
 }
 
-pub fn storage_read(
+pub fn storage_read<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(storage_read_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(storage_read_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const STORAGE_WRITE: &str = "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn storage_write_async(
+pub async fn storage_write_async<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError> {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.storage_write(syscall_ptr).await?;
@@ -338,14 +339,14 @@ pub async fn storage_write_async(
     Ok(())
 }
 
-pub fn storage_write(
+pub fn storage_write<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    execute_coroutine(storage_write_async(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(storage_write_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const SET_SYSCALL_PTR: &str = indoc! {r#"
@@ -355,7 +356,7 @@ pub const SET_SYSCALL_PTR: &str = indoc! {r#"
 	syscall_handler.set_syscall_ptr(syscall_ptr=ids.syscall_ptr)"#
 };
 
-pub fn set_syscall_ptr(
+pub fn set_syscall_ptr<S: Storage + 'static>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -368,7 +369,7 @@ pub fn set_syscall_ptr(
     insert_value_from_var_name(vars::ids::OS_CONTEXT, os_context, vm, ids_data, ap_tracking)?;
     insert_value_from_var_name(vars::ids::SYSCALL_PTR, syscall_ptr, vm, ids_data, ap_tracking)?;
 
-    let syscall_handler: OsSyscallHandlerWrapper = exec_scopes.get(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler: OsSyscallHandlerWrapper<S> = exec_scopes.get(vars::scopes::SYSCALL_HANDLER)?;
     execute_coroutine(syscall_handler.set_syscall_ptr(syscall_ptr))?;
 
     Ok(())
@@ -411,12 +412,13 @@ mod tests {
     use super::*;
     use crate::execution::helper::ContractStorageMap;
     use crate::hints::tests::tests::{block_context, old_block_number_and_hash};
+    use crate::storage::dict_storage::DictStorage;
     use crate::ExecutionHelperWrapper;
 
     #[fixture]
     fn exec_scopes(block_context: BlockContext, old_block_number_and_hash: (Felt252, Felt252)) -> ExecutionScopes {
         let execution_infos = vec![];
-        let exec_helper = ExecutionHelperWrapper::new(
+        let exec_helper = ExecutionHelperWrapper::<DictStorage>::new(
             ContractStorageMap::default(),
             execution_infos,
             &block_context,
@@ -446,7 +448,7 @@ mod tests {
         let ap_tracking = ApTracking::new();
         let constants = HashMap::new();
 
-        set_syscall_ptr(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
+        set_syscall_ptr::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
 
         let os_context = get_ptr_from_var_name(vars::ids::OS_CONTEXT, &vm, &ids_data, &ap_tracking).unwrap();
         let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, &vm, &ids_data, &ap_tracking).unwrap();
@@ -454,7 +456,8 @@ mod tests {
         assert_eq!(os_context, Relocatable::from((2, 0)));
         assert_eq!(syscall_ptr, Relocatable::from((3, 0)));
 
-        let syscall_handler: OsSyscallHandlerWrapper = exec_scopes.get(vars::scopes::SYSCALL_HANDLER).unwrap();
+        let syscall_handler: OsSyscallHandlerWrapper<DictStorage> =
+            exec_scopes.get(vars::scopes::SYSCALL_HANDLER).unwrap();
         assert_eq!(syscall_handler.syscall_ptr().await, Some(syscall_ptr));
     }
 }

--- a/crates/starknet-os/src/hints/tests.rs
+++ b/crates/starknet-os/src/hints/tests.rs
@@ -160,7 +160,8 @@ pub mod tests {
         // before starting tx, tx_execution_info should be none
         assert!(exec_helper_box.execution_helper.read().await.tx_execution_info.is_none());
 
-        start_tx::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
+        start_tx::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
+            .expect("start_tx");
 
         // after starting tx, tx_execution_info should be some
         assert!(exec_helper_box.execution_helper.read().await.tx_execution_info.is_some());
@@ -201,7 +202,8 @@ pub mod tests {
             exec_helper_box.execution_helper.read().await.tx_execution_info_iter.clone().peekable().peek().is_some()
         );
 
-        skip_tx::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("skip_tx");
+        skip_tx::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
+            .expect("skip_tx");
 
         // after skipping a tx, tx_execution_info should be some and iter should not have a next()
         assert!(exec_helper_box.execution_helper.read().await.tx_execution_info.is_none());
@@ -241,12 +243,14 @@ pub mod tests {
         let exec_helper_box = Box::new(exec_helper);
         exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 
-        start_tx::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("start_tx");
+        start_tx::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
+            .expect("start_tx");
 
         // we should have a call next
         assert!(exec_helper_box.execution_helper.read().await.call_iter.clone().peekable().peek().is_some());
 
-        skip_call::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("skip_call");
+        skip_call::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default())
+            .expect("skip_call");
 
         // our only call should have been consumed
         assert!(exec_helper_box.execution_helper.read().await.call_iter.clone().peekable().peek().is_none());

--- a/crates/starknet-os/src/hints/unimplemented.rs
+++ b/crates/starknet-os/src/hints/unimplemented.rs
@@ -1,6 +1,18 @@
 use indoc::indoc;
 
 #[allow(unused)]
+pub const COMPUTE_SLOPE: &str = indoc! {r#"
+    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_ALPHA, SECP256R1_P
+    from starkware.cairo.common.cairo_secp.secp_utils import pack
+    from starkware.python.math_utils import ec_double_slope
+
+    # Compute the slope.
+    x = pack(ids.point.x, SECP256R1_P)
+    y = pack(ids.point.y, SECP256R1_P)
+    value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)"#
+};
+
+#[allow(unused)]
 pub const CALCULATE_VALUE: &str = indoc! {r#"
     from starkware.cairo.common.cairo_secp.secp_utils import SECP256R1, pack
     from starkware.python.math_utils import y_squared_from_x
@@ -159,4 +171,18 @@ pub const COMPUTE_Q_MOD_PRIME: &str = indoc! {r#"
     q, r = divmod(pack(ids.val, PRIME), SECP256R1_P)
     assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
     ids.q = q % PRIME"#
+};
+
+#[allow(unused)]
+pub const COMPUTE_SLOPE_2: &str = indoc! {r#"
+    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
+    from starkware.cairo.common.cairo_secp.secp_utils import pack
+    from starkware.python.math_utils import line_slope
+
+    # Compute the slope.
+    x0 = pack(ids.point0.x, PRIME)
+    y0 = pack(ids.point0.y, PRIME)
+    x1 = pack(ids.point1.x, PRIME)
+    y1 = pack(ids.point1.y, PRIME)
+    value = slope = line_slope(point1=(x0, y0), point2=(x1, y1), p=SECP256R1_P)"#
 };

--- a/crates/starknet-os/src/hints/unimplemented.rs
+++ b/crates/starknet-os/src/hints/unimplemented.rs
@@ -1,18 +1,6 @@
 use indoc::indoc;
 
 #[allow(unused)]
-pub const COMPUTE_SLOPE: &str = indoc! {r#"
-    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_ALPHA, SECP256R1_P
-    from starkware.cairo.common.cairo_secp.secp_utils import pack
-    from starkware.python.math_utils import ec_double_slope
-
-    # Compute the slope.
-    x = pack(ids.point.x, SECP256R1_P)
-    y = pack(ids.point.y, SECP256R1_P)
-    value = slope = ec_double_slope(point=(x, y), alpha=SECP256R1_ALPHA, p=SECP256R1_P)"#
-};
-
-#[allow(unused)]
 pub const CALCULATE_VALUE: &str = indoc! {r#"
     from starkware.cairo.common.cairo_secp.secp_utils import SECP256R1, pack
     from starkware.python.math_utils import y_squared_from_x
@@ -171,18 +159,4 @@ pub const COMPUTE_Q_MOD_PRIME: &str = indoc! {r#"
     q, r = divmod(pack(ids.val, PRIME), SECP256R1_P)
     assert r == 0, f"verify_zero: Invalid input {ids.val.d0, ids.val.d1, ids.val.d2}."
     ids.q = q % PRIME"#
-};
-
-#[allow(unused)]
-pub const COMPUTE_SLOPE_2: &str = indoc! {r#"
-    from starkware.cairo.common.cairo_secp.secp256r1_utils import SECP256R1_P
-    from starkware.cairo.common.cairo_secp.secp_utils import pack
-    from starkware.python.math_utils import line_slope
-
-    # Compute the slope.
-    x0 = pack(ids.point0.x, PRIME)
-    y0 = pack(ids.point0.y, PRIME)
-    x1 = pack(ids.point1.x, PRIME)
-    y1 = pack(ids.point1.y, PRIME)
-    value = slope = line_slope(point1=(x0, y0), point2=(x1, y1), p=SECP256R1_P)"#
 };


### PR DESCRIPTION
Problem: for RPC compatibility, we need the OS to be compatible with user-defined storage types. This would allow, for example, to load storage values from an RPC at runtime.

Solution: make the execution helper generic on the storage type.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
