### PR TITLE
Internal: make it easier to declare new test contracts

### DIFF
--- a/tests/integration/common/blockifier_contracts.rs
+++ b/tests/integration/common/blockifier_contracts.rs
@@ -1,18 +1,14 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 
-use crate::common::contract_fixtures::{get_compiled_sierra_class, get_deprecated_compiled_class};
-use crate::common::utils::compile_sierra_contract_class;
+use crate::common::contract_fixtures::{get_deprecated_compiled_class, load_cairo1_contract};
 
-pub fn get_deprecated_feature_contract_class(contract_name: &str) -> DeprecatedCompiledClass {
+fn get_deprecated_feature_contract_path(contract_name: &str) -> PathBuf {
     let filename = format!("{contract_name}_compiled.json");
-    let contract_rel_path =
-        Path::new("blockifier_contracts").join("feature_contracts").join("cairo0").join("compiled").join(filename);
-    log::debug!("Getting contract at {:?}", contract_rel_path);
-    get_deprecated_compiled_class(&contract_rel_path)
+    Path::new("blockifier_contracts").join("feature_contracts").join("cairo0").join("compiled").join(filename)
 }
 
 pub fn get_deprecated_erc20_contract_class() -> DeprecatedCompiledClass {
@@ -23,23 +19,21 @@ pub fn get_deprecated_erc20_contract_class() -> DeprecatedCompiledClass {
     get_deprecated_compiled_class(&contract_rel_path)
 }
 
-pub fn get_feature_sierra_contract_class(contract_name: &str) -> ContractClass {
+fn get_feature_sierra_contract_path(contract_name: &str) -> PathBuf {
     let filename = format!("{contract_name}.sierra");
-    let contract_rel_path =
-        Path::new("blockifier_contracts").join("feature_contracts").join("cairo1").join("compiled").join(filename);
-    log::debug!("Getting contract at {:?}", contract_rel_path);
-    get_compiled_sierra_class(&contract_rel_path)
+    Path::new("blockifier_contracts").join("feature_contracts").join("cairo1").join("compiled").join(filename)
 }
 
 /// Helper to load a Cairo 0 contract class.
 pub(crate) fn load_cairo0_feature_contract(name: &str) -> (String, DeprecatedCompiledClass) {
-    (name.to_string(), get_deprecated_feature_contract_class(name))
+    let contract_path = get_deprecated_feature_contract_path(name);
+    let compiled_class = get_deprecated_compiled_class(&contract_path);
+    (name.to_string(), compiled_class)
 }
 
 /// Helper to load a Cairo1 contract class.
-pub(crate) fn load_cairo1_contract(name: &str) -> (String, ContractClass, CasmContractClass) {
-    let sierra_contract_class = get_feature_sierra_contract_class(name);
-    let casm_contract_class = compile_sierra_contract_class(sierra_contract_class.clone())
-        .unwrap_or_else(|e| panic!("Failed to compile Sierra contract {}: {}", name, e));
+pub(crate) fn load_cairo1_feature_contract(name: &str) -> (String, ContractClass, CasmContractClass) {
+    let sierra_contract_path = get_feature_sierra_contract_path(name);
+    let (sierra_contract_class, casm_contract_class) = load_cairo1_contract(&sierra_contract_path);
     (name.to_string(), sierra_contract_class, casm_contract_class)
 }

--- a/tests/integration/common/contract_fixtures.rs
+++ b/tests/integration/common/contract_fixtures.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, StarknetSierraCompilationError};
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 
@@ -25,4 +26,23 @@ pub fn get_deprecated_compiled_class(contract_rel_path: &Path) -> DeprecatedComp
 pub fn get_compiled_sierra_class(contract_rel_path: &Path) -> ContractClass {
     let content = read_contract(contract_rel_path);
     serde_json::from_slice(&content).unwrap_or_else(|e| panic!("Failed to load deprecated compiled class: {e}"))
+}
+
+/// Compiles a Sierra class to CASM.
+pub(crate) fn compile_sierra_contract_class(
+    sierra_contract_class: ContractClass,
+) -> Result<CasmContractClass, StarknetSierraCompilationError> {
+    // Values taken from the defaults of `starknet-sierra-compile`, see here:
+    // https://github.com/starkware-libs/cairo/blob/main/crates/bin/starknet-sierra-compile/src/main.rs
+    let add_pythonic_hints = false;
+    let max_bytecode_size = 180000;
+    CasmContractClass::from_contract_class(sierra_contract_class, add_pythonic_hints, max_bytecode_size)
+}
+
+/// Helper to load a Cairo1 contract class.
+pub(crate) fn load_cairo1_contract(contract_path: &Path) -> (ContractClass, CasmContractClass) {
+    let sierra_contract_class = get_compiled_sierra_class(contract_path);
+    let casm_contract_class = compile_sierra_contract_class(sierra_contract_class.clone())
+        .unwrap_or_else(|e| panic!("Failed to compile Sierra contract {}: {}", contract_path.to_string_lossy(), e));
+    (sierra_contract_class, casm_contract_class)
 }

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -6,7 +6,6 @@ use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_def
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::vm::runners::cairo_runner::CairoRunner;
-use cairo_vm::vm::vm_core::VirtualMachine;
 use rstest::fixture;
 
 pub mod block_utils;

--- a/tests/integration/common/os_itest_contracts.rs
+++ b/tests/integration/common/os_itest_contracts.rs
@@ -1,17 +1,16 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 
 use crate::common::contract_fixtures::get_deprecated_compiled_class;
 
-fn get_deprecated_os_itest_contract_class(contract_name: &str) -> DeprecatedCompiledClass {
+fn get_deprecated_os_itest_contract_path(contract_name: &str) -> PathBuf {
     let filename = format!("{contract_name}_compiled.json");
-    let contract_rel_path = Path::new("os_itest_contracts").join("compiled").join(filename);
-    log::debug!("Getting contract at {:?}", contract_rel_path);
-    get_deprecated_compiled_class(&contract_rel_path)
+    Path::new("os_itest_contracts").join("compiled").join(filename)
 }
 
 /// Helper to load a Cairo 0 contract class.
 pub fn load_os_itest_contract(name: &str) -> (String, DeprecatedCompiledClass) {
-    (name.to_string(), get_deprecated_os_itest_contract_class(name))
+    let contract_path = get_deprecated_os_itest_contract_path(name);
+    (name.to_string(), get_deprecated_compiled_class(&contract_path))
 }

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -22,7 +22,7 @@ use starknet_os::storage::dict_storage::DictStorage;
 use starknet_os::storage::storage::{FactFetchingContext, HashFunctionType, StorageError};
 use starknet_os::storage::storage_utils::{compiled_contract_class_cl2vm, deprecated_contract_class_api2vm};
 
-use super::blockifier_contracts::{load_cairo0_feature_contract, load_cairo1_contract};
+use super::blockifier_contracts::{load_cairo0_feature_contract, load_cairo1_feature_contract};
 use crate::common::block_context;
 use crate::common::blockifier_contracts::get_deprecated_erc20_contract_class;
 
@@ -587,7 +587,7 @@ pub async fn initial_state_cairo1(
     #[from(init_logging)] _logging: (),
 ) -> StarknetTestState {
     let test_contract = load_cairo0_feature_contract("test_contract");
-    let account_with_dummy_validate = load_cairo1_contract("account_with_dummy_validate");
+    let account_with_dummy_validate = load_cairo1_feature_contract("account_with_dummy_validate");
 
     StarknetStateBuilder::new(&block_context)
         .deploy_cairo1_contract(
@@ -607,8 +607,8 @@ pub async fn initial_state_syscalls(
     block_context: BlockContext,
     #[from(init_logging)] _logging: (),
 ) -> StarknetTestState {
-    let account_with_dummy_validate = load_cairo1_contract("account_with_dummy_validate");
-    let test_contract = load_cairo1_contract("test_contract");
+    let account_with_dummy_validate = load_cairo1_feature_contract("account_with_dummy_validate");
+    let test_contract = load_cairo1_feature_contract("test_contract");
 
     StarknetStateBuilder::new(&block_context)
         .deploy_cairo1_contract(

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -1,13 +1,12 @@
 use std::env;
 
-use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, StarknetSierraCompilationError};
-use cairo_lang_starknet_classes::contract_class::ContractClass;
+use blockifier::context::BlockContext;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
+use cairo_vm::vm::runners::cairo_runner::CairoRunner;
+use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_vm::Felt252;
 use num_traits::ToPrimitive;
 use starknet_os::io::output::StarknetOsOutput;
-
-use super::*;
 
 #[allow(unused)]
 pub fn check_output_vs_python(
@@ -68,15 +67,4 @@ pub fn check_os_output_read_only_syscall(os_output: StarknetOsOutput, block_cont
     assert!(os_output.messages_to_l2.is_empty());
     let use_kzg_da = os_output.use_kzg_da != Felt252::ZERO;
     assert_eq!(use_kzg_da, block_context.block_info().use_kzg_da);
-}
-
-/// Compiles a Sierra class to CASM.
-pub(crate) fn compile_sierra_contract_class(
-    sierra_contract_class: ContractClass,
-) -> Result<CasmContractClass, StarknetSierraCompilationError> {
-    // Values taken from the defaults of `starknet-sierra-compile`, see here:
-    // https://github.com/starkware-libs/cairo/blob/main/crates/bin/starknet-sierra-compile/src/main.rs
-    let add_pythonic_hints = false;
-    let max_bytecode_size = 180000;
-    CasmContractClass::from_contract_class(sierra_contract_class, add_pythonic_hints, max_bytecode_size)
 }

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -11,7 +11,7 @@ use starknet_os::starknet::business_logic::utils::write_class_facts;
 use starknet_os::storage::storage_utils::{compiled_contract_class_cl2vm, deprecated_contract_class_api2vm};
 
 use crate::common::block_context;
-use crate::common::blockifier_contracts::load_cairo1_contract;
+use crate::common::blockifier_contracts::load_cairo1_feature_contract;
 use crate::common::state::{initial_state_cairo0, initial_state_cairo1, StarknetTestState};
 use crate::common::transaction_utils::execute_txs_and_run_os;
 
@@ -42,7 +42,7 @@ async fn declare_v3_cairo1_account(
     // We want to declare a fresh (never-before-declared) contract, so we don't want to reuse
     // anything from the test fixtures, and we need to do it "by hand". The transaction will
     // error if the class trie already contains the class we are trying to deploy.
-    let (_, sierra_class, casm_class) = load_cairo1_contract("empty_contract");
+    let (_, sierra_class, casm_class) = load_cairo1_feature_contract("empty_contract");
 
     // We also need to write the class and compiled class facts so that the FFC will contain them
     // during block re-execution.
@@ -101,7 +101,7 @@ async fn declare_cairo1_account(
     // We want to declare a fresh (never-before-declared) contract, so we don't want to reuse
     // anything from the test fixtures, and we need to do it "by hand". The transaction will
     // error if the class trie already contains the class we are trying to deploy.
-    let (_, sierra_class, casm_class) = load_cairo1_contract("empty_contract");
+    let (_, sierra_class, casm_class) = load_cairo1_feature_contract("empty_contract");
 
     // We also need to write the class and compiled class facts so that the FFC will contain them
     // during block re-execution.

--- a/tests/integration/deploy_txn_tests.rs
+++ b/tests/integration/deploy_txn_tests.rs
@@ -11,7 +11,7 @@ use starknet_api::transaction::{Calldata, ContractAddressSalt, Fee, TransactionV
 use starknet_api::{class_hash, contract_address, patricia_key, stark_felt};
 
 use crate::common::block_context;
-use crate::common::blockifier_contracts::{load_cairo0_feature_contract, load_cairo1_contract};
+use crate::common::blockifier_contracts::{load_cairo0_feature_contract, load_cairo1_feature_contract};
 use crate::common::state::{init_logging, StarknetStateBuilder, StarknetTestState};
 use crate::common::transaction_utils::execute_txs_and_run_os;
 
@@ -116,8 +116,8 @@ pub async fn initial_state_for_deploy_v3(
     block_context: BlockContext,
     #[from(init_logging)] _logging: (),
 ) -> (StarknetTestState, DeployArgs) {
-    let account_with_dummy_validate = load_cairo1_contract("account_with_dummy_validate");
-    let account_with_long_validate = load_cairo1_contract("account_with_long_validate");
+    let account_with_dummy_validate = load_cairo1_feature_contract("account_with_dummy_validate");
+    let account_with_long_validate = load_cairo1_feature_contract("account_with_long_validate");
 
     // This is the hardcoded class hash of `account_with_long_validate` (Cairo 1).
     // Recomputing it automatically requires a significant amount of code reorganization so


### PR DESCRIPTION
Problem: loading use-case specific test contracts (Blockifier feature contracts, OS itests) involves too much duplication.

Solution: provide generic functions to load a contract from its path in the `contract_fixtures` module and simplify the logic in specific modules to just get the path to contracts.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
