### PR TITLE
Chore: bump Blockifier to 0.6.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ anyhow = "1.0.75"
 assert_matches = "1.5.0"
 base64 = "0.21.3"
 bitvec = { version = "1.0.1", features = ["serde"] }
-blockifier = { git = "https://github.com/Moonsong-Labs/blockifier", branch = "msl/derive-clone", features = ["testing"] }
+# Point to the latest commit of branch msl/snos-0.6.0-rc.2
+blockifier = { git = "https://github.com/Moonsong-Labs/blockifier", rev = "30bb3d29b695ec4e0e9e6dccb62737f8f9474a54", features = ["testing"] }
 cairo-lang-starknet = { version = "2.6.3" }
 cairo-lang-starknet-classes = { version = "2.6.3" }
 cairo-lang-casm = { version = "2.6.3" }

--- a/crates/starknet-os/src/hints/tests.rs
+++ b/crates/starknet-os/src/hints/tests.rs
@@ -56,6 +56,7 @@ pub mod tests {
             da_gas: Default::default(),
             actual_resources: Default::default(),
             revert_error: None,
+            bouncer_resources: Default::default(),
         }
     }
 


### PR DESCRIPTION
Blockifier 0.6.0-rc.2 is used in production for cairo-lang 0.13.1 so we can safely use it.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [x] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
