### PR TITLE
Reflect renamed module (fix the build)

### DIFF
--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -43,7 +43,7 @@ use starknet_os::storage::cached_storage::CachedStorage;
 use starknet_os::storage::storage::{Fact, FactFetchingContext, Storage, StorageError};
 use starknet_os::utils::felt_vm2api;
 use starknet_os::{config, run_os};
-use starknet_os_types::contract_class::GenericCasmContractClass;
+use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_types_core::felt::Felt;
 use types::starknet_rs_to_blockifier;
 


### PR DESCRIPTION
This fixes the build. #298 renamed the `contract_class` module to `casm_contract_class` module without #287 noticing...

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
