### PR TITLE
Feature: generic deprecated compiled class

### DIFF
--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -9,6 +9,7 @@ license-file.workspace = true
 blockifier = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
 num-bigint = { workspace = true }
+pathfinder-gateway-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 starknet_api = { workspace = true }

--- a/crates/starknet-os-types/src/contract_class.rs
+++ b/crates/starknet-os-types/src/contract_class.rs
@@ -3,22 +3,11 @@ use std::rc::Rc;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::error::ContractClassError;
 use crate::hash::GenericClassHash;
 
 pub type CairoLangCasmClass = cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 pub type BlockifierCasmClass = blockifier::execution::contract_class::ContractClassV1;
-
-#[derive(thiserror::Error, Debug)]
-pub enum ContractClassError {
-    #[error("Internal error: no type conversion is possible to generate the desired effect.")]
-    NoPossibleConversion,
-
-    #[error("Could not build Blockifier contract class")]
-    BlockifierConversionError,
-
-    #[error(transparent)]
-    SerdeError(#[from] serde_json::Error),
-}
 
 /// A generic contract class that supports conversion to/from the most commonly used
 /// contract class types in Starknet and provides utility methods.

--- a/crates/starknet-os-types/src/deprecated_compiled_class.rs
+++ b/crates/starknet-os-types/src/deprecated_compiled_class.rs
@@ -1,0 +1,142 @@
+use std::cell::OnceCell;
+use std::rc::Rc;
+
+use pathfinder_gateway_types::class_hash::compute_class_hash;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::ContractClassError;
+use crate::hash::GenericClassHash;
+
+pub type StarknetApiDeprecatedClass = starknet_api::deprecated_contract_class::ContractClass;
+pub type BlockifierDeprecatedClass = blockifier::execution::contract_class::ContractClassV0;
+
+/// A generic contract class that supports conversion to/from the most commonly used
+/// contract class types in Starknet and provides utility methods.
+/// Operations are implemented as lazily as possible, i.e. we only convert
+/// between different types if strictly necessary.
+/// Fields are boxed in an RC for cheap cloning.
+#[derive(Debug, Clone)]
+pub struct GenericDeprecatedCompiledClass {
+    blockifier_contract_class: OnceCell<Rc<BlockifierDeprecatedClass>>,
+    starknet_api_contract_class: OnceCell<Rc<StarknetApiDeprecatedClass>>,
+    serialized_class: OnceCell<Vec<u8>>,
+    class_hash: OnceCell<GenericClassHash>,
+}
+
+impl GenericDeprecatedCompiledClass {
+    pub fn from_bytes(serialized_class: Vec<u8>) -> Self {
+        Self {
+            blockifier_contract_class: Default::default(),
+            starknet_api_contract_class: Default::default(),
+            serialized_class: OnceCell::from(serialized_class),
+            class_hash: OnceCell::new(),
+        }
+    }
+
+    fn build_starknet_api_class(&self) -> Result<StarknetApiDeprecatedClass, ContractClassError> {
+        if let Some(serialized_class) = self.serialized_class.get() {
+            let contract_class = serde_json::from_slice(serialized_class)?;
+            return Ok(contract_class);
+        }
+
+        Err(ContractClassError::NoPossibleConversion)
+    }
+
+    fn build_blockifier_class(&self) -> Result<BlockifierDeprecatedClass, ContractClassError> {
+        let serialized_class = self.serialized_class.get_or_try_init(|| serde_json::to_vec(self))?;
+
+        let blockifier_class: BlockifierDeprecatedClass = serde_json::from_slice(serialized_class)?;
+        Ok(blockifier_class)
+    }
+
+    pub fn get_starknet_api_contract_class(&self) -> Result<&StarknetApiDeprecatedClass, ContractClassError> {
+        self.starknet_api_contract_class
+            .get_or_try_init(|| self.build_starknet_api_class().map(Rc::new))
+            .map(|boxed| boxed.as_ref())
+    }
+
+    pub fn get_blockifier_contract_class(&self) -> Result<&BlockifierDeprecatedClass, ContractClassError> {
+        self.blockifier_contract_class
+            .get_or_try_init(|| self.build_blockifier_class().map(Rc::new))
+            .map(|boxed| boxed.as_ref())
+    }
+
+    pub fn get_serialized_contract_class(&self) -> Result<&Vec<u8>, ContractClassError> {
+        self.serialized_class.get_or_try_init(|| serde_json::to_vec(self)).map_err(Into::into)
+    }
+
+    pub fn to_starknet_api_contract_class(self) -> Result<StarknetApiDeprecatedClass, ContractClassError> {
+        let cairo_lang_class = self.get_starknet_api_contract_class()?;
+        Ok(cairo_lang_class.clone())
+    }
+
+    pub fn to_blockifier_contract_class(self) -> Result<BlockifierDeprecatedClass, ContractClassError> {
+        let blockifier_class = self.get_blockifier_contract_class()?;
+        Ok(blockifier_class.clone())
+    }
+
+    fn compute_class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        let serialized_class = self.get_serialized_contract_class()?;
+        let class_hash =
+            compute_class_hash(serialized_class).unwrap_or_else(|e| panic!("Failed to compute class hash: {}", e));
+
+        Ok(GenericClassHash::from_bytes_be(class_hash.hash().0.to_be_bytes()))
+    }
+
+    pub fn class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        self.class_hash.get_or_try_init(|| self.compute_class_hash()).copied()
+    }
+}
+
+impl Serialize for GenericDeprecatedCompiledClass {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // It seems like there is no way to just pass the `serialized_class` field as the output
+        // of `serialize()`, so we are forced to serialize an actual class instance.
+        let starknet_api_class =
+            self.get_starknet_api_contract_class().map_err(|e| serde::ser::Error::custom(e.to_string()))?;
+        starknet_api_class.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for GenericDeprecatedCompiledClass {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let starknet_api_class = StarknetApiDeprecatedClass::deserialize(deserializer)?;
+        Ok(Self::from(starknet_api_class))
+    }
+}
+
+impl From<StarknetApiDeprecatedClass> for GenericDeprecatedCompiledClass {
+    fn from(starknet_api_class: StarknetApiDeprecatedClass) -> Self {
+        Self {
+            blockifier_contract_class: Default::default(),
+            starknet_api_contract_class: OnceCell::from(Rc::new(starknet_api_class)),
+            serialized_class: Default::default(),
+            class_hash: Default::default(),
+        }
+    }
+}
+
+impl From<BlockifierDeprecatedClass> for GenericDeprecatedCompiledClass {
+    fn from(blockifier_class: BlockifierDeprecatedClass) -> Self {
+        Self {
+            blockifier_contract_class: OnceCell::from(Rc::new(blockifier_class)),
+            starknet_api_contract_class: Default::default(),
+            serialized_class: Default::default(),
+            class_hash: Default::default(),
+        }
+    }
+}
+
+impl TryFrom<GenericDeprecatedCompiledClass> for BlockifierDeprecatedClass {
+    type Error = ContractClassError;
+
+    fn try_from(contract_class: GenericDeprecatedCompiledClass) -> Result<Self, Self::Error> {
+        contract_class.to_blockifier_contract_class()
+    }
+}

