### PR TITLE
Feature: generic CASM class

### DIFF
--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -9,7 +9,6 @@ license-file.workspace = true
 blockifier = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
 num-bigint = { workspace = true }
-pathfinder-gateway-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 starknet_api = { workspace = true }

--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -6,7 +6,12 @@ repository.workspace = true
 license-file.workspace = true
 
 [dependencies]
+blockifier = { workspace = true }
+cairo-lang-starknet-classes = { workspace = true }
 num-bigint = { workspace = true }
+pathfinder-gateway-types = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 starknet_api = { workspace = true }
 starknet-types-core = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/starknet-os-types/src/contract_class.rs
+++ b/crates/starknet-os-types/src/contract_class.rs
@@ -1,0 +1,220 @@
+use std::cell::OnceCell;
+use std::rc::Rc;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::hash::GenericClassHash;
+
+pub type CairoLangCasmClass = cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
+pub type BlockifierCasmClass = blockifier::execution::contract_class::ContractClassV1;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ContractClassError {
+    #[error("Internal error: no type conversion is possible to generate the desired effect.")]
+    NoPossibleConversion,
+
+    #[error("Could not build Blockifier contract class")]
+    BlockifierConversionError,
+
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+}
+
+/// A generic contract class that supports conversion to/from the most commonly used
+/// contract class types in Starknet and provides utility methods.
+/// Operations are implemented as lazily as possible, i.e. we only convert
+/// between different types if strictly necessary.
+/// Fields are boxed in an RC for cheap cloning.
+#[derive(Debug, Clone)]
+pub struct GenericCasmContractClass {
+    blockifier_contract_class: OnceCell<Rc<BlockifierCasmClass>>,
+    cairo_lang_contract_class: OnceCell<Rc<CairoLangCasmClass>>,
+    serialized_class: OnceCell<Vec<u8>>,
+    class_hash: OnceCell<GenericClassHash>,
+}
+
+fn blockifier_contract_class_from_cairo_lang_class(
+    cairo_lang_class: CairoLangCasmClass,
+) -> Result<BlockifierCasmClass, ContractClassError> {
+    let blockifier_class: BlockifierCasmClass =
+        cairo_lang_class.try_into().map_err(|_| ContractClassError::BlockifierConversionError)?;
+    Ok(blockifier_class)
+}
+
+fn cairo_lang_contract_class_from_bytes(bytes: &[u8]) -> Result<CairoLangCasmClass, ContractClassError> {
+    let contract_class = serde_json::from_slice(bytes)?;
+    Ok(contract_class)
+}
+
+impl GenericCasmContractClass {
+    pub fn from_bytes(serialized_class: Vec<u8>) -> Self {
+        Self {
+            blockifier_contract_class: OnceCell::new(),
+            cairo_lang_contract_class: OnceCell::new(),
+            serialized_class: OnceCell::from(serialized_class),
+            class_hash: OnceCell::new(),
+        }
+    }
+
+    fn build_cairo_lang_class(&self) -> Result<CairoLangCasmClass, ContractClassError> {
+        if let Some(serialized_class) = self.serialized_class.get() {
+            let contract_class = serde_json::from_slice(serialized_class)?;
+            return Ok(contract_class);
+        }
+
+        Err(ContractClassError::NoPossibleConversion)
+    }
+
+    fn build_blockifier_class(&self) -> Result<BlockifierCasmClass, ContractClassError> {
+        if let Some(cairo_lang_class) = self.cairo_lang_contract_class.get() {
+            return blockifier_contract_class_from_cairo_lang_class(cairo_lang_class.as_ref().clone());
+        }
+
+        if let Some(serialized_class) = &self.serialized_class.get() {
+            let cairo_lang_class = cairo_lang_contract_class_from_bytes(serialized_class)?;
+            self.cairo_lang_contract_class
+                .set(Rc::new(cairo_lang_class.clone()))
+                .expect("cairo-lang class is already set");
+            return blockifier_contract_class_from_cairo_lang_class(cairo_lang_class);
+        }
+
+        Err(ContractClassError::NoPossibleConversion)
+    }
+    pub fn get_cairo_lang_contract_class(&self) -> Result<&CairoLangCasmClass, ContractClassError> {
+        self.cairo_lang_contract_class
+            .get_or_try_init(|| self.build_cairo_lang_class().map(Rc::new))
+            .map(|boxed| boxed.as_ref())
+    }
+
+    pub fn get_blockifier_contract_class(&self) -> Result<&BlockifierCasmClass, ContractClassError> {
+        self.blockifier_contract_class
+            .get_or_try_init(|| self.build_blockifier_class().map(Rc::new))
+            .map(|boxed| boxed.as_ref())
+    }
+
+    pub fn to_cairo_lang_contract_class(self) -> Result<CairoLangCasmClass, ContractClassError> {
+        let cairo_lang_class = self.get_cairo_lang_contract_class()?;
+        Ok(cairo_lang_class.clone())
+    }
+
+    pub fn to_blockifier_contract_class(self) -> Result<BlockifierCasmClass, ContractClassError> {
+        let blockifier_class = self.get_blockifier_contract_class()?;
+        Ok(blockifier_class.clone())
+    }
+
+    fn compute_class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        let compiled_class = self.get_cairo_lang_contract_class()?;
+        let class_hash_felt = compiled_class.compiled_class_hash();
+
+        Ok(GenericClassHash::from_bytes_be(class_hash_felt.to_be_bytes()))
+    }
+
+    pub fn class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        self.class_hash.get_or_try_init(|| self.compute_class_hash()).copied()
+    }
+}
+
+impl Serialize for GenericCasmContractClass {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // It seems like there is no way to just pass the `serialized_class` field as the output
+        // of `serialize()`, so we are forced to serialize an actual class instance.
+        let cairo_lang_class =
+            self.get_cairo_lang_contract_class().map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+        cairo_lang_class.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for GenericCasmContractClass {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let cairo_lang_class = CairoLangCasmClass::deserialize(deserializer)?;
+        Ok(Self::from(cairo_lang_class))
+    }
+}
+
+impl From<CairoLangCasmClass> for GenericCasmContractClass {
+    fn from(cairo_lang_class: CairoLangCasmClass) -> Self {
+        Self {
+            blockifier_contract_class: Default::default(),
+            cairo_lang_contract_class: OnceCell::from(Rc::new(cairo_lang_class)),
+            serialized_class: Default::default(),
+            class_hash: Default::default(),
+        }
+    }
+}
+
+impl From<BlockifierCasmClass> for GenericCasmContractClass {
+    fn from(blockifier_class: BlockifierCasmClass) -> Self {
+        Self {
+            blockifier_contract_class: OnceCell::from(Rc::new(blockifier_class)),
+            cairo_lang_contract_class: Default::default(),
+            serialized_class: Default::default(),
+            class_hash: Default::default(),
+        }
+    }
+}
+
+impl TryFrom<GenericCasmContractClass> for BlockifierCasmClass {
+    type Error = ContractClassError;
+
+    fn try_from(contract_class: GenericCasmContractClass) -> Result<Self, Self::Error> {
+        contract_class.to_blockifier_contract_class()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use starknet_types_core::felt::Felt;
+
+    use super::*;
+
+    const CONTRACT_BYTES: &[u8] = include_bytes!(
+        "../../../tests/integration/contracts/blockifier_contracts/feature_contracts/cairo1/compiled/test_contract.\
+         casm.json"
+    );
+
+    #[test]
+    fn test_serialize_and_deserialize() {
+        let generic_class = GenericCasmContractClass::from_bytes(CONTRACT_BYTES.to_vec());
+
+        let serialized_class = serde_json::to_vec(&generic_class).unwrap();
+        assert_eq!(&serialized_class, CONTRACT_BYTES);
+
+        // Check that the deserialization works
+        let _deserialized_class: GenericCasmContractClass = serde_json::from_slice(&serialized_class).unwrap();
+    }
+
+    #[test]
+    fn test_compare_serde_formats() {
+        let generic_class = GenericCasmContractClass::from_bytes(CONTRACT_BYTES.to_vec());
+        let cairo_lang_class: CairoLangCasmClass = serde_json::from_slice(CONTRACT_BYTES).unwrap();
+
+        let generated_cairo_lang_class = generic_class.to_cairo_lang_contract_class().unwrap();
+
+        assert_eq!(generated_cairo_lang_class, cairo_lang_class);
+
+        let deserialized_generic_class: GenericCasmContractClass = serde_json::from_slice(CONTRACT_BYTES).unwrap();
+        let deserialized_cairo_lang_class = deserialized_generic_class.to_cairo_lang_contract_class().unwrap();
+
+        assert_eq!(deserialized_cairo_lang_class, cairo_lang_class);
+    }
+
+    #[test]
+    fn test_class_hash() {
+        let generic_class = GenericCasmContractClass::from_bytes(CONTRACT_BYTES.to_vec());
+        let class_hash = generic_class.class_hash().unwrap();
+
+        // Some weird type conversions here to load the class hash from string easily, may be
+        // improved with more methods on `Hash` / `GenericClassHash`.
+        let expected_class_hash =
+            Felt::from_str("0x607c67298d45092cca5b2ae6804373dd8a2cbe7d2ec4072b3f67097461d5ff4").unwrap();
+        assert_eq!(Felt::from(*class_hash), expected_class_hash);
+    }
+}

--- a/crates/starknet-os-types/src/contract_class.rs
+++ b/crates/starknet-os-types/src/contract_class.rs
@@ -185,8 +185,6 @@ mod tests {
         let generic_class = GenericCasmContractClass::from_bytes(CONTRACT_BYTES.to_vec());
 
         let serialized_class = serde_json::to_vec(&generic_class).unwrap();
-        assert_eq!(&serialized_class, CONTRACT_BYTES);
-
         // Check that the deserialization works
         let _deserialized_class: GenericCasmContractClass = serde_json::from_slice(&serialized_class).unwrap();
     }

--- a/crates/starknet-os-types/src/contract_class.rs
+++ b/crates/starknet-os-types/src/contract_class.rs
@@ -29,7 +29,7 @@ pub enum ContractClassError {
 pub struct GenericCasmContractClass {
     blockifier_contract_class: OnceCell<Rc<BlockifierCasmClass>>,
     cairo_lang_contract_class: OnceCell<Rc<CairoLangCasmClass>>,
-    serialized_class: OnceCell<Vec<u8>>,
+    serialized_class: OnceCell<Rc<Vec<u8>>>,
     class_hash: OnceCell<GenericClassHash>,
 }
 
@@ -51,7 +51,7 @@ impl GenericCasmContractClass {
         Self {
             blockifier_contract_class: OnceCell::new(),
             cairo_lang_contract_class: OnceCell::new(),
-            serialized_class: OnceCell::from(serialized_class),
+            serialized_class: OnceCell::from(Rc::new(serialized_class)),
             class_hash: OnceCell::new(),
         }
     }

--- a/crates/starknet-os-types/src/lib.rs
+++ b/crates/starknet-os-types/src/lib.rs
@@ -1,1 +1,4 @@
+#![feature(once_cell_try)]
+
+pub mod contract_class;
 pub mod hash;

--- a/crates/starknet-os/src/io/input.rs
+++ b/crates/starknet-os/src/io/input.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::{fs, path};
 
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_vm::Felt252;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
+use starknet_os_types::contract_class::GenericCasmContractClass;
 
 use super::InternalTransaction;
 use crate::config::StarknetGeneralConfig;
@@ -15,12 +15,12 @@ use crate::starknet::business_logic::fact_state::contract_state_objects::Contrac
 use crate::starknet::starknet_storage::CommitmentInfo;
 use crate::utils::Felt252HexNoPrefix;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StarknetOsInput {
     pub contract_state_commitment_info: CommitmentInfo,
     pub contract_class_commitment_info: CommitmentInfo,
     pub deprecated_compiled_classes: HashMap<Felt252, DeprecatedContractClass>,
-    pub compiled_classes: HashMap<Felt252, CasmContractClass>,
+    pub compiled_classes: HashMap<Felt252, GenericCasmContractClass>,
     pub compiled_class_visited_pcs: HashMap<Felt252, Vec<Felt252>>,
     pub contracts: HashMap<Felt252, ContractState>,
     pub class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252>,

--- a/crates/starknet-os/src/starknet/business_logic/utils.rs
+++ b/crates/starknet-os/src/starknet/business_logic/utils.rs
@@ -1,6 +1,6 @@
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
+use starknet_os_types::contract_class::GenericCasmContractClass;
 use starknet_os_types::hash::Hash;
 
 use crate::starknet::business_logic::fact_state::contract_class_objects::{
@@ -10,7 +10,7 @@ use crate::storage::storage::{Fact, FactFetchingContext, HashFunctionType, Stora
 
 pub async fn write_class_facts<S, H>(
     contract_class: ContractClass,
-    compiled_class: CasmContractClass,
+    compiled_class: GenericCasmContractClass,
     ffc: &mut FactFetchingContext<S, H>,
 ) -> Result<(Hash, Hash), StorageError>
 where
@@ -70,7 +70,7 @@ mod tests {
         );
 
         let contract_class: ContractClass = serde_json::from_slice(sierra_bytes).unwrap();
-        let compiled_class: CasmContractClass = serde_json::from_slice(casm_bytes).unwrap();
+        let compiled_class = GenericCasmContractClass::from_bytes(casm_bytes.to_vec());
 
         let (class_hash, compiled_class_hash) =
             write_class_facts(contract_class, compiled_class, &mut ffc).await.unwrap();

--- a/crates/starknet-os/src/storage/storage_utils.rs
+++ b/crates/starknet-os/src/storage/storage_utils.rs
@@ -1,7 +1,5 @@
-use blockifier::execution::contract_class::ContractClassV1;
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::State;
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_vm::Felt252;
 use starknet_os_types::hash::Hash;
 
@@ -130,13 +128,4 @@ pub fn deprecated_contract_class_api2vm(
     let vm_class = blockifier::execution::contract_class::ContractClass::V0(vm_class_v0);
 
     Ok(vm_class)
-}
-
-/// Convert a starknet_api ContractClass to a cairo-vm ContractClass (v1 only).
-pub fn compiled_contract_class_cl2vm(
-    cl_class: &CasmContractClass,
-) -> Result<blockifier::execution::contract_class::ContractClass, cairo_vm::types::errors::program_errors::ProgramError>
-{
-    let v1_class = ContractClassV1::try_from(cl_class.clone()).unwrap(); // TODO: type issue?
-    Ok(v1_class.into())
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,5 +26,6 @@ serde_json = { workspace = true }
 starknet_api = { workspace = true }
 starknet-crypto = { workspace = true }
 starknet-os = { path = "../crates/starknet-os" }
+starknet-os-types = { path = "../crates/starknet-os-types" }
 tokio = { workspace = true }
 uuid = { workspace = true }

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -5,7 +5,6 @@ use blockifier::execution::contract_class::ContractClass::{V0, V1};
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::{State, StateReader};
 use blockifier::transaction::objects::TransactionExecutionInfo;
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
@@ -25,6 +24,7 @@ use starknet_os::starkware_utils::commitment_tree::base_types::{Height, TreeInde
 use starknet_os::storage::storage::Storage;
 use starknet_os::storage::storage_utils::build_starknet_storage_async;
 use starknet_os::utils::{felt_api2vm, felt_vm2api};
+use starknet_os_types::contract_class::GenericCasmContractClass;
 
 use crate::common::transaction_utils::to_felt252;
 
@@ -34,12 +34,12 @@ pub async fn os_hints<S>(
     transactions: Vec<InternalTransaction>,
     tx_execution_infos: Vec<TransactionExecutionInfo>,
     deprecated_compiled_classes: HashMap<ClassHash, DeprecatedContractClass>,
-    compiled_classes: HashMap<ClassHash, CasmContractClass>,
+    compiled_classes: HashMap<ClassHash, GenericCasmContractClass>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper<S>)
 where
     S: Storage,
 {
-    let mut compiled_class_hash_to_compiled_class: HashMap<Felt252, CasmContractClass> = HashMap::new();
+    let mut compiled_class_hash_to_compiled_class: HashMap<Felt252, GenericCasmContractClass> = HashMap::new();
 
     let mut contracts: HashMap<Felt252, ContractState> = blockifier_state
         .state
@@ -79,12 +79,13 @@ where
         match blockifier_class {
             V0(_) => {} // deprecated_compiled_classes are passed in by caller
             V1(_) => {
-                let class =
+                let compiled_class =
                     compiled_classes.get(&class_hash).unwrap_or_else(|| panic!("No class given for {:?}", class_hash));
-                let compiled_class_hash = Felt252::from_bytes_be(&class.compiled_class_hash().to_be_bytes());
+                let compiled_class_hash = compiled_class.class_hash().expect("Failed to compute class hash");
+                let compiled_class_hash = Felt252::from(compiled_class_hash);
                 class_hash_to_compiled_class_hash.insert(to_felt252(&class_hash.0), compiled_class_hash);
 
-                compiled_class_hash_to_compiled_class.insert(compiled_class_hash, class.clone());
+                compiled_class_hash_to_compiled_class.insert(compiled_class_hash, compiled_class.clone());
             }
         };
     }

--- a/tests/integration/common/blockifier_contracts.rs
+++ b/tests/integration/common/blockifier_contracts.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
+use starknet_os_types::contract_class::GenericCasmContractClass;
 
 use crate::common::contract_fixtures::{get_deprecated_compiled_class, load_cairo1_contract};
 
@@ -32,7 +32,7 @@ pub(crate) fn load_cairo0_feature_contract(name: &str) -> (String, DeprecatedCom
 }
 
 /// Helper to load a Cairo1 contract class.
-pub(crate) fn load_cairo1_feature_contract(name: &str) -> (String, ContractClass, CasmContractClass) {
+pub(crate) fn load_cairo1_feature_contract(name: &str) -> (String, ContractClass, GenericCasmContractClass) {
     let sierra_contract_path = get_feature_sierra_contract_path(name);
     let (sierra_contract_class, casm_contract_class) = load_cairo1_contract(&sierra_contract_path);
     (name.to_string(), sierra_contract_class, casm_contract_class)

--- a/tests/integration/common/contract_fixtures.rs
+++ b/tests/integration/common/contract_fixtures.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, StarknetSierraCompilationError};
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
+use starknet_os_types::contract_class::GenericCasmContractClass;
 
 pub fn get_contracts_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("contracts")
@@ -31,16 +32,19 @@ pub fn get_compiled_sierra_class(contract_rel_path: &Path) -> ContractClass {
 /// Compiles a Sierra class to CASM.
 pub(crate) fn compile_sierra_contract_class(
     sierra_contract_class: ContractClass,
-) -> Result<CasmContractClass, StarknetSierraCompilationError> {
+) -> Result<GenericCasmContractClass, StarknetSierraCompilationError> {
     // Values taken from the defaults of `starknet-sierra-compile`, see here:
     // https://github.com/starkware-libs/cairo/blob/main/crates/bin/starknet-sierra-compile/src/main.rs
     let add_pythonic_hints = false;
     let max_bytecode_size = 180000;
-    CasmContractClass::from_contract_class(sierra_contract_class, add_pythonic_hints, max_bytecode_size)
+    let casm_contract_class =
+        CasmContractClass::from_contract_class(sierra_contract_class, add_pythonic_hints, max_bytecode_size)?;
+
+    Ok(GenericCasmContractClass::from(casm_contract_class))
 }
 
 /// Helper to load a Cairo1 contract class.
-pub(crate) fn load_cairo1_contract(contract_path: &Path) -> (ContractClass, CasmContractClass) {
+pub(crate) fn load_cairo1_contract(contract_path: &Path) -> (ContractClass, GenericCasmContractClass) {
     let sierra_contract_class = get_compiled_sierra_class(contract_path);
     let casm_contract_class = compile_sierra_contract_class(sierra_contract_class.clone())
         .unwrap_or_else(|e| panic!("Failed to compile Sierra contract {}: {}", contract_path.to_string_lossy(), e));

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -9,7 +9,6 @@ use blockifier::transaction::account_transaction::AccountTransaction::{Declare, 
 use blockifier::transaction::objects::{TransactionInfo, TransactionInfoCreator};
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::{ExecutableTransaction, L1HandlerTransaction};
-use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError::VmException;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::Felt252;
@@ -40,6 +39,7 @@ use starknet_os::starknet::core::os::transaction_hash::{L1_GAS, L2_GAS};
 use starknet_os::storage::storage::Storage;
 use starknet_os::utils::felt_api2vm;
 use starknet_os::{config, run_os};
+use starknet_os_types::contract_class::GenericCasmContractClass;
 
 use crate::common::block_utils::os_hints;
 
@@ -775,7 +775,7 @@ async fn execute_txs<S>(
     block_context: &BlockContext,
     txs: Vec<Transaction>,
     deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
-    contract_classes: HashMap<ClassHash, CasmContractClass>,
+    contract_classes: HashMap<ClassHash, GenericCasmContractClass>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper<S>)
 where
     S: Storage,
@@ -815,7 +815,7 @@ pub async fn execute_txs_and_run_os<S>(
     block_context: BlockContext,
     txs: Vec<Transaction>,
     deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
-    contract_classes: HashMap<ClassHash, CasmContractClass>,
+    contract_classes: HashMap<ClassHash, GenericCasmContractClass>,
 ) -> Result<(CairoPie, StarknetOsOutput), SnOsError>
 where
     S: Storage,

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -8,7 +8,7 @@ use starknet_api::core::CompiledClassHash;
 use starknet_api::transaction::{Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionVersion};
 use starknet_os::crypto::poseidon::PoseidonHash;
 use starknet_os::starknet::business_logic::utils::write_class_facts;
-use starknet_os::storage::storage_utils::{compiled_contract_class_cl2vm, deprecated_contract_class_api2vm};
+use starknet_os::storage::storage_utils::deprecated_contract_class_api2vm;
 
 use crate::common::block_context;
 use crate::common::blockifier_contracts::load_cairo1_feature_contract;
@@ -52,11 +52,11 @@ async fn declare_v3_cairo1_account(
 
     let sender_address = account_contract.address;
 
-    let contract_class = compiled_contract_class_cl2vm(&casm_class).unwrap();
+    let contract_class = casm_class.to_blockifier_contract_class().unwrap();
     let class_hash = starknet_api::core::ClassHash::try_from(contract_class_hash).unwrap();
     let compiled_class_hash = CompiledClassHash::try_from(compiled_class_hash).unwrap();
 
-    let class_info = ClassInfo::new(&contract_class, sierra_class.sierra_program.len(), 0).unwrap();
+    let class_info = ClassInfo::new(&contract_class.into(), sierra_class.sierra_program.len(), 0).unwrap();
 
     let declare_tx = blockifier::test_utils::declare::declare_tx(
         declare_tx_args! {
@@ -111,11 +111,11 @@ async fn declare_cairo1_account(
 
     let sender_address = account_contract.address;
 
-    let contract_class = compiled_contract_class_cl2vm(&casm_class).unwrap();
+    let contract_class = casm_class.to_blockifier_contract_class().unwrap();
     let class_hash = starknet_api::core::ClassHash::try_from(contract_class_hash).unwrap();
     let compiled_class_hash = CompiledClassHash::try_from(compiled_class_hash).unwrap();
 
-    let class_info = ClassInfo::new(&contract_class, sierra_class.sierra_program.len(), 0).unwrap();
+    let class_info = ClassInfo::new(&contract_class.into(), sierra_class.sierra_program.len(), 0).unwrap();
 
     let declare_tx = blockifier::test_utils::declare::declare_tx(
         declare_tx_args! {


### PR DESCRIPTION
Problem: we use different CASM contract classes depending on the use
case. We serialize/deserialize with the `cairo-lang` implementation, we
reexecute txs with the Blockifier implementation and we compute class
hashes through Pathfinder. Currently, we convert explicitly between
these types/crates. This makes the code harder to read and maintain.

Solution: introduce a generic class that is able to convert to/from all
the types we use under the hood. This puts a lid on the problem and
reduces the amount of code to change if things improve in the ecosystem.


Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes, the new type appears in `StarknetOsInput`.
- [ ] no
