### PR TITLE
Internal: introduce the `starknet-os-types` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/bin/hint_tool",
     "crates/cairo-type-derive",
     "crates/starknet-os",
+    "crates/starknet-os-types",
     "tests",
 ]
 
@@ -51,6 +52,7 @@ serde_with = "3.3.0"
 serde_yaml = "0.9.25"
 starknet_api = { version = "=0.10", features = ["testing"] }
 starknet-crypto = "0.6.2"
+starknet-types-core = "0.1.5"
 thiserror = "1.0.48"
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
 uuid = { version = "1.4.0", features = ["v4", "serde"] }

--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "starknet-os-types"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+
+[dependencies]
+num-bigint = { workspace = true }
+serde = { workspace = true }
+starknet_api = { workspace = true }
+starknet-types-core = { workspace = true }

--- a/crates/starknet-os-types/src/hash.rs
+++ b/crates/starknet-os-types/src/hash.rs
@@ -1,0 +1,105 @@
+use std::ops::Deref;
+
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::hash::StarkFelt;
+use starknet_api::StarknetApiError;
+use starknet_types_core::felt::Felt;
+
+const EMPTY_HASH: [u8; 32] = [0; 32];
+
+/// Starknet hash type.
+/// Encapsulates the result of hash functions and provides conversion functions to Cairo VM
+/// and Starknet API types for convenience.
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Hash([u8; 32]);
+
+impl Hash {
+    pub fn empty() -> Self {
+        Self::from_bytes_be(EMPTY_HASH)
+    }
+
+    pub fn from_bytes_be(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Builds a `Hash` from a bytes slice.
+    /// The slice length must be <= 32.
+    pub fn from_bytes_be_slice(bytes: &[u8]) -> Self {
+        let mut array = [0u8; 32];
+        let start = 32 - bytes.len();
+
+        for (i, &byte) in bytes.iter().enumerate() {
+            array[start + i] = byte;
+        }
+
+        Hash(array)
+    }
+}
+
+impl PartialEq<[u8; 32]> for Hash {
+    fn eq(&self, other: &[u8; 32]) -> bool {
+        &self.0 == other
+    }
+}
+
+impl Deref for Hash {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Hash> for Felt {
+    fn from(hash: Hash) -> Self {
+        Felt::from_bytes_be(&hash.0)
+    }
+}
+
+impl From<&Hash> for BigUint {
+    fn from(hash: &Hash) -> Self {
+        BigUint::from_bytes_be(&hash.0)
+    }
+}
+
+impl From<&BigUint> for Hash {
+    fn from(value: &BigUint) -> Self {
+        // `BigUint.to_bytes_be()` only returns the minimum amount of bytes, so we need to use
+        // `from_bytes_be_slice` for this conversion.
+        Self::from_bytes_be_slice(&value.to_bytes_be())
+    }
+}
+
+impl From<Felt> for Hash {
+    fn from(value: Felt) -> Self {
+        // This conversion is safe, BigUint is 32 bytes so this will always work.
+        Self::from_bytes_be(value.to_bytes_be())
+    }
+}
+
+impl TryFrom<Hash> for StarkFelt {
+    type Error = StarknetApiError;
+
+    fn try_from(hash: Hash) -> Result<Self, Self::Error> {
+        Self::new(hash.0)
+    }
+}
+
+impl TryFrom<Hash> for CompiledClassHash {
+    type Error = StarknetApiError;
+
+    fn try_from(hash: Hash) -> Result<Self, Self::Error> {
+        Ok(Self(hash.try_into()?))
+    }
+}
+
+impl TryFrom<Hash> for ClassHash {
+    type Error = StarknetApiError;
+
+    fn try_from(hash: Hash) -> Result<Self, Self::Error> {
+        Ok(Self(hash.try_into()?))
+    }
+}

--- a/crates/starknet-os-types/src/hash.rs
+++ b/crates/starknet-os-types/src/hash.rs
@@ -12,7 +12,7 @@ const EMPTY_HASH: [u8; 32] = [0; 32];
 /// Starknet hash type.
 /// Encapsulates the result of hash functions and provides conversion functions to Cairo VM
 /// and Starknet API types for convenience.
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Hash([u8; 32]);
 

--- a/crates/starknet-os-types/src/lib.rs
+++ b/crates/starknet-os-types/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod hash;

--- a/crates/starknet-os/Cargo.toml
+++ b/crates/starknet-os/Cargo.toml
@@ -37,6 +37,7 @@ serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 starknet_api = { workspace = true }
 starknet-crypto = { workspace = true }
+starknet-os-types = { path = "../starknet-os-types" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }

--- a/crates/starknet-os/src/crypto/pedersen.rs
+++ b/crates/starknet-os/src/crypto/pedersen.rs
@@ -1,6 +1,7 @@
 use starknet_crypto::{pedersen_hash, FieldElement};
+use starknet_os_types::hash::Hash;
 
-use crate::storage::storage::{Hash, HashFunctionType};
+use crate::storage::storage::HashFunctionType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PedersenHash;

--- a/crates/starknet-os/src/crypto/poseidon.rs
+++ b/crates/starknet-os/src/crypto/poseidon.rs
@@ -1,7 +1,8 @@
 use cairo_vm::types::errors::math_errors::MathError;
 use starknet_crypto::{poseidon_hash, poseidon_hash_many, FieldElement};
+use starknet_os_types::hash::Hash;
 
-use crate::storage::storage::{Hash, HashFunctionType};
+use crate::storage::storage::HashFunctionType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PoseidonHash;

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/contract_class_objects.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/contract_class_objects.rs
@@ -4,12 +4,13 @@ use cairo_vm::Felt252;
 use pathfinder_gateway_types::class_hash::compute_class_hash;
 use serde::{Deserialize, Serialize};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
+use starknet_os_types::hash::Hash;
 
 use crate::config::CONTRACT_CLASS_LEAF_VERSION;
 use crate::crypto::poseidon::PoseidonHash;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::serializable::SerializationPrefix;
-use crate::storage::storage::{DbObject, Fact, FactFetchingContext, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
 
 /// Represents a single contract class which is stored in the Starknet state.
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/contract_state_objects.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/contract_state_objects.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use cairo_vm::Felt252;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use starknet_os_types::hash::Hash;
 
 use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::base_types::Height;
@@ -12,7 +13,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::{PatriciaTree, EMPTY_NODE_HASH};
 use crate::starkware_utils::serializable::SerializationPrefix;
-use crate::storage::storage::{DbObject, Fact, FactFetchingContext, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
 
 pub const UNINITIALIZED_CLASS_HASH: [u8; 32] = [0; 32];
 

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
@@ -13,6 +13,7 @@ use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContract
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 use starknet_crypto::FieldElement;
+use starknet_os_types::hash::Hash;
 
 use crate::config::{
     COMPILED_CLASS_HASH_COMMITMENT_TREE_HEIGHT, CONTRACT_ADDRESS_BITS, CONTRACT_STATES_COMMITMENT_TREE_HEIGHT,
@@ -28,7 +29,7 @@ use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
-use crate::storage::storage::{DbObject, FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{DbObject, FactFetchingContext, HashFunctionType, Storage, StorageError};
 use crate::storage::storage_utils::{compiled_contract_class_cl2vm, deprecated_contract_class_api2vm};
 use crate::utils::{execute_coroutine, felt_api2vm, felt_vm2api};
 

--- a/crates/starknet-os/src/starknet/business_logic/utils.rs
+++ b/crates/starknet-os/src/starknet/business_logic/utils.rs
@@ -1,11 +1,12 @@
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
+use starknet_os_types::hash::Hash;
 
 use crate::starknet::business_logic::fact_state::contract_class_objects::{
     CompiledClassFact, ContractClassFact, DeprecatedCompiledClassFact,
 };
-use crate::storage::storage::{Fact, FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{Fact, FactFetchingContext, HashFunctionType, Storage, StorageError};
 
 pub async fn write_class_facts<S, H>(
     contract_class: ContractClass,

--- a/crates/starknet-os/src/starknet/starknet_storage.rs
+++ b/crates/starknet-os/src/starknet/starknet_storage.rs
@@ -5,6 +5,7 @@ use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use starknet_os_types::hash::Hash;
 
 use crate::starkware_utils::commitment_tree::base_types::TreeIndex;
 use crate::starkware_utils::commitment_tree::binary_fact_tree::{
@@ -14,7 +15,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
-use crate::storage::storage::{DbObject, Fact, FactFetchingContext, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, FactFetchingContext, HashFunctionType, Storage};
 use crate::utils::{Felt252Num, Felt252Str};
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/binary_fact_tree_node.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 
 use futures::future::FutureExt;
 use num_bigint::BigUint;
+use starknet_os_types::hash::Hash;
 
 use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
@@ -11,7 +12,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::merkle_tree::traverse_tree::{traverse_tree, TreeTraverser};
-use crate::storage::storage::{FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage, StorageError};
 
 #[derive(Debug, PartialEq)]
 pub struct BinaryFactTreeNodeDiff<S, H, LF>

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/calculation.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/calculation.rs
@@ -2,11 +2,13 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
+use starknet_os_types::hash::Hash;
+
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
 use crate::starkware_utils::commitment_tree::errors::CombineError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::nodes::PatriciaNodeFact;
-use crate::storage::storage::{FactFetchingContext, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
 
 // These enums are used instead of trait objects because the conditions to turn
 // LeafFact and InnerNodeFact into object safe traits are complex to lift: multiple places where

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/nodes.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/nodes.rs
@@ -1,12 +1,13 @@
 use cairo_vm::Felt252;
 use num_bigint::BigUint;
+use starknet_os_types::hash::Hash;
 
 use crate::starkware_utils::commitment_tree::base_types::{Length, NodePath};
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
-use crate::storage::storage::{DbObject, Fact, Hash, HashFunctionType, Storage, HASH_BYTES};
+use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage, HASH_BYTES};
 
 const PATRICIA_NODE_PREFIX: &[u8] = "patricia_node".as_bytes();
 

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use starknet_os_types::hash::Hash;
 
 use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::{BinaryFactDict, BinaryFactTree};
@@ -10,7 +11,7 @@ use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::virtual_calculation_node::VirtualCalculationNode;
 use crate::starkware_utils::commitment_tree::patricia_tree::virtual_patricia_node::VirtualPatriciaNode;
 use crate::starkware_utils::commitment_tree::update_tree::update_tree;
-use crate::storage::storage::{FactFetchingContext, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
 
 pub const EMPTY_NODE_HASH: [u8; 32] = [0; 32];
 

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::marker::PhantomData;
 
 use num_bigint::BigUint;
+use starknet_os_types::hash::Hash;
 
 use crate::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
@@ -17,7 +18,7 @@ use crate::starkware_utils::commitment_tree::patricia_tree::nodes::{
 };
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
 use crate::starkware_utils::commitment_tree::patricia_tree::virtual_patricia_node::VirtualPatriciaNode;
-use crate::storage::storage::{Fact, FactFetchingContext, Hash, HashFunctionType, Storage, StorageError};
+use crate::storage::storage::{Fact, FactFetchingContext, HashFunctionType, Storage, StorageError};
 
 #[derive(Debug, PartialEq)]
 pub struct BinaryCalculation<S, H, LF>

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 
 use futures::future::FutureExt;
 use num_bigint::BigUint;
+use starknet_os_types::hash::Hash;
 
 use crate::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath, TreeIndex};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactDict;
@@ -17,7 +18,7 @@ use crate::starkware_utils::commitment_tree::patricia_tree::nodes::{
     verify_path_value, EdgeNodeFact, PatriciaNodeFact,
 };
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::EMPTY_NODE_HASH;
-use crate::storage::storage::{FactFetchingContext, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{FactFetchingContext, HashFunctionType, Storage};
 
 #[derive(Debug)]
 pub struct VirtualPatriciaNode<S, H, LF>

--- a/crates/starknet-os/src/storage/storage_utils.rs
+++ b/crates/starknet-os/src/storage/storage_utils.rs
@@ -3,6 +3,7 @@ use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::State;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_vm::Felt252;
+use starknet_os_types::hash::Hash;
 
 use crate::execution::helper::ContractStorageMap;
 use crate::starknet::business_logic::fact_state::contract_state_objects::ContractState;
@@ -12,7 +13,7 @@ use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::serializable::{DeserializeError, Serializable, SerializationPrefix, SerializeError};
-use crate::storage::storage::{DbObject, Fact, Hash, HashFunctionType, Storage};
+use crate::storage::storage::{DbObject, Fact, HashFunctionType, Storage};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SimpleLeafFact {


### PR DESCRIPTION
Problem: we need a single crate that defines useful types for all parts of the project. Useful types should be available from all the other crates.

Solution: introduce the `starknet-os-types` crate. Moved the `Hash` type there as a demonstration and preparation for upcoming PRs.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
