### PR TITLE
Fix: copy-paste issues in the implementation of `get_block_timestamp()`

### DIFF
--- a/crates/starknet-os/src/cairo_types/syscalls.rs
+++ b/crates/starknet-os/src/cairo_types/syscalls.rs
@@ -97,6 +97,22 @@ pub struct GetBlockNumber {
     pub response: GetBlockNumberResponse,
 }
 
+#[derive(FieldOffsetGetters)]
+pub struct GetBlockTimestampRequest {
+    pub selector: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct GetBlockTimestampResponse {
+    pub block_timestamp: Felt252,
+}
+
+#[derive(FieldOffsetGetters)]
+pub struct GetBlockTimestamp {
+    pub request: GetBlockTimestampRequest,
+    pub response: GetBlockTimestampResponse,
+}
+
 // Describes the GetContractAddress system call format.
 #[derive(FieldOffsetGetters)]
 pub struct GetContractAddressRequest {

--- a/crates/starknet-os/src/execution/deprecated_syscall_handler.rs
+++ b/crates/starknet-os/src/execution/deprecated_syscall_handler.rs
@@ -10,8 +10,9 @@ use tokio::sync::RwLock;
 use super::helper::ExecutionHelperWrapper;
 use crate::cairo_types::syscalls::{
     CallContract, CallContractResponse, Deploy, DeployResponse, GetBlockNumber, GetBlockNumberResponse,
-    GetContractAddress, GetContractAddressResponse, GetSequencerAddress, GetSequencerAddressResponse, GetTxInfo,
-    GetTxInfoResponse, GetTxSignature, GetTxSignatureResponse, LibraryCall, TxInfo,
+    GetBlockTimestamp, GetBlockTimestampResponse, GetContractAddress, GetContractAddressResponse, GetSequencerAddress,
+    GetSequencerAddressResponse, GetTxInfo, GetTxInfoResponse, GetTxSignature, GetTxSignatureResponse, LibraryCall,
+    TxInfo,
 };
 use crate::storage::storage::Storage;
 use crate::utils::felt_api2vm;
@@ -158,10 +159,11 @@ where
     ) -> Result<(), HintError> {
         let syscall_handler = self.deprecated_syscall_handler.read().await;
 
-        let block_number = syscall_handler.block_info.block_timestamp;
+        let block_timestamp = syscall_handler.block_info.block_timestamp;
 
-        let response_offset = GetBlockNumber::response_offset() + GetBlockNumberResponse::block_number_offset();
-        vm.insert_value((syscall_ptr + response_offset)?, Felt252::from(block_number.0))?;
+        let response_offset =
+            GetBlockTimestamp::response_offset() + GetBlockTimestampResponse::block_timestamp_offset();
+        vm.insert_value((syscall_ptr + response_offset)?, Felt252::from(block_timestamp.0))?;
 
         Ok(())
     }


### PR DESCRIPTION
Problem: the implementation of the `get_block_timestamp()` syscall was hastily copied from the implementation of `get_block_number()` and uses the wrong types. There is no functional problem because the types used have the same sizes, but this needs to be cleaned up.

Solution: define the request/response types and use them.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
