### PR TITLE
Fix: include compiled OS in the library binary

### DIFF
--- a/crates/starknet-os/src/config.rs
+++ b/crates/starknet-os/src/config.rs
@@ -24,12 +24,12 @@ pub fn default_layout() -> LayoutName {
 // https://github.com/starkware-libs/blockifier/blob/8da582b285bfbc7d4c21178609bbd43f80a69240/crates/native_blockifier/src/py_block_executor.rs#L44
 const MAX_STEPS_PER_TX: u32 = 4_000_000;
 
+pub const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../build/os_latest.json");
+
 const DEFAULT_CONFIG_PATH: &str = "../../cairo-lang/src/starkware/starknet/definitions/general_config.yml";
 pub const STORED_BLOCK_HASH_BUFFER: u64 = 10;
 pub const BLOCK_HASH_CONTRACT_ADDRESS: u64 = 1;
 pub const STARKNET_OS_CONFIG_HASH_VERSION: &str = "StarknetOsConfig1";
-pub const DEFAULT_COMPILED_OS: &str = "../build/os_latest.json";
-pub const DEFAULT_INPUT_PATH: &str = "../build/input.json";
 pub const DEFAULT_COMPILER_VERSION: &str = "0.12.2";
 pub const DEFAULT_STORAGE_TREE_HEIGHT: usize = 251;
 pub const COMPILED_CLASS_HASH_COMMITMENT_TREE_HEIGHT: usize = 251;

--- a/crates/starknet-os/src/lib.rs
+++ b/crates/starknet-os/src/lib.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use blockifier::context::BlockContext;
 use cairo_vm::cairo_run::CairoRunConfig;
 use cairo_vm::types::layout_name::LayoutName;
@@ -32,7 +30,7 @@ pub mod storage;
 pub mod utils;
 
 pub fn run_os<S>(
-    os_path: String,
+    compiled_os: &[u8],
     layout: LayoutName,
     os_input: StarknetOsInput,
     block_context: BlockContext,
@@ -46,13 +44,12 @@ where
     let allow_missing_builtins = cairo_run_config.allow_missing_builtins.unwrap_or(false);
 
     // Load the Starknet OS Program
-    let starknet_os = fs::read(os_path).map_err(|e| SnOsError::CatchAll(format!("{e}")))?;
-    let program = Program::from_bytes(&starknet_os, Some(cairo_run_config.entrypoint))
-        .map_err(|e| SnOsError::Runner(e.into()))?;
+    let os_program =
+        Program::from_bytes(compiled_os, Some(cairo_run_config.entrypoint)).map_err(|e| SnOsError::Runner(e.into()))?;
 
     // Init cairo runner
     let mut cairo_runner = CairoRunner::new(
-        &program,
+        &os_program,
         cairo_run_config.layout,
         cairo_run_config.proof_mode,
         cairo_run_config.trace_enabled,

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -826,7 +826,7 @@ where
         execute_txs(state, &block_context, txs, deprecated_contract_classes, contract_classes).await;
 
     let layout = config::default_layout();
-    let result = run_os(config::DEFAULT_COMPILED_OS.to_string(), layout, os_input, block_context, execution_helper);
+    let result = run_os(config::DEFAULT_COMPILED_OS, layout, os_input, block_context, execution_helper);
 
     match &result {
         Err(Runner(VmException(vme))) => {


### PR DESCRIPTION
Problem: the OS was configured as a relative path inside the `starknet-os` library, leading to potential issues when using the library in different contexts.

Solution: load the compiled OS as a constant. Note that this makes the library quite heavy as the OS takes around 32MB. We believe this is acceptable for a first iteration.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes, the signature to `run_os` changes.
- [ ] no
