### PR TITLE
Fix: CI fails on main

### DIFF
--- a/crates/starknet-os/src/cairo_types/syscalls.rs
+++ b/crates/starknet-os/src/cairo_types/syscalls.rs
@@ -123,17 +123,21 @@ pub struct GetBlockNumber {
 
 #[derive(FieldOffsetGetters)]
 pub struct GetBlockTimestampRequest {
+    #[allow(unused)]
     pub selector: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetBlockTimestampResponse {
+    #[allow(unused)]
     pub block_timestamp: Felt252,
 }
 
 #[derive(FieldOffsetGetters)]
 pub struct GetBlockTimestamp {
+    #[allow(unused)]
     pub request: GetBlockTimestampRequest,
+    #[allow(unused)]
     pub response: GetBlockTimestampResponse,
 }
 


### PR DESCRIPTION
Problem: someone (me) was a little trigger-happy merging a PR that was not rebased, as we introduced stricter checks to the CI this PR broke the CI on main because of some warnings.

Solution: fix the problematic warnings.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [x] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
