### PR TITLE
Internal: port compiled class hash tests from cairo-lang

### DIFF
--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -16,3 +16,7 @@ starknet_api = { workspace = true }
 starknet-types-core = { workspace = true }
 starknet-core = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+indoc = { workspace = true }
+rstest = { workspace = true }

--- a/crates/starknet-os-types/src/casm_contract_class.rs
+++ b/crates/starknet-os-types/src/casm_contract_class.rs
@@ -160,9 +160,12 @@ impl TryFrom<GenericCasmContractClass> for BlockifierCasmClass {
 mod tests {
     use std::str::FromStr;
 
+    use indoc::indoc;
+    use rstest::rstest;
     use starknet_types_core::felt::Felt;
 
     use super::*;
+    use crate::hash::Hash;
 
     const CONTRACT_BYTES: &[u8] = include_bytes!(
         "../../../tests/integration/contracts/blockifier_contracts/feature_contracts/cairo1/compiled/test_contract.\
@@ -203,5 +206,105 @@ mod tests {
         let expected_class_hash =
             Felt::from_str("0x607c67298d45092cca5b2ae6804373dd8a2cbe7d2ec4072b3f67097461d5ff4").unwrap();
         assert_eq!(Felt::from(*class_hash), expected_class_hash);
+    }
+
+    const TEST_CONTRACT_WITHOUT_SEGMENTATION: &str = indoc! {r#"
+        {
+          "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+          "compiler_version": "",
+          "bytecode": [
+            "0x1",
+            "0x2",
+            "0x3",
+            "0x4",
+            "0x5",
+            "0x6",
+            "0x7",
+            "0x8",
+            "0x9",
+            "0xa"
+          ],
+          "hints": [],
+          "entry_points_by_type": {
+            "EXTERNAL": [
+              {
+                "selector": "0x1",
+                "offset": 1,
+                "builtins": [
+                  "237"
+                ]
+              }
+            ],
+            "L1_HANDLER": [],
+            "CONSTRUCTOR": [
+              {
+                "selector": "0x5",
+                "offset": 0,
+                "builtins": []
+              }
+            ]
+          }
+        }
+        "#
+    };
+
+    const TEST_CONTRACT_WITH_SEGMENTATION: &str = indoc! {r#"
+        {
+          "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+          "compiler_version": "",
+          "bytecode": [
+            "0x1",
+            "0x2",
+            "0x3",
+            "0x4",
+            "0x5",
+            "0x6",
+            "0x7",
+            "0x8",
+            "0x9",
+            "0xa"
+          ],
+          "bytecode_segment_lengths": [3, [1, 1, [1]], 4],
+          "hints": [],
+          "entry_points_by_type": {
+            "EXTERNAL": [
+              {
+                "selector": "0x1",
+                "offset": 1,
+                "builtins": [
+                  "237"
+                ]
+              }
+            ],
+            "L1_HANDLER": [],
+            "CONSTRUCTOR": [
+              {
+                "selector": "0x5",
+                "offset": 0,
+                "builtins": []
+              }
+            ]
+          }
+        }
+        "#
+    };
+
+    #[rstest]
+    #[case::without_segmentation(
+        TEST_CONTRACT_WITHOUT_SEGMENTATION,
+        "0xB268995DD0EE80DEBFB8718852750B5FD22082D0C729121C48A0487A4D2F64"
+    )]
+    #[case::with_segmentation(
+        TEST_CONTRACT_WITH_SEGMENTATION,
+        "0x5517AD8471C9AA4D1ADD31837240DEAD9DC6653854169E489A813DB4376BE9C"
+    )]
+    fn test_compiled_class_hash_without_segmentation(#[case] test_contract: &str, #[case] expected_hash_str: &str) {
+        let expected_hash = Felt::from_hex(expected_hash_str).unwrap();
+        let expected_compiled_class_hash = GenericClassHash::new(Hash::from(expected_hash));
+
+        let casm_class: GenericCasmContractClass = serde_json::from_str(test_contract).unwrap();
+        let compiled_class_hash = casm_class.class_hash().unwrap();
+
+        assert_eq!(compiled_class_hash, expected_compiled_class_hash);
     }
 }


### PR DESCRIPTION
Problem: our test coverage for compiled class hashing is lacking, and we are having trouble determining where hashing issues occur.

Solution: increase the coverage by porting tests from cairo-lang.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [x] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
