### PR TITLE
Fix: bump Rust toolchain

### DIFF
--- a/crates/starknet-os/src/cairo_types/bigint.rs
+++ b/crates/starknet-os/src/cairo_types/bigint.rs
@@ -3,7 +3,10 @@ use cairo_vm::Felt252;
 
 #[derive(FieldOffsetGetters)]
 pub struct BigInt3 {
+    #[allow(unused)]
     pub d0: Felt252,
+    #[allow(unused)]
     pub d1: Felt252,
+    #[allow(unused)]
     pub d2: Felt252,
 }

--- a/crates/starknet-os/src/cairo_types/builtins.rs
+++ b/crates/starknet-os/src/cairo_types/builtins.rs
@@ -3,17 +3,26 @@ use cairo_vm::Felt252;
 
 #[derive(FieldOffsetGetters)]
 pub struct HashBuiltin {
+    #[allow(unused)]
     pub x: Felt252,
+    #[allow(unused)]
     pub y: Felt252,
+    #[allow(unused)]
     pub result: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct SpongeHashBuiltin {
+    #[allow(unused)]
     pub x: Felt252,
+    #[allow(unused)]
     pub y: Felt252,
+    #[allow(unused)]
     pub c_in: Felt252,
+    #[allow(unused)]
     pub result: Felt252,
+    #[allow(unused)]
     pub result1: Felt252,
+    #[allow(unused)]
     pub c_out: Felt252,
 }

--- a/crates/starknet-os/src/cairo_types/dict_access.rs
+++ b/crates/starknet-os/src/cairo_types/dict_access.rs
@@ -3,7 +3,10 @@ use cairo_vm::Felt252;
 
 #[derive(FieldOffsetGetters)]
 pub struct DictAccess {
+    #[allow(unused)]
     pub key: Felt252,
+    #[allow(unused)]
     pub prev_value: Felt252,
+    #[allow(unused)]
     pub new_value: Felt252,
 }

--- a/crates/starknet-os/src/cairo_types/new_syscalls.rs
+++ b/crates/starknet-os/src/cairo_types/new_syscalls.rs
@@ -37,8 +37,11 @@ pub struct DeployRequest {
 
 #[derive(FieldOffsetGetters)]
 pub struct DeployResponse {
+    #[allow(unused)]
     pub contract_address: Felt252,
+    #[allow(unused)]
     pub constructor_retdata_start: Relocatable,
+    #[allow(unused)]
     pub constructor_retdata_end: Relocatable,
 }
 
@@ -60,11 +63,15 @@ pub struct GetBlockHashRequest {
 #[derive(FieldOffsetGetters)]
 pub struct LibraryCallRequest {
     /// The hash of the class to run.
+    #[allow(unused)]
     pub class_hash: Felt252,
     /// The selector of the function to call.
+    #[allow(unused)]
     pub selector: Felt252,
     /// The calldata.
+    #[allow(unused)]
     pub calldata_start: Relocatable,
+    #[allow(unused)]
     pub calldata_end: Relocatable,
 }
 

--- a/crates/starknet-os/src/cairo_types/structs.rs
+++ b/crates/starknet-os/src/cairo_types/structs.rs
@@ -4,11 +4,17 @@ use cairo_vm::Felt252;
 
 #[derive(FieldOffsetGetters)]
 pub struct ExecutionContext {
+    #[allow(unused)]
     pub entry_point_type: Felt252,
+    #[allow(unused)]
     pub class_hash: Felt252,
+    #[allow(unused)]
     pub calldata_size: Felt252,
+    #[allow(unused)]
     pub calldata: Relocatable,
+    #[allow(unused)]
     pub execution_info: Relocatable,
+    #[allow(unused)]
     pub deprecated_tx_info: Relocatable,
 }
 

--- a/crates/starknet-os/src/cairo_types/syscalls.rs
+++ b/crates/starknet-os/src/cairo_types/syscalls.rs
@@ -32,22 +32,31 @@ pub struct StorageWrite {
 
 #[derive(FieldOffsetGetters)]
 pub struct CallContractRequest {
+    #[allow(unused)]
     pub selector: Felt252,
+    #[allow(unused)]
     pub contract_address: Felt252,
+    #[allow(unused)]
     pub function_selector: Felt252,
+    #[allow(unused)]
     pub calldata_size: Felt252,
+    #[allow(unused)]
     pub calldata: Relocatable,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct CallContractResponse {
+    #[allow(unused)]
     pub retdata_size: Felt252,
+    #[allow(unused)]
     pub retdata: Relocatable,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct CallContract {
+    #[allow(unused)]
     pub request: CallContractRequest,
+    #[allow(unused)]
     pub response: CallContractResponse,
 }
 
@@ -55,45 +64,60 @@ pub struct CallContract {
 #[derive(FieldOffsetGetters)]
 pub struct DeployRequest {
     /// The system call selector (= DEPLOY_SELECTOR).
+    #[allow(unused)]
     pub selector: Felt252,
     /// The hash of the class to deploy.
+    #[allow(unused)]
     pub class_hash: Felt252,
     /// A salt for the new contract address calculation.
+    #[allow(unused)]
     pub contract_address_salt: Felt252,
     /// The size of the calldata for the constructor.
+    #[allow(unused)]
     pub constructor_calldata_size: Felt252,
     /// The calldata for the constructor.
+    #[allow(unused)]
     pub constructor_calldata: Relocatable,
     /// Used for deterministic contract address deployment.
+    #[allow(unused)]
     pub deploy_from_zero: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct DeployResponse {
+    #[allow(unused)]
     pub contract_address: Felt252,
+    #[allow(unused)]
     pub constructor_retdata_size: Felt252,
+    #[allow(unused)]
     pub constructor_retdata: Relocatable,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct Deploy {
+    #[allow(unused)]
     pub request: DeployRequest,
+    #[allow(unused)]
     pub response: DeployResponse,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetBlockNumberRequest {
+    #[allow(unused)]
     pub selector: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetBlockNumberResponse {
+    #[allow(unused)]
     pub block_number: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetBlockNumber {
+    #[allow(unused)]
     pub request: GetBlockNumberRequest,
+    #[allow(unused)]
     pub response: GetBlockNumberResponse,
 }
 
@@ -101,17 +125,21 @@ pub struct GetBlockNumber {
 #[derive(FieldOffsetGetters)]
 pub struct GetContractAddressRequest {
     // The system call selector (= GET_CONTRACT_ADDRESS_SELECTOR).
+    #[allow(unused)]
     pub selector: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetContractAddressResponse {
+    #[allow(unused)]
     pub contract_address: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetContractAddress {
+    #[allow(unused)]
     pub request: GetContractAddressRequest,
+    #[allow(unused)]
     pub response: GetContractAddressResponse,
 }
 
@@ -119,20 +147,27 @@ pub struct GetContractAddress {
 pub struct LibraryCallRequest {
     /// The system library call selector
     /// (= LIBRARY_CALL_SELECTOR or LIBRARY_CALL_L1_HANDLER_SELECTOR).
+    #[allow(unused)]
     pub selector: Felt252,
     /// The hash of the class to run.
+    #[allow(unused)]
     pub class_hash: Felt252,
     /// The selector of the function to call.
+    #[allow(unused)]
     pub function_selector: Felt252,
     /// The size of the calldata.
+    #[allow(unused)]
     pub calldata_size: Felt252,
     /// The calldata.
+    #[allow(unused)]
     pub calldata: Relocatable,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct LibraryCall {
+    #[allow(unused)]
     pub request: LibraryCallRequest,
+    #[allow(unused)]
     pub response: CallContractResponse,
 }
 
@@ -140,17 +175,21 @@ pub struct LibraryCall {
 #[derive(FieldOffsetGetters)]
 pub struct GetSequencerAddressRequest {
     // The system call selector (= GET_SEQUENCER_ADDRESS_SELECTOR).
+    #[allow(unused)]
     pub selector: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetSequencerAddressResponse {
+    #[allow(unused)]
     pub sequencer_address: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetSequencerAddress {
+    #[allow(unused)]
     pub request: GetSequencerAddressRequest,
+    #[allow(unused)]
     pub response: GetSequencerAddressResponse,
 }
 
@@ -160,20 +199,28 @@ pub struct TxInfo {
     /// signed by the account contract.
     /// This field allows invalidating old transactions, whenever the meaning of the other
     /// transaction fields is changed (in the OS).
+    #[allow(unused)]
     pub version: Felt252,
     /// The account contract from which this transaction originates.
+    #[allow(unused)]
     pub account_contract_address: Felt252,
     /// The max_fee field of the transaction.
+    #[allow(unused)]
     pub max_fee: Felt252,
     /// The signature of the transaction.
+    #[allow(unused)]
     pub signature_len: Felt252,
+    #[allow(unused)]
     pub signature: Relocatable,
     /// The hash of the transaction.
+    #[allow(unused)]
     pub transaction_hash: Felt252,
     /// The identifier of the chain.
     /// This field can be used to prevent replay of testnet transactions on mainnet.
+    #[allow(unused)]
     pub chain_id: Felt252,
     /// The transaction's nonce.
+    #[allow(unused)]
     pub nonce: Felt252,
 }
 
@@ -181,35 +228,44 @@ pub struct TxInfo {
 #[derive(FieldOffsetGetters)]
 pub struct GetTxInfoRequest {
     /// The system call selector (= GET_TX_INFO_SELECTOR).
+    #[allow(unused)]
     pub selector: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetTxInfoResponse {
     /// Points to a TxInfo struct.
+    #[allow(unused)]
     pub tx_info: Relocatable,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetTxInfo {
+    #[allow(unused)]
     pub request: GetTxInfoRequest,
+    #[allow(unused)]
     pub response: GetTxInfoResponse,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetTxSignatureRequest {
     // The system call selector (= GET_TX_SIGNATURE_SELECTOR).
+    #[allow(unused)]
     pub selector: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetTxSignatureResponse {
+    #[allow(unused)]
     pub signature_len: Felt252,
+    #[allow(unused)]
     pub signature: Relocatable,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetTxSignature {
+    #[allow(unused)]
     pub request: GetTxSignatureRequest,
+    #[allow(unused)]
     pub response: GetTxSignatureResponse,
 }

--- a/crates/starknet-os/src/cairo_types/traits.rs
+++ b/crates/starknet-os/src/cairo_types/traits.rs
@@ -3,9 +3,11 @@ use cairo_vm::vm::errors::memory_errors::MemoryError;
 use cairo_vm::vm::vm_core::VirtualMachine;
 
 pub trait CairoType: Sized {
+    #[allow(unused)]
     fn from_memory(vm: &VirtualMachine, address: Relocatable) -> Result<Self, MemoryError>;
     fn to_memory(&self, vm: &mut VirtualMachine, address: Relocatable) -> Result<(), MemoryError>;
 
+    #[allow(unused)]
     fn n_fields() -> usize;
 }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-01-11"
+channel = "nightly-2024-05-02"
 components = ["rustfmt", "clippy"]
-profile = "minimal"
+profile = "minimal" 

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -44,6 +44,7 @@ pub struct StarknetTestState {
     pub declared_cairo0_contracts: HashMap<String, DeclaredDeprecatedContract>,
     /// Declared cairo1 contracts. This only contains contracts added with
     /// `declare_cairo1_contract`.
+    #[allow(unused)]
     pub declared_cairo1_contracts: HashMap<String, DeclaredContract>,
     /// State initially created for blockifier execution
     pub cached_state: CachedState<SharedState<DictStorage, PedersenHash>>,
@@ -69,6 +70,7 @@ impl StarknetTestState {
 pub struct DeclaredContract {
     pub class_hash: ClassHash,
     pub casm_class: CasmContractClass,
+    #[allow(unused)]
     pub sierra_class: ContractClass,
 }
 
@@ -91,15 +93,6 @@ pub struct DeclaredDeprecatedContract {
 pub struct DeployedDeprecatedContract {
     pub address: ContractAddress,
     pub declaration: DeclaredDeprecatedContract,
-}
-
-/// ERC20 contract deployments for Eth and Strk tokens, as well as the compiled class. Note that
-/// this is always a cairo0 contract.
-#[derive(Debug)]
-pub struct FeeContracts {
-    pub erc20_contract: DeprecatedCompiledClass,
-    pub eth_fee_token_address: ContractAddress,
-    pub strk_fee_token_address: ContractAddress,
 }
 
 /// Configures the logging for integration tests.


### PR DESCRIPTION
Problem: The CI pipeline is broken because of new requirements for `udeps`.

Solution: bump the Rust toolchain to 1.78 nightly. The date of the build is the release date of Rust 1.78.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [x] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