--- a/crates/starknet-os-types/src/error.rs
+++ b/crates/starknet-os-types/src/error.rs
@@ -1,0 +1,11 @@
+#[derive(thiserror::Error, Debug)]
+pub enum ContractClassError {
+    #[error("Internal error: no type conversion is possible to generate the desired effect.")]
+    NoPossibleConversion,
+
+    #[error("Could not build Blockifier contract class")]
+    BlockifierConversionError,
+
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+}

--- a/crates/starknet-os-types/src/lib.rs
+++ b/crates/starknet-os-types/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(once_cell_try)]
 
 pub mod contract_class;
+pub mod deprecated_compiled_class;
+pub mod error;
 pub mod hash;

--- a/crates/starknet-os/src/io/input.rs
+++ b/crates/starknet-os/src/io/input.rs
@@ -5,8 +5,8 @@ use std::{fs, path};
 use cairo_vm::Felt252;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
 use super::InternalTransaction;
 use crate::config::StarknetGeneralConfig;
@@ -19,7 +19,7 @@ use crate::utils::Felt252HexNoPrefix;
 pub struct StarknetOsInput {
     pub contract_state_commitment_info: CommitmentInfo,
     pub contract_class_commitment_info: CommitmentInfo,
-    pub deprecated_compiled_classes: HashMap<Felt252, DeprecatedContractClass>,
+    pub deprecated_compiled_classes: HashMap<Felt252, GenericDeprecatedCompiledClass>,
     pub compiled_classes: HashMap<Felt252, GenericCasmContractClass>,
     pub compiled_class_visited_pcs: HashMap<Felt252, Vec<Felt252>>,
     pub contracts: HashMap<Felt252, ContractState>,

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/contract_class_objects.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/contract_class_objects.rs
@@ -2,8 +2,8 @@ use cairo_lang_starknet_classes::contract_class::{ContractClass, ContractEntryPo
 use cairo_vm::Felt252;
 use pathfinder_gateway_types::class_hash::compute_class_hash;
 use serde::{Deserialize, Serialize};
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 use starknet_os_types::hash::Hash;
 
 use crate::config::CONTRACT_CLASS_LEAF_VERSION;
@@ -84,7 +84,7 @@ where
 /// Represents a single deprecated compiled contract class which is stored in the Starknet state.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeprecatedCompiledClassFact {
-    pub contract_definition: DeprecatedCompiledClass,
+    pub contract_definition: GenericDeprecatedCompiledClass,
 }
 
 const DEPRECATED_COMPILED_CLASS_PREFIX: &[u8] = "contract_definition_fact".as_bytes();

--- a/crates/starknet-os/src/starknet/business_logic/utils.rs
+++ b/crates/starknet-os/src/starknet/business_logic/utils.rs
@@ -1,6 +1,6 @@
 use cairo_lang_starknet_classes::contract_class::ContractClass;
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 use starknet_os_types::hash::Hash;
 
 use crate::starknet::business_logic::fact_state::contract_class_objects::{
@@ -27,7 +27,7 @@ where
 }
 
 pub async fn write_deprecated_compiled_class_fact<S, H>(
-    deprecated_compiled_class: DeprecatedCompiledClass,
+    deprecated_compiled_class: GenericDeprecatedCompiledClass,
     ffc: &mut FactFetchingContext<S, H>,
 ) -> Result<Hash, StorageError>
 where
@@ -93,7 +93,7 @@ mod tests {
              test_contract_compiled.json"
         );
 
-        let contract_class: DeprecatedCompiledClass = serde_json::from_slice(program_bytes).unwrap();
+        let contract_class: GenericDeprecatedCompiledClass = serde_json::from_slice(program_bytes).unwrap();
 
         let compiled_class_hash = write_deprecated_compiled_class_fact(contract_class, &mut ffc).await.unwrap();
 

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -8,7 +8,6 @@ use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use starknet_api::core::{ClassHash, ContractAddress, PatriciaKey};
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::StarkHash;
 use starknet_os::config::{StarknetGeneralConfig, StarknetOsConfig, STORED_BLOCK_HASH_BUFFER};
 use starknet_os::crypto::pedersen::PedersenHash;
@@ -25,6 +24,7 @@ use starknet_os::storage::storage::Storage;
 use starknet_os::storage::storage_utils::build_starknet_storage_async;
 use starknet_os::utils::{felt_api2vm, felt_vm2api};
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
 use crate::common::transaction_utils::to_felt252;
 
@@ -33,7 +33,7 @@ pub async fn os_hints<S>(
     mut blockifier_state: CachedState<SharedState<S, PedersenHash>>,
     transactions: Vec<InternalTransaction>,
     tx_execution_infos: Vec<TransactionExecutionInfo>,
-    deprecated_compiled_classes: HashMap<ClassHash, DeprecatedContractClass>,
+    deprecated_compiled_classes: HashMap<ClassHash, GenericDeprecatedCompiledClass>,
     compiled_classes: HashMap<ClassHash, GenericCasmContractClass>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper<S>)
 where

--- a/tests/integration/common/blockifier_contracts.rs
+++ b/tests/integration/common/blockifier_contracts.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use cairo_lang_starknet_classes::contract_class::ContractClass;
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
 use crate::common::contract_fixtures::{get_deprecated_compiled_class, load_cairo1_contract};
 
@@ -11,7 +11,7 @@ fn get_deprecated_feature_contract_path(contract_name: &str) -> PathBuf {
     Path::new("blockifier_contracts").join("feature_contracts").join("cairo0").join("compiled").join(filename)
 }
 
-pub fn get_deprecated_erc20_contract_class() -> DeprecatedCompiledClass {
+pub fn get_deprecated_erc20_contract_class() -> GenericDeprecatedCompiledClass {
     let contract_rel_path = Path::new("blockifier_contracts")
         .join("ERC20_without_some_syscalls")
         .join("ERC20")
@@ -25,7 +25,7 @@ fn get_feature_sierra_contract_path(contract_name: &str) -> PathBuf {
 }
 
 /// Helper to load a Cairo 0 contract class.
-pub(crate) fn load_cairo0_feature_contract(name: &str) -> (String, DeprecatedCompiledClass) {
+pub(crate) fn load_cairo0_feature_contract(name: &str) -> (String, GenericDeprecatedCompiledClass) {
     let contract_path = get_deprecated_feature_contract_path(name);
     let compiled_class = get_deprecated_compiled_class(&contract_path);
     (name.to_string(), compiled_class)

--- a/tests/integration/common/contract_fixtures.rs
+++ b/tests/integration/common/contract_fixtures.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 
 use cairo_lang_starknet_classes::casm_contract_class::{CasmContractClass, StarknetSierraCompilationError};
 use cairo_lang_starknet_classes::contract_class::ContractClass;
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
 pub fn get_contracts_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("contracts")
@@ -19,7 +19,7 @@ fn read_contract(contract_rel_path: &Path) -> Vec<u8> {
     })
 }
 
-pub fn get_deprecated_compiled_class(contract_rel_path: &Path) -> DeprecatedCompiledClass {
+pub fn get_deprecated_compiled_class(contract_rel_path: &Path) -> GenericDeprecatedCompiledClass {
     let content = read_contract(contract_rel_path);
     serde_json::from_slice(&content).unwrap_or_else(|e| panic!("Failed to load deprecated compiled class: {e}"))
 }

--- a/tests/integration/common/os_itest_contracts.rs
+++ b/tests/integration/common/os_itest_contracts.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
 use crate::common::contract_fixtures::get_deprecated_compiled_class;
 
@@ -10,7 +10,7 @@ fn get_deprecated_os_itest_contract_path(contract_name: &str) -> PathBuf {
 }
 
 /// Helper to load a Cairo 0 contract class.
-pub fn load_os_itest_contract(name: &str) -> (String, DeprecatedCompiledClass) {
+pub fn load_os_itest_contract(name: &str) -> (String, GenericDeprecatedCompiledClass) {
     let contract_path = get_deprecated_os_itest_contract_path(name);
     (name.to_string(), get_deprecated_compiled_class(&contract_path))
 }

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -15,7 +15,6 @@ use cairo_vm::Felt252;
 use num_bigint::BigUint;
 use rstest::rstest;
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress, PatriciaKey};
-use starknet_api::deprecated_contract_class::ContractClass as DeprecatedCompiledClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
@@ -40,6 +39,7 @@ use starknet_os::storage::storage::Storage;
 use starknet_os::utils::felt_api2vm;
 use starknet_os::{config, run_os};
 use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
 use crate::common::block_utils::os_hints;
 
@@ -774,7 +774,7 @@ async fn execute_txs<S>(
     mut state: CachedState<SharedState<S, PedersenHash>>,
     block_context: &BlockContext,
     txs: Vec<Transaction>,
-    deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
+    deprecated_contract_classes: HashMap<ClassHash, GenericDeprecatedCompiledClass>,
     contract_classes: HashMap<ClassHash, GenericCasmContractClass>,
 ) -> (StarknetOsInput, ExecutionHelperWrapper<S>)
 where
@@ -814,7 +814,7 @@ pub async fn execute_txs_and_run_os<S>(
     state: CachedState<SharedState<S, PedersenHash>>,
     block_context: BlockContext,
     txs: Vec<Transaction>,
-    deprecated_contract_classes: HashMap<ClassHash, DeprecatedCompiledClass>,
+    deprecated_contract_classes: HashMap<ClassHash, GenericDeprecatedCompiledClass>,
     contract_classes: HashMap<ClassHash, GenericCasmContractClass>,
 ) -> Result<(CairoPie, StarknetOsOutput), SnOsError>
 where

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -8,7 +8,6 @@ use starknet_api::core::CompiledClassHash;
 use starknet_api::transaction::{Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionVersion};
 use starknet_os::crypto::poseidon::PoseidonHash;
 use starknet_os::starknet::business_logic::utils::write_class_facts;
-use starknet_os::storage::storage_utils::deprecated_contract_class_api2vm;
 
 use crate::common::block_context;
 use crate::common::blockifier_contracts::load_cairo1_feature_contract;
@@ -160,9 +159,8 @@ async fn declare_v1_cairo0_account(
 
     let class_hash = test_contract.declaration.class_hash;
 
-    let class = deprecated_contract_class_api2vm(&test_contract.declaration.class).unwrap();
-
-    let class_info = calculate_class_info_for_testing(class);
+    let blockifier_class = test_contract.declaration.class.get_blockifier_contract_class().unwrap().clone();
+    let class_info = calculate_class_info_for_testing(blockifier_class.into());
 
     let declare_tx = blockifier::test_utils::declare::declare_tx(
         declare_tx_args! {

--- a/tests/integration/run_os.rs
+++ b/tests/integration/run_os.rs
@@ -28,7 +28,7 @@ use starknet_os::execution::helper::GenCallIter;
 use starknet_os::io::output::StarknetOsOutput;
 use starknet_os::starknet::business_logic::fact_state::state::SharedState;
 use starknet_os::storage::dict_storage::DictStorage;
-use starknet_os::storage::storage_utils::{deprecated_contract_class_api2vm, unpack_blockifier_state_async};
+use starknet_os::storage::storage_utils::unpack_blockifier_state_async;
 use starknet_os::utils::felt_api2vm;
 
 use crate::common::block_context;
@@ -352,8 +352,8 @@ async fn prepare_extensive_os_test_params(
     let test_contract2 = cairo0_contracts.get("test_contract2").unwrap();
 
     let class_hash = test_contract2.class_hash;
-    let class = deprecated_contract_class_api2vm(&test_contract2.class).unwrap();
-    let class_info = calculate_class_info_for_testing(class);
+    let class = test_contract2.class.get_blockifier_contract_class().unwrap().clone();
+    let class_info = calculate_class_info_for_testing(class.into());
 
     let declare_tx = declare_tx(
         declare_tx_args! {
@@ -436,8 +436,8 @@ fn add_declare_and_deploy_contract_txs(
 ) -> Result<ContractAddress, &'static str> {
     let contract = cairo0_contracts.get(contract).ok_or("Contract not found")?;
 
-    let class = deprecated_contract_class_api2vm(&contract.class).map_err(|_| "Failed to get VM class")?;
-    let class_info = calculate_class_info_for_testing(class);
+    let class = contract.class.get_blockifier_contract_class().map_err(|_| "Failed to get VM class")?;
+    let class_info = calculate_class_info_for_testing(class.clone().into());
     let declare_tx = declare_tx(
         declare_tx_args! {
             sender_address: *account_address,


### PR DESCRIPTION
Problem: as for CASM classes, we use many different deprecated compiled
class types, creating a mess.

Solution: introduce `GenericDeprecatedCompiledClass`, a type that is
able to convert to all useful deprecated compiled class types and
to compute class hashes.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
