### PR TITLE
Internal: derive `Copy` for `Hash`

### DIFF
--- a/crates/starknet-os-types/src/hash.rs
+++ b/crates/starknet-os-types/src/hash.rs
@@ -12,7 +12,7 @@ const EMPTY_HASH: [u8; 32] = [0; 32];
 /// Starknet hash type.
 /// Encapsulates the result of hash functions and provides conversion functions to Cairo VM
 /// and Starknet API types for convenience.
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Hash([u8; 32]);
 

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/calculation.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/calculation.rs
@@ -229,7 +229,7 @@ where
 
     fn calculate(&self, _dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Hash {
         let hash_result = self.fact.hash();
-        fact_nodes.leaves.insert(hash_result.clone(), self.fact.clone());
+        fact_nodes.leaves.insert(hash_result, self.fact.clone());
         hash_result
     }
 }

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/patricia_tree.rs
@@ -38,7 +38,7 @@ where
         indices: &[TreeIndex],
         facts: &mut Option<BinaryFactDict>,
     ) -> Result<HashMap<TreeIndex, LF>, TreeError> {
-        let virtual_root_node = VirtualPatriciaNode::from_hash(self.root.clone(), self.height);
+        let virtual_root_node = VirtualPatriciaNode::from_hash(self.root, self.height);
         virtual_root_node._get_leaves(ffc, indices, facts).await
     }
 

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_calculation_node.rs
@@ -73,9 +73,9 @@ where
         let left_hash: &Hash = dependency_results[0].downcast_ref().unwrap();
         let right_hash: &Hash = dependency_results[1].downcast_ref().unwrap();
 
-        let fact = BinaryNodeFact { left_node: left_hash.clone(), right_node: right_hash.clone() };
+        let fact = BinaryNodeFact { left_node: *left_hash, right_node: *right_hash };
         let fact_hash = <BinaryNodeFact as Fact<S, H>>::hash(&fact);
-        fact_nodes.inner_nodes.insert(fact_hash.clone(), PatriciaNodeFact::Binary(fact));
+        fact_nodes.inner_nodes.insert(fact_hash, PatriciaNodeFact::Binary(fact));
 
         fact_hash
     }
@@ -143,9 +143,9 @@ where
 
     fn calculate(&self, dependency_results: Vec<Box<dyn Any>>, fact_nodes: &mut NodeFactDict<LF>) -> Hash {
         let bottom_hash: &Hash = dependency_results[0].downcast_ref().unwrap();
-        let fact = EdgeNodeFact::new_unchecked(bottom_hash.clone(), self.path.clone(), self.length);
+        let fact = EdgeNodeFact::new_unchecked(*bottom_hash, self.path.clone(), self.length);
         let fact_hash = <EdgeNodeFact as Fact<S, H>>::hash(&fact);
-        fact_nodes.inner_nodes.insert(fact_hash.clone(), PatriciaNodeFact::Edge(fact));
+        fact_nodes.inner_nodes.insert(fact_hash, PatriciaNodeFact::Edge(fact));
 
         fact_hash
     }
@@ -469,7 +469,7 @@ where
     }
 
     fn create_from_node(node: &Self::BinaryFactTreeNodeType) -> Self {
-        let bottom_calculation = HashCalculationImpl::Constant(ConstantCalculation::new(node.bottom_node.clone()));
+        let bottom_calculation = HashCalculationImpl::Constant(ConstantCalculation::new(node.bottom_node));
         Self::new_unchecked(bottom_calculation, node.path.clone(), node.length, node.height)
     }
 

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -85,10 +85,10 @@ where
     ) -> Result<Hash, TreeError> {
         if !self.is_virtual_edge() {
             // Node is already of form (hash, 0, 0); no work to be done.
-            return Ok(self.bottom_node.clone());
+            return Ok(self.bottom_node);
         }
 
-        let edge_node_fact = EdgeNodeFact::new(self.bottom_node.clone(), self.path.clone(), self.length)?;
+        let edge_node_fact = EdgeNodeFact::new(self.bottom_node, self.path.clone(), self.length)?;
 
         let hash = write_node_fact(ffc, edge_node_fact, facts).await?;
         Ok(hash)
@@ -103,7 +103,7 @@ where
         // Turn the MSB off.
         let path = NodePath(self.path.0.clone() & ((BigUint::from(1u64) << children_length.0) - BigUint::from(1u64)));
         let non_empty_child =
-            VirtualPatriciaNode::new_unchecked(self.bottom_node.clone(), path, children_length, children_height);
+            VirtualPatriciaNode::new_unchecked(self.bottom_node, path, children_length, children_height);
 
         let edge_child_direction = self.path.0.clone() >> children_length.0;
         let empty_child = Self::empty_node(children_height);
@@ -149,7 +149,7 @@ where
         };
 
         // Get bottom subtree root.
-        let bottom_subtree_root = Self::from_hash(self.bottom_node.clone(), Height(path_suffix_width));
+        let bottom_subtree_root = Self::from_hash(self.bottom_node, Height(path_suffix_width));
         let bottom_subtree_leaves = bottom_subtree_root._get_leaves(ffc, &bottom_subtree_indices, facts).await?;
         let empty_leaves = get_empty_leaves(ffc, &empty_indices).await?;
 
@@ -179,7 +179,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            bottom_node: self.bottom_node.clone(),
+            bottom_node: self.bottom_node,
             path: self.path.clone(),
             length: self.length,
             height: self.height,
@@ -195,7 +195,7 @@ where
     LF: LeafFact<S, H> + Send,
 {
     fn _leaf_hash(&self) -> Hash {
-        self.bottom_node.clone()
+        self.bottom_node
     }
 
     fn get_height_in_tree(&self) -> Height {


### PR DESCRIPTION
Problem: as all the 32-byte wide types we use implement Copy, there is no
reason for `Hash` not to.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
