### PR TITLE
Feature: make OS per-contract storage customizable

### DIFF
--- a/crates/bin/hint_tool/src/main.rs
+++ b/crates/bin/hint_tool/src/main.rs
@@ -13,7 +13,9 @@ use cairo_vm::vm::vm_core::VirtualMachineBuilder;
 use cairo_vm::vm::vm_memory::memory_segments::MemorySegmentManager;
 use clap::Parser;
 use serde::Deserialize;
+use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::hints::SnosHintProcessor;
+use starknet_os::starknet::starknet_storage::OsSingleStarknetStorage;
 use starknet_os::storage::dict_storage::DictStorage;
 
 #[derive(Clone, Copy, Debug, Default, clap::ValueEnum, PartialEq)]
@@ -72,7 +74,7 @@ fn main() -> std::io::Result<()> {
     let args = Args::parse();
     let subset = args.subset.unwrap_or_default();
 
-    let mut hint_processor = SnosHintProcessor::<DictStorage>::default();
+    let mut hint_processor = SnosHintProcessor::<OsSingleStarknetStorage<DictStorage, PedersenHash>>::default();
     let snos_hints = hint_processor.hints();
 
     let mut result = Vec::new();

--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -542,7 +542,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         transactions,
         block_hash: block_with_txs.block_hash,
     };
-    let execution_helper = ExecutionHelperWrapper::<CachedRpcStorage>::new(
+    let execution_helper = ExecutionHelperWrapper::<OsSingleStarknetStorage<CachedRpcStorage, PedersenHash>>::new(
         contract_storages,
         tx_execution_infos,
         &block_context,

--- a/crates/starknet-os/src/hints/execute_transactions.rs
+++ b/crates/starknet-os/src/hints/execute_transactions.rs
@@ -12,7 +12,7 @@ use indoc::indoc;
 use crate::cairo_types::structs::ExecutionContext;
 use crate::execution::helper::ExecutionHelperWrapper;
 use crate::hints::vars;
-use crate::storage::storage::Storage;
+use crate::starknet::starknet_storage::PerContractStorage;
 use crate::utils::execute_coroutine;
 
 pub const START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = indoc! {r#"
@@ -20,16 +20,16 @@ pub const START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT: &str = indoc! {r#"
         tx_info_ptr=ids.validate_declare_execution_context.deprecated_tx_info.address_
     )"#
 };
-pub async fn start_tx_validate_declare_execution_context_async<S>(
+pub async fn start_tx_validate_declare_execution_context_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper: ExecutionHelperWrapper<PCS> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let execution_context_ptr =
         get_relocatable_from_var_name(vars::ids::VALIDATE_DECLARE_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
     let deprecated_tx_info_ptr = (execution_context_ptr + ExecutionContext::deprecated_tx_info_offset())?;
@@ -39,7 +39,7 @@ where
     Ok(())
 }
 
-pub fn start_tx_validate_declare_execution_context<S>(
+pub fn start_tx_validate_declare_execution_context<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -47,7 +47,7 @@ pub fn start_tx_validate_declare_execution_context<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(start_tx_validate_declare_execution_context_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(start_tx_validate_declare_execution_context_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -33,10 +33,9 @@ use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
 use crate::io::InternalTransaction;
 use crate::starknet::core::os::transaction_hash::create_resource_bounds_list;
-use crate::starknet::starknet_storage::StorageLeaf;
+use crate::starknet::starknet_storage::{PerContractStorage, StorageLeaf};
 use crate::starkware_utils::commitment_tree::base_types::DescentMap;
 use crate::starkware_utils::commitment_tree::update_tree::{DecodeNodeCase, TreeUpdate, UpdateTree};
-use crate::storage::storage::Storage;
 use crate::utils::{custom_hint_error, execute_coroutine, get_constant};
 
 pub const LOAD_NEXT_TX: &str = indoc! {r#"
@@ -187,7 +186,7 @@ pub fn assert_transaction_hash(
 
 pub const ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER: &str =
     "vm_enter_scope({'syscall_handler': deprecated_syscall_handler})";
-pub fn enter_scope_deprecated_syscall_handler<S>(
+pub fn enter_scope_deprecated_syscall_handler<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -195,9 +194,10 @@ pub fn enter_scope_deprecated_syscall_handler<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let dep_sys = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?;
+    let dep_sys =
+        exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?;
     let deprecated_syscall_handler: Box<dyn Any> = Box::new(dep_sys);
     exec_scopes
         .enter_scope(HashMap::from_iter([(String::from(vars::scopes::SYSCALL_HANDLER), deprecated_syscall_handler)]));
@@ -205,7 +205,7 @@ where
 }
 
 pub const ENTER_SCOPE_SYSCALL_HANDLER: &str = "vm_enter_scope({'syscall_handler': syscall_handler})";
-pub fn enter_scope_syscall_handler<S>(
+pub fn enter_scope_syscall_handler<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -213,9 +213,9 @@ pub fn enter_scope_syscall_handler<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let sys = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let sys = exec_scopes.get::<OsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_handler: Box<dyn Any> = Box::new(sys);
     exec_scopes.enter_scope(HashMap::from_iter([(String::from(vars::scopes::SYSCALL_HANDLER), syscall_handler)]));
     Ok(())
@@ -423,7 +423,7 @@ pub const ENTER_SYSCALL_SCOPES: &str = indoc! {r#"
          '__dict_manager': __dict_manager,
     })"#
 };
-pub fn enter_syscall_scopes<S>(
+pub fn enter_syscall_scopes<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -431,18 +431,18 @@ pub fn enter_syscall_scopes<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let os_input = exec_scopes.get::<StarknetOsInput>(vars::scopes::OS_INPUT)?;
     let deprecated_class_hashes: Box<dyn Any> =
         Box::new(exec_scopes.get::<HashSet<Felt252>>(vars::scopes::DEPRECATED_CLASS_HASHES)?);
     let transactions: Box<dyn Any> = Box::new(os_input.transactions.into_iter());
     let execution_helper: Box<dyn Any> =
-        Box::new(exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?);
+        Box::new(exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?);
     let deprecated_syscall_handler: Box<dyn Any> =
-        Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?);
+        Box::new(exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::DEPRECATED_SYSCALL_HANDLER)?);
     let syscall_handler: Box<dyn Any> =
-        Box::new(exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?);
+        Box::new(exec_scopes.get::<OsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?);
     let dict_manager: Box<dyn Any> = Box::new(exec_scopes.get_dict_manager()?);
     exec_scopes.enter_scope(HashMap::from_iter([
         (String::from(vars::scopes::DEPRECATED_CLASS_HASHES), deprecated_class_hashes),
@@ -456,16 +456,16 @@ where
 }
 
 pub const END_TX: &str = "execution_helper.end_tx()";
-pub async fn end_tx_async<S>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
+pub async fn end_tx_async<PCS>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.end_tx().await;
     Ok(())
 }
 
-pub fn end_tx<S>(
+pub fn end_tx<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -473,34 +473,34 @@ pub fn end_tx<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(end_tx_async::<S>(exec_scopes))?
+    execute_coroutine(end_tx_async::<PCS>(exec_scopes))?
 }
 
 pub const ENTER_CALL: &str = indoc! {r#"
     execution_helper.enter_call(
         execution_info_ptr=ids.execution_context.execution_info.address_)"#
 };
-pub async fn enter_call_async<S>(
+pub async fn enter_call_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let execution_info_ptr = vm.get_relocatable(
         (get_ptr_from_var_name(vars::ids::EXECUTION_CONTEXT, vm, ids_data, ap_tracking)? + 4i32).unwrap(),
     )?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.enter_call(Some(execution_info_ptr)).await;
     Ok(())
 }
 
-pub fn enter_call<S>(
+pub fn enter_call<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -508,22 +508,22 @@ pub fn enter_call<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(enter_call_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(enter_call_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const EXIT_CALL: &str = "execution_helper.exit_call()";
-pub async fn exit_call_async<S>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
+pub async fn exit_call_async<PCS>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.exit_call().await;
     Ok(())
 }
 
-pub fn exit_call<S>(
+pub fn exit_call<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -531,9 +531,9 @@ pub fn exit_call<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(exit_call_async::<S>(exec_scopes))?
+    execute_coroutine(exit_call_async::<PCS>(exec_scopes))?
 }
 
 pub const CONTRACT_ADDRESS: &str = indoc! {r#"
@@ -862,17 +862,17 @@ pub const START_TX: &str = indoc! {r#"
     tx_info_ptr = ids.tx_execution_context.deprecated_tx_info.address_
     execution_helper.start_tx(tx_info_ptr=tx_info_ptr)"#
 };
-pub async fn start_tx_async<S>(
+pub async fn start_tx_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let tx_execution_context = get_ptr_from_var_name(vars::ids::TX_EXECUTION_CONTEXT, vm, ids_data, ap_tracking)?;
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
 
     let tx_info_ptr = vm.get_relocatable((tx_execution_context + ExecutionContext::deprecated_tx_info_offset())?)?;
 
@@ -880,7 +880,7 @@ where
     Ok(())
 }
 
-pub fn start_tx<S>(
+pub fn start_tx<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -888,9 +888,9 @@ pub fn start_tx<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(start_tx_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(start_tx_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const IS_REVERTED: &str = "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.is_reverted)";
@@ -939,14 +939,14 @@ pub const CHECK_EXECUTION: &str = indoc! {r#"
 
 // implement check_execution according to the pythonic version given in the CHECK_EXECUTION const
 // above
-pub async fn check_execution_async<S>(
+pub async fn check_execution_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let return_values_ptr = get_ptr_from_var_name(vars::ids::ENTRY_POINT_RETURN_VALUES, vm, ids_data, ap_tracking)?;
 
@@ -967,7 +967,7 @@ where
         log::debug!("  Error (at most 100 elements): {:?}", error);
     }
 
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     // TODO: make sure it is necessary to check the gas costs
     // if execution_helper.debug_mode {
     //     let actual = get_integer_from_var_name("remaining_gas", vm, ids_data, ap_tracking)?;
@@ -982,14 +982,14 @@ where
     // }
 
     let syscall_ptr_end = vm.get_relocatable((return_values_ptr + EntryPointReturnValues::syscall_ptr_offset())?)?;
-    let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     execute_coroutine(syscall_handler.validate_and_discard_syscall_ptr(syscall_ptr_end))??;
     execution_helper.exit_call().await;
 
     Ok(())
 }
 
-pub fn check_execution<S>(
+pub fn check_execution<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -997,9 +997,9 @@ pub fn check_execution<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(check_execution_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(check_execution_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 fn assert_memory_ranges_equal(
@@ -1211,7 +1211,7 @@ pub fn check_response_return_value(
     Ok(())
 }
 
-async fn cache_contract_storage<S>(
+async fn cache_contract_storage<PCS>(
     key: Felt252,
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
@@ -1219,9 +1219,9 @@ async fn cache_contract_storage<S>(
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
 
@@ -1485,16 +1485,16 @@ pub const WRITE_SYSCALL_RESULT_DEPRECATED: &str = indoc! {r#"
 	ids.new_state_entry = segments.add()"#
 };
 
-pub async fn write_syscall_result_deprecated_async<S>(
+pub async fn write_syscall_result_deprecated_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper: ExecutionHelperWrapper<PCS> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
@@ -1527,7 +1527,7 @@ where
     Ok(())
 }
 
-pub fn write_syscall_result_deprecated<S>(
+pub fn write_syscall_result_deprecated<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1535,9 +1535,9 @@ pub fn write_syscall_result_deprecated<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(write_syscall_result_deprecated_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(write_syscall_result_deprecated_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
@@ -1550,16 +1550,16 @@ pub const WRITE_SYSCALL_RESULT: &str = indoc! {r#"
     ids.new_state_entry = segments.add()"#
 };
 
-pub async fn write_syscall_result_async<S>(
+pub async fn write_syscall_result_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper: ExecutionHelperWrapper<PCS> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let contract_address = get_integer_from_var_name(vars::ids::CONTRACT_ADDRESS, vm, ids_data, ap_tracking)?;
     let request = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
@@ -1591,7 +1591,7 @@ where
     Ok(())
 }
 
-pub fn write_syscall_result<S>(
+pub fn write_syscall_result<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1599,9 +1599,9 @@ pub fn write_syscall_result<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(write_syscall_result_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(write_syscall_result_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const GEN_CLASS_HASH_ARG: &str = indoc! {r#"
@@ -1662,7 +1662,7 @@ pub const WRITE_OLD_BLOCK_TO_STORAGE: &str = indoc! {r#"
 	storage.write(key=ids.old_block_number, value=ids.old_block_hash)"#
 };
 
-pub async fn write_old_block_to_storage_async<S>(
+pub async fn write_old_block_to_storage_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1670,9 +1670,9 @@ pub async fn write_old_block_to_storage_async<S>(
     constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let mut execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper: ExecutionHelperWrapper<PCS> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
 
     let block_hash_contract_address = get_constant(vars::constants::BLOCK_HASH_CONTRACT_ADDRESS, constants)?;
     let old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
@@ -1687,7 +1687,7 @@ where
     Ok(())
 }
 
-pub fn write_old_block_to_storage<S>(
+pub fn write_old_block_to_storage<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1695,9 +1695,9 @@ pub fn write_old_block_to_storage<S>(
     constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(write_old_block_to_storage_async::<S>(vm, exec_scopes, ids_data, ap_tracking, constants))?
+    execute_coroutine(write_old_block_to_storage_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking, constants))?
 }
 
 pub const CACHE_CONTRACT_STORAGE_REQUEST_KEY: &str = indoc! {r#"
@@ -1707,7 +1707,7 @@ pub const CACHE_CONTRACT_STORAGE_REQUEST_KEY: &str = indoc! {r#"
 	assert ids.value == value, "Inconsistent storage value.""#
 };
 
-pub fn cache_contract_storage_request_key<S>(
+pub fn cache_contract_storage_request_key<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1715,12 +1715,12 @@ pub fn cache_contract_storage_request_key<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let request_ptr = get_ptr_from_var_name(vars::ids::REQUEST, vm, ids_data, ap_tracking)?;
     let key = vm.get_integer((request_ptr + new_syscalls::StorageReadRequest::key_offset())?)?.into_owned();
 
-    execute_coroutine(cache_contract_storage::<S>(key, vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(cache_contract_storage::<PCS>(key, vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS: &str = indoc! {r#"
@@ -1732,7 +1732,7 @@ pub const CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS: &str = indoc! {r#"
 	assert ids.value == value, "Inconsistent storage value.""#
 };
 
-pub fn cache_contract_storage_syscall_request_address<S>(
+pub fn cache_contract_storage_syscall_request_address<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1740,13 +1740,13 @@ pub fn cache_contract_storage_syscall_request_address<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
     let offset = StorageRead::request_offset() + StorageReadRequest::address_offset();
     let key = vm.get_integer((syscall_ptr + offset)?)?.into_owned();
 
-    execute_coroutine(cache_contract_storage::<S>(key, vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(cache_contract_storage::<PCS>(key, vm, exec_scopes, ids_data, ap_tracking))?
 }
 pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	(
@@ -1759,16 +1759,16 @@ pub const GET_OLD_BLOCK_NUMBER_AND_HASH: &str = indoc! {r#"
 	ids.old_block_hash = old_block_hash"#
 };
 
-pub async fn get_old_block_number_and_hash_async<S>(
+pub async fn get_old_block_number_and_hash_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper: ExecutionHelperWrapper<PCS> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let (old_block_number, old_block_hash) = execution_helper.get_old_block_number_and_hash().await?;
 
     let ids_old_block_number = get_integer_from_var_name(vars::ids::OLD_BLOCK_NUMBER, vm, ids_data, ap_tracking)?;
@@ -1786,7 +1786,7 @@ where
     Ok(())
 }
 
-pub fn get_old_block_number_and_hash<S>(
+pub fn get_old_block_number_and_hash<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -1794,9 +1794,9 @@ pub fn get_old_block_number_and_hash<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(get_old_block_number_and_hash_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(get_old_block_number_and_hash_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const FETCH_RESULT: &str = indoc! {r#"
@@ -1861,6 +1861,11 @@ mod tests {
     use crate::storage::dict_storage::DictStorage;
     use crate::storage::storage::FactFetchingContext;
 
+    #[allow(clippy::upper_case_acronyms)]
+    type PCS = OsSingleStarknetStorage<DictStorage, PedersenHash>;
+    #[allow(clippy::upper_case_acronyms)]
+    type EHW = ExecutionHelperWrapper<PCS>;
+
     #[fixture]
     pub fn block_context() -> BlockContext {
         BlockContext::create_for_account_testing()
@@ -1872,11 +1877,8 @@ mod tests {
     }
 
     #[fixture]
-    fn execution_helper(
-        block_context: BlockContext,
-        old_block_number_and_hash: (Felt252, Felt252),
-    ) -> ExecutionHelperWrapper<DictStorage> {
-        ExecutionHelperWrapper::new(ContractStorageMap::default(), vec![], &block_context, old_block_number_and_hash)
+    fn execution_helper(block_context: BlockContext, old_block_number_and_hash: (Felt252, Felt252)) -> EHW {
+        EHW::new(ContractStorageMap::default(), vec![], &block_context, old_block_number_and_hash)
     }
 
     #[fixture]
@@ -1885,10 +1887,7 @@ mod tests {
     }
 
     #[fixture]
-    async fn execution_helper_with_storage(
-        execution_helper: ExecutionHelperWrapper<DictStorage>,
-        contract_address: Felt252,
-    ) -> ExecutionHelperWrapper<DictStorage> {
+    async fn execution_helper_with_storage(execution_helper: EHW, contract_address: Felt252) -> EHW {
         let storage = DictStorage::default();
         let mut ffc = FactFetchingContext::<_, PedersenHash>::new(storage);
 
@@ -1911,7 +1910,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // TODO: fix
     async fn test_cache_contract_storage_request_key(
-        #[future] execution_helper_with_storage: ExecutionHelperWrapper<DictStorage>,
+        #[future] execution_helper_with_storage: EHW,
         contract_address: Felt252,
     ) {
         let execution_helper_with_storage = execution_helper_with_storage.await;
@@ -1945,14 +1944,8 @@ mod tests {
 
         // Just make sure that the hint goes through, all meaningful assertions are
         // in the implementation of the hint
-        cache_contract_storage_request_key::<DictStorage>(
-            &mut vm,
-            &mut exec_scopes,
-            &ids_data,
-            &ap_tracking,
-            &constants,
-        )
-        .expect("Hint should not fail");
+        cache_contract_storage_request_key::<PCS>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
+            .expect("Hint should not fail");
     }
 
     #[test]
@@ -2005,10 +1998,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     #[ignore] // TODO: fix
-    async fn test_write_syscall_result(
-        #[future] execution_helper_with_storage: ExecutionHelperWrapper<DictStorage>,
-        contract_address: Felt252,
-    ) {
+    async fn test_write_syscall_result(#[future] execution_helper_with_storage: EHW, contract_address: Felt252) {
         let mut execution_helper_with_storage = execution_helper_with_storage.await;
 
         let mut vm = VirtualMachine::new(false);
@@ -2061,7 +2051,7 @@ mod tests {
 
         // Just make sure that the hint goes through, all meaningful assertions are
         // in the implementation of the hint
-        write_syscall_result_deprecated::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
+        write_syscall_result_deprecated::<PCS>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants)
             .expect("Hint should not fail");
 
         // Check that the storage was updated

--- a/crates/starknet-os/src/hints/mod.rs
+++ b/crates/starknet-os/src/hints/mod.rs
@@ -26,8 +26,7 @@ use crate::execution::helper::ExecutionHelperWrapper;
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::block_context::is_leaf;
 use crate::io::input::StarknetOsInput;
-use crate::storage::dict_storage::DictStorage;
-use crate::storage::storage::Storage;
+use crate::starknet::starknet_storage::PerContractStorage;
 use crate::utils::execute_coroutine;
 
 pub mod block_context;
@@ -59,8 +58,8 @@ pub type HintImpl = fn(
 ) -> Result<(), HintError>;
 
 #[rustfmt::skip]
-fn hints<S>() -> HashMap<String, HintImpl> where
-    S: Storage + 'static {
+fn hints<PCS>() -> HashMap<String, HintImpl> where
+    PCS: PerContractStorage + 'static {
     let mut hints = HashMap::<String, HintImpl>::new();
     hints.insert(BREAKPOINT.into(), breakpoint);
     hints.insert(INITIALIZE_CLASS_HASHES.into(), initialize_class_hashes);
@@ -69,11 +68,11 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(OS_INPUT_TRANSACTIONS.into(), os_input_transactions);
     hints.insert(SEGMENTS_ADD.into(), segments_add);
     hints.insert(SEGMENTS_ADD_TEMP.into(), segments_add_temp);
-    hints.insert(SET_AP_TO_ACTUAL_FEE.into(), set_ap_to_actual_fee::<DictStorage>);
-    hints.insert(SKIP_CALL.into(), skip_call::<S>);
-    hints.insert(SKIP_TX.into(), skip_tx::<S>);
+    hints.insert(SET_AP_TO_ACTUAL_FEE.into(), set_ap_to_actual_fee::<PCS>);
+    hints.insert(SKIP_CALL.into(), skip_call::<PCS>);
+    hints.insert(SKIP_TX.into(), skip_tx::<PCS>);
     hints.insert(STARKNET_OS_INPUT.into(), starknet_os_input);
-    hints.insert(START_TX.into(), start_tx::<S>);
+    hints.insert(START_TX.into(), start_tx::<PCS>);
     hints.insert(block_context::BLOCK_NUMBER.into(), block_context::block_number);
     hints.insert(block_context::BLOCK_TIMESTAMP.into(), block_context::block_timestamp);
     hints.insert(block_context::BYTECODE_SEGMENT_STRUCTURE.into(), block_context::bytecode_segment_structure);
@@ -96,20 +95,20 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(deprecated_compiled_class::LOAD_DEPRECATED_CLASS_FACTS.into(), deprecated_compiled_class::load_deprecated_class_facts);
     hints.insert(deprecated_compiled_class::LOAD_DEPRECATED_CLASS_INNER.into(), deprecated_compiled_class::load_deprecated_class_inner);
     hints.insert(execute_syscalls::IS_BLOCK_NUMBER_IN_BLOCK_HASH_BUFFER.into(), execute_syscalls::is_block_number_in_block_hash_buffer);
-    hints.insert(execute_transactions::START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT.into(), execute_transactions::start_tx_validate_declare_execution_context::<S>);
+    hints.insert(execute_transactions::START_TX_VALIDATE_DECLARE_EXECUTION_CONTEXT.into(), execute_transactions::start_tx_validate_declare_execution_context::<PCS>);
     hints.insert(execution::ADD_RELOCATION_RULE.into(), execution::add_relocation_rule);
     hints.insert(execution::ASSERT_TRANSACTION_HASH.into(), execution::assert_transaction_hash);
-    hints.insert(execution::CACHE_CONTRACT_STORAGE_REQUEST_KEY.into(), execution::cache_contract_storage_request_key::<S>);
-    hints.insert(execution::CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS.into(), execution::cache_contract_storage_syscall_request_address::<S>);
-    hints.insert(execution::CHECK_EXECUTION.into(), execution::check_execution::<S>);
+    hints.insert(execution::CACHE_CONTRACT_STORAGE_REQUEST_KEY.into(), execution::cache_contract_storage_request_key::<PCS>);
+    hints.insert(execution::CACHE_CONTRACT_STORAGE_SYSCALL_REQUEST_ADDRESS.into(), execution::cache_contract_storage_syscall_request_address::<PCS>);
+    hints.insert(execution::CHECK_EXECUTION.into(), execution::check_execution::<PCS>);
     hints.insert(execution::CHECK_IS_DEPRECATED.into(), execution::check_is_deprecated);
     hints.insert(execution::CHECK_NEW_DEPLOY_RESPONSE.into(), execution::check_new_deploy_response);
     hints.insert(execution::CHECK_NEW_SYSCALL_RESPONSE.into(), execution::check_new_syscall_response);
     hints.insert(execution::CHECK_SYSCALL_RESPONSE.into(), execution::check_syscall_response);
     hints.insert(execution::CONTRACT_ADDRESS.into(), execution::contract_address);
-    hints.insert(execution::END_TX.into(), execution::end_tx::<S>);
-    hints.insert(execution::ENTER_CALL.into(), execution::enter_call::<S>);
-    hints.insert(execution::ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER.into(), execution::enter_scope_deprecated_syscall_handler::<S>);
+    hints.insert(execution::END_TX.into(), execution::end_tx::<PCS>);
+    hints.insert(execution::ENTER_CALL.into(), execution::enter_call::<PCS>);
+    hints.insert(execution::ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER.into(), execution::enter_scope_deprecated_syscall_handler::<PCS>);
     hints.insert(execution::ENTER_SCOPE_DESCEND_EDGE.into(), execution::enter_scope_descend_edge);
     hints.insert(execution::ENTER_SCOPE_LEFT_CHILD.into(), execution::enter_scope_left_child);
     hints.insert(execution::ENTER_SCOPE_NEW_NODE.into(), execution::enter_scope_new_node);
@@ -117,9 +116,9 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(execution::ENTER_SCOPE_NEXT_NODE_BIT_1.into(), execution::enter_scope_next_node_bit_1);
     hints.insert(execution::ENTER_SCOPE_NODE.into(), execution::enter_scope_node_hint);
     hints.insert(execution::ENTER_SCOPE_RIGHT_CHILD.into(), execution::enter_scope_right_child);
-    hints.insert(execution::ENTER_SCOPE_SYSCALL_HANDLER.into(), execution::enter_scope_syscall_handler::<S>);
-    hints.insert(execution::ENTER_SYSCALL_SCOPES.into(), execution::enter_syscall_scopes::<S>);
-    hints.insert(execution::EXIT_CALL.into(), execution::exit_call::<S>);
+    hints.insert(execution::ENTER_SCOPE_SYSCALL_HANDLER.into(), execution::enter_scope_syscall_handler::<PCS>);
+    hints.insert(execution::ENTER_SYSCALL_SCOPES.into(), execution::enter_syscall_scopes::<PCS>);
+    hints.insert(execution::EXIT_CALL.into(), execution::exit_call::<PCS>);
     hints.insert(execution::EXIT_TX.into(), execution::exit_tx);
     hints.insert(execution::FETCH_RESULT.into(), execution::fetch_result);
     hints.insert(execution::GEN_CLASS_HASH_ARG.into(), execution::gen_class_hash_arg);
@@ -128,7 +127,7 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(execution::GET_CONTRACT_ADDRESS_STATE_ENTRY.into(), execution::get_contract_address_state_entry);
     hints.insert(execution::GET_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY.into(), execution::get_contract_address_state_entry_and_set_new_state_entry);
     hints.insert(execution::GET_CONTRACT_ADDRESS_STATE_ENTRY_AND_SET_NEW_STATE_ENTRY_2.into(), execution::get_contract_address_state_entry_and_set_new_state_entry);
-    hints.insert(execution::GET_OLD_BLOCK_NUMBER_AND_HASH.into(), execution::get_old_block_number_and_hash::<S>);
+    hints.insert(execution::GET_OLD_BLOCK_NUMBER_AND_HASH.into(), execution::get_old_block_number_and_hash::<PCS>);
     hints.insert(execution::INITIAL_GE_REQUIRED_GAS.into(), execution::initial_ge_required_gas);
     hints.insert(execution::IS_DEPRECATED.into(), execution::is_deprecated);
     hints.insert(execution::IS_REVERTED.into(), execution::is_reverted);
@@ -140,7 +139,7 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(execution::SET_AP_TO_TX_NONCE.into(), execution::set_ap_to_tx_nonce);
     hints.insert(execution::SET_FP_PLUS_4_TO_TX_NONCE.into(), execution::set_fp_plus_4_to_tx_nonce);
     hints.insert(execution::SET_STATE_ENTRY_TO_ACCOUNT_CONTRACT_ADDRESS.into(), execution::set_state_entry_to_account_contract_address);
-    hints.insert(execution::START_TX.into(), execution::start_tx::<S>);
+    hints.insert(execution::START_TX.into(), execution::start_tx::<PCS>);
     hints.insert(execution::TRANSACTION_VERSION.into(), execution::transaction_version);
     hints.insert(execution::TX_ACCOUNT_DEPLOYMENT_DATA.into(), execution::tx_account_deployment_data);
     hints.insert(execution::TX_ACCOUNT_DEPLOYMENT_DATA_LEN.into(), execution::tx_account_deployment_data_len);
@@ -155,9 +154,9 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(execution::TX_PAYMASTER_DATA_LEN.into(), execution::tx_paymaster_data_len);
     hints.insert(execution::TX_RESOURCE_BOUNDS_LEN.into(), execution::tx_resource_bounds_len);
     hints.insert(execution::TX_TIP.into(), execution::tx_tip);
-    hints.insert(execution::WRITE_OLD_BLOCK_TO_STORAGE.into(), execution::write_old_block_to_storage::<S>);
-    hints.insert(execution::WRITE_SYSCALL_RESULT.into(), execution::write_syscall_result::<S>);
-    hints.insert(execution::WRITE_SYSCALL_RESULT_DEPRECATED.into(), execution::write_syscall_result_deprecated::<S>);
+    hints.insert(execution::WRITE_OLD_BLOCK_TO_STORAGE.into(), execution::write_old_block_to_storage::<PCS>);
+    hints.insert(execution::WRITE_SYSCALL_RESULT.into(), execution::write_syscall_result::<PCS>);
+    hints.insert(execution::WRITE_SYSCALL_RESULT_DEPRECATED.into(), execution::write_syscall_result_deprecated::<PCS>);
     hints.insert(output::SET_AP_TO_BLOCK_HASH.into(), output::set_ap_to_block_hash);
     hints.insert(output::SET_STATE_UPDATES_START.into(), output::set_state_updates_start);
     hints.insert(output::SET_TREE_STRUCTURE.into(), output::set_tree_structure);
@@ -173,18 +172,18 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(patricia::WRITE_CASE_NOT_LEFT_TO_AP.into(), patricia::write_case_not_left_to_ap);
     hints.insert(state::DECODE_NODE.into(), state::decode_node_hint);
     hints.insert(state::DECODE_NODE_2.into(), state::decode_node_hint);
-    hints.insert(state::ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS.into(), state::enter_scope_commitment_info_by_address::<S>);
+    hints.insert(state::ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS.into(), state::enter_scope_commitment_info_by_address::<PCS>);
     hints.insert(state::LOAD_BOTTOM.into(), state::load_bottom);
     hints.insert(state::LOAD_EDGE.into(), state::load_edge);
     hints.insert(state::SET_PREIMAGE_FOR_CLASS_COMMITMENTS.into(), state::set_preimage_for_class_commitments);
     hints.insert(state::SET_PREIMAGE_FOR_CURRENT_COMMITMENT_INFO.into(), state::set_preimage_for_current_commitment_info);
     hints.insert(state::SET_PREIMAGE_FOR_STATE_COMMITMENTS.into(), state::set_preimage_for_state_commitments);
     hints.insert(state::WRITE_SPLIT_RESULT.into(), state::write_split_result);
-    hints.insert(syscalls::CALL_CONTRACT.into(), syscalls::call_contract::<S>);
-    hints.insert(syscalls::DELEGATE_CALL.into(), syscalls::delegate_call::<S>);
-    hints.insert(syscalls::DELEGATE_L1_HANDLER.into(), syscalls::delegate_l1_handler::<S>);
-    hints.insert(syscalls::DEPLOY.into(), syscalls::deploy::<S>);
-    hints.insert(syscalls::EMIT_EVENT.into(), syscalls::emit_event::<S>);
+    hints.insert(syscalls::CALL_CONTRACT.into(), syscalls::call_contract::<PCS>);
+    hints.insert(syscalls::DELEGATE_CALL.into(), syscalls::delegate_call::<PCS>);
+    hints.insert(syscalls::DELEGATE_L1_HANDLER.into(), syscalls::delegate_l1_handler::<PCS>);
+    hints.insert(syscalls::DEPLOY.into(), syscalls::deploy::<PCS>);
+    hints.insert(syscalls::EMIT_EVENT.into(), syscalls::emit_event::<PCS>);
     hints.insert(syscalls::EXIT_CALL_CONTRACT_SYSCALL.into(), syscalls::exit_call_contract_syscall);
     hints.insert(syscalls::EXIT_DELEGATE_CALL_SYSCALL.into(), syscalls::exit_delegate_call_syscall);
     hints.insert(syscalls::EXIT_DELEGATE_L1_HANDLER_SYSCALL.into(), syscalls::exit_delegate_l1_handler_syscall);
@@ -216,21 +215,21 @@ fn hints<S>() -> HashMap<String, HintImpl> where
     hints.insert(syscalls::EXIT_SEND_MESSAGE_TO_L1_SYSCALL.into(), syscalls::exit_send_message_to_l1_syscall);
     hints.insert(syscalls::EXIT_STORAGE_READ_SYSCALL.into(), syscalls::exit_storage_read_syscall);
     hints.insert(syscalls::EXIT_STORAGE_WRITE_SYSCALL.into(), syscalls::exit_storage_write_syscall);
-    hints.insert(syscalls::GET_BLOCK_NUMBER.into(), syscalls::get_block_number::<S>);
-    hints.insert(syscalls::GET_BLOCK_TIMESTAMP.into(), syscalls::get_block_timestamp::<S>);
-    hints.insert(syscalls::GET_CALLER_ADDRESS.into(), syscalls::get_caller_address::<S>);
-    hints.insert(syscalls::GET_CONTRACT_ADDRESS.into(), syscalls::get_contract_address::<S>);
-    hints.insert(syscalls::GET_SEQUENCER_ADDRESS.into(), syscalls::get_sequencer_address::<S>);
-    hints.insert(syscalls::GET_TX_INFO.into(), syscalls::get_tx_info::<S>);
-    hints.insert(syscalls::GET_TX_SIGNATURE.into(), syscalls::get_tx_signature::<S>);
-    hints.insert(syscalls::LIBRARY.into(), syscalls::library_call::<S>);
-    hints.insert(syscalls::LIBRARY_CALL_L1_HANDLER.into(), syscalls::library_call_l1_handler::<S>);
+    hints.insert(syscalls::GET_BLOCK_NUMBER.into(), syscalls::get_block_number::<PCS>);
+    hints.insert(syscalls::GET_BLOCK_TIMESTAMP.into(), syscalls::get_block_timestamp::<PCS>);
+    hints.insert(syscalls::GET_CALLER_ADDRESS.into(), syscalls::get_caller_address::<PCS>);
+    hints.insert(syscalls::GET_CONTRACT_ADDRESS.into(), syscalls::get_contract_address::<PCS>);
+    hints.insert(syscalls::GET_SEQUENCER_ADDRESS.into(), syscalls::get_sequencer_address::<PCS>);
+    hints.insert(syscalls::GET_TX_INFO.into(), syscalls::get_tx_info::<PCS>);
+    hints.insert(syscalls::GET_TX_SIGNATURE.into(), syscalls::get_tx_signature::<PCS>);
+    hints.insert(syscalls::LIBRARY.into(), syscalls::library_call::<PCS>);
+    hints.insert(syscalls::LIBRARY_CALL_L1_HANDLER.into(), syscalls::library_call_l1_handler::<PCS>);
     hints.insert(syscalls::OS_LOGGER_ENTER_SYSCALL_PREPRARE_EXIT_SYSCALL.into(), syscalls::os_logger_enter_syscall_preprare_exit_syscall);
-    hints.insert(syscalls::REPLACE_CLASS.into(), syscalls::replace_class::<S>);
-    hints.insert(syscalls::SEND_MESSAGE_TO_L1.into(), syscalls::send_message_to_l1::<S>);
-    hints.insert(syscalls::SET_SYSCALL_PTR.into(), syscalls::set_syscall_ptr::<S>);
-    hints.insert(syscalls::STORAGE_READ.into(), syscalls::storage_read::<S>);
-    hints.insert(syscalls::STORAGE_WRITE.into(), syscalls::storage_write::<S>);
+    hints.insert(syscalls::REPLACE_CLASS.into(), syscalls::replace_class::<PCS>);
+    hints.insert(syscalls::SEND_MESSAGE_TO_L1.into(), syscalls::send_message_to_l1::<PCS>);
+    hints.insert(syscalls::SET_SYSCALL_PTR.into(), syscalls::set_syscall_ptr::<PCS>);
+    hints.insert(syscalls::STORAGE_READ.into(), syscalls::storage_read::<PCS>);
+    hints.insert(syscalls::STORAGE_WRITE.into(), syscalls::storage_write::<PCS>);
     hints.insert(transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT.into(), transaction_hash::additional_data_new_segment);
     hints.insert(transaction_hash::DATA_TO_HASH_NEW_SEGMENT.into(), transaction_hash::data_to_hash_new_segment);
     hints.insert(block_context::WRITE_USE_ZKG_DA_TO_MEM.into(), block_context::write_use_zkg_da_to_mem);
@@ -254,21 +253,21 @@ static EXTENSIVE_HINTS: [(&str, ExtensiveHintImpl); 2] = [
     (deprecated_compiled_class::LOAD_DEPRECATED_CLASS, deprecated_compiled_class::load_deprecated_class),
 ];
 
-pub struct SnosHintProcessor<S>
+pub struct SnosHintProcessor<PCS>
 where
-    S: Storage,
+    PCS: PerContractStorage,
 {
     builtin_hint_proc: BuiltinHintProcessor,
     cairo1_builtin_hint_proc: Cairo1HintProcessor,
     hints: HashMap<String, HintImpl>,
     extensive_hints: HashMap<String, ExtensiveHintImpl>,
     run_resources: RunResources,
-    _phantom: PhantomData<S>,
+    _phantom: PhantomData<PCS>,
 }
 
-impl<S> ResourceTracker for SnosHintProcessor<S>
+impl<PCS> ResourceTracker for SnosHintProcessor<PCS>
 where
-    S: Storage,
+    PCS: PerContractStorage,
 {
     fn consumed(&self) -> bool {
         self.run_resources.consumed()
@@ -287,12 +286,12 @@ where
     }
 }
 
-impl<S> Default for SnosHintProcessor<S>
+impl<PCS> Default for SnosHintProcessor<PCS>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     fn default() -> Self {
-        let hints = hints::<S>();
+        let hints = hints::<PCS>();
         let extensive_hints = EXTENSIVE_HINTS.into_iter().map(|(h, i)| (h.to_string(), i)).collect();
         Self {
             builtin_hint_proc: BuiltinHintProcessor::new_empty(),
@@ -328,9 +327,9 @@ fn get_ptr_from_res_operand(vm: &mut VirtualMachine, res: &ResOperand) -> Result
     (vm.get_relocatable(cell_reloc)? + &base_offset).map_err(|e| e.into())
 }
 
-impl<S> SnosHintProcessor<S>
+impl<PCS> SnosHintProcessor<PCS>
 where
-    S: Storage,
+    PCS: PerContractStorage,
 {
     pub fn hints(&self) -> HashSet<String> {
         self.hints
@@ -343,9 +342,9 @@ where
     }
 }
 
-impl<S> HintProcessorLogic for SnosHintProcessor<S>
+impl<PCS> HintProcessorLogic for SnosHintProcessor<PCS>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     // stub for trait impl
     fn execute_hint(
@@ -387,7 +386,7 @@ where
             if let Hint::Starknet(StarknetHint::SystemCall { system }) = hint {
                 let syscall_ptr = get_ptr_from_res_operand(vm, system)?;
                 // TODO: need to be generic here
-                let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+                let syscall_handler = exec_scopes.get::<OsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
 
                 return execute_coroutine(syscall_handler.execute_syscall(vm, syscall_ptr))?
                     .map(|_| HintExtension::default());
@@ -549,7 +548,7 @@ pub fn breakpoint(
 pub const SET_AP_TO_ACTUAL_FEE: &str =
     "memory[ap] = to_felt_or_relocatable(execution_helper.tx_execution_info.actual_fee)";
 
-pub fn set_ap_to_actual_fee<S>(
+pub fn set_ap_to_actual_fee<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -557,9 +556,9 @@ pub fn set_ap_to_actual_fee<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     let actual_fee = execute_coroutine(async {
         let eh_ref = execution_helper.execution_helper.read().await;
         eh_ref
@@ -593,25 +592,25 @@ pub fn is_on_curve(
 
 const START_TX: &str = "execution_helper.start_tx(tx_info_ptr=ids.deprecated_tx_info.address_)";
 
-pub async fn start_tx_async<S>(
+pub async fn start_tx_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let deprecated_tx_info_ptr =
         get_relocatable_from_var_name(vars::ids::DEPRECATED_TX_INFO, vm, ids_data, ap_tracking)?;
 
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.start_tx(Some(deprecated_tx_info_ptr)).await;
 
     Ok(())
 }
 
-pub fn start_tx<S>(
+pub fn start_tx<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -619,24 +618,24 @@ pub fn start_tx<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(start_tx_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(start_tx_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 const SKIP_TX: &str = "execution_helper.skip_tx()";
 
-pub async fn skip_tx_async<S>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
+pub async fn skip_tx_async<PCS>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.skip_tx().await;
 
     Ok(())
 }
 
-pub fn skip_tx<S>(
+pub fn skip_tx<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -644,24 +643,24 @@ pub fn skip_tx<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(skip_tx_async::<S>(exec_scopes))?
+    execute_coroutine(skip_tx_async::<PCS>(exec_scopes))?
 }
 
 const SKIP_CALL: &str = "execution_helper.skip_call()";
 
-pub async fn skip_call_async<S>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
+pub async fn skip_call_async<PCS>(exec_scopes: &mut ExecutionScopes) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<S>>(vars::scopes::EXECUTION_HELPER)?;
+    let mut execution_helper = exec_scopes.get::<ExecutionHelperWrapper<PCS>>(vars::scopes::EXECUTION_HELPER)?;
     execution_helper.skip_call().await;
 
     Ok(())
 }
 
-pub fn skip_call<S>(
+pub fn skip_call<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -669,9 +668,9 @@ pub fn skip_call<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(skip_call_async::<S>(exec_scopes))?
+    execute_coroutine(skip_call_async::<PCS>(exec_scopes))?
 }
 
 const OS_INPUT_TRANSACTIONS: &str = "memory[fp + 8] = to_felt_or_relocatable(len(os_input.transactions))";

--- a/crates/starknet-os/src/hints/state.rs
+++ b/crates/starknet-os/src/hints/state.rs
@@ -20,9 +20,8 @@ use crate::execution::helper::ExecutionHelperWrapper;
 use crate::hints::types::{get_hash_builtin_fields, skip_verification_if_configured, PatriciaTreeMode, Preimage};
 use crate::hints::vars;
 use crate::io::input::StarknetOsInput;
-use crate::starknet::starknet_storage::{CommitmentInfo, StorageLeaf};
+use crate::starknet::starknet_storage::{CommitmentInfo, PerContractStorage, StorageLeaf};
 use crate::starkware_utils::commitment_tree::update_tree::{decode_node, DecodeNodeCase, DecodedNode, UpdateTree};
-use crate::storage::storage::Storage;
 use crate::utils::{execute_coroutine, get_constant};
 
 fn assert_tree_height_eq_merkle_height(tree_height: Felt252, merkle_height: Felt252) -> Result<(), HintError> {
@@ -310,7 +309,7 @@ pub const ENTER_SCOPE_COMMITMENT_INFO_BY_ADDRESS: &str = indoc! {r#"
 	))"#
 };
 
-pub fn enter_scope_commitment_info_by_address<S>(
+pub fn enter_scope_commitment_info_by_address<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -318,9 +317,9 @@ pub fn enter_scope_commitment_info_by_address<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let execution_helper: ExecutionHelperWrapper<S> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
+    let execution_helper: ExecutionHelperWrapper<PCS> = exec_scopes.get(vars::scopes::EXECUTION_HELPER)?;
     let os_input: StarknetOsInput = exec_scopes.get(vars::scopes::OS_INPUT)?;
 
     let commitment_info_by_address = execute_coroutine(execution_helper.compute_storage_commitments())??;

--- a/crates/starknet-os/src/hints/syscalls.rs
+++ b/crates/starknet-os/src/hints/syscalls.rs
@@ -12,21 +12,21 @@ use indoc::indoc;
 use crate::execution::deprecated_syscall_handler::DeprecatedOsSyscallHandlerWrapper;
 use crate::execution::syscall_handler::OsSyscallHandlerWrapper;
 use crate::hints::vars;
-use crate::storage::storage::Storage;
+use crate::starknet::starknet_storage::PerContractStorage;
 use crate::utils::execute_coroutine;
 
 pub const CALL_CONTRACT: &str = "syscall_handler.call_contract(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn call_contract_async<S>(
+pub async fn call_contract_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.call_contract(syscall_ptr, vm).await?;
@@ -34,7 +34,7 @@ where
     Ok(())
 }
 
-pub fn call_contract<S>(
+pub fn call_contract<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -42,23 +42,23 @@ pub fn call_contract<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(call_contract_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(call_contract_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const DELEGATE_CALL: &str = "syscall_handler.delegate_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn delegate_call_async<S>(
+pub async fn delegate_call_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.storage_write(syscall_ptr).await?;
@@ -66,7 +66,7 @@ where
     Ok(())
 }
 
-pub fn delegate_call<S>(
+pub fn delegate_call<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -74,15 +74,15 @@ pub fn delegate_call<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(delegate_call_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(delegate_call_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const DELEGATE_L1_HANDLER: &str =
     "syscall_handler.delegate_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn delegate_l1_handler<S>(
+pub fn delegate_l1_handler<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -90,9 +90,9 @@ pub fn delegate_l1_handler<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.delegate_l1_handler(syscall_ptr, vm))?
@@ -100,7 +100,7 @@ where
 
 pub const DEPLOY: &str = "syscall_handler.deploy(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn deploy<S>(
+pub fn deploy<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -108,9 +108,9 @@ pub fn deploy<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.deploy(syscall_ptr, vm))?
@@ -118,7 +118,7 @@ where
 
 pub const EMIT_EVENT: &str = "syscall_handler.emit_event(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn emit_event<S>(
+pub fn emit_event<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -126,9 +126,9 @@ pub fn emit_event<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     syscall_handler.emit_event();
 
     Ok(())
@@ -136,7 +136,7 @@ where
 
 pub const GET_BLOCK_NUMBER: &str = "syscall_handler.get_block_number(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_block_number<S>(
+pub fn get_block_number<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -144,9 +144,9 @@ pub fn get_block_number<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_block_number(syscall_ptr, vm))?
@@ -155,7 +155,7 @@ where
 pub const GET_BLOCK_TIMESTAMP: &str =
     "syscall_handler.get_block_timestamp(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_block_timestamp<S>(
+pub fn get_block_timestamp<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -163,9 +163,9 @@ pub fn get_block_timestamp<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_block_timestamp(syscall_ptr, vm))?
@@ -174,16 +174,16 @@ where
 pub const GET_CALLER_ADDRESS: &str =
     "syscall_handler.get_caller_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn get_caller_address_async<S>(
+pub async fn get_caller_address_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.get_caller_address(syscall_ptr, vm).await;
@@ -191,7 +191,7 @@ where
     Ok(())
 }
 
-pub fn get_caller_address<S>(
+pub fn get_caller_address<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -199,15 +199,15 @@ pub fn get_caller_address<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(get_caller_address_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(get_caller_address_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const GET_CONTRACT_ADDRESS: &str =
     "syscall_handler.get_contract_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_contract_address<S>(
+pub fn get_contract_address<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -215,9 +215,9 @@ pub fn get_contract_address<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_contract_address(syscall_ptr, vm))?
@@ -226,7 +226,7 @@ where
 pub const GET_SEQUENCER_ADDRESS: &str =
     "syscall_handler.get_sequencer_address(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_sequencer_address<S>(
+pub fn get_sequencer_address<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -234,9 +234,9 @@ pub fn get_sequencer_address<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_sequencer_address(syscall_ptr, vm))?
@@ -244,7 +244,7 @@ where
 
 pub const GET_TX_INFO: &str = "syscall_handler.get_tx_info(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_tx_info<S>(
+pub fn get_tx_info<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -252,9 +252,9 @@ pub fn get_tx_info<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_tx_info(syscall_ptr, vm))?
@@ -262,7 +262,7 @@ where
 
 pub const GET_TX_SIGNATURE: &str = "syscall_handler.get_tx_signature(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn get_tx_signature<S>(
+pub fn get_tx_signature<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -270,9 +270,9 @@ pub fn get_tx_signature<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.get_tx_signature(syscall_ptr, vm))?
@@ -280,7 +280,7 @@ where
 
 pub const LIBRARY: &str = "syscall_handler.library_call(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn library_call<S>(
+pub fn library_call<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -288,9 +288,9 @@ pub fn library_call<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.library_call(syscall_ptr, vm))?
@@ -299,7 +299,7 @@ where
 pub const LIBRARY_CALL_L1_HANDLER: &str =
     "syscall_handler.library_call_l1_handler(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn library_call_l1_handler<S>(
+pub fn library_call_l1_handler<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -307,9 +307,9 @@ pub fn library_call_l1_handler<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     execute_coroutine(syscall_handler.library_call_l1_handler(syscall_ptr, vm))?
@@ -317,7 +317,7 @@ where
 
 pub const REPLACE_CLASS: &str = "syscall_handler.replace_class(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn replace_class<S>(
+pub fn replace_class<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -325,9 +325,9 @@ pub fn replace_class<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
 
     syscall_handler.replace_class();
 
@@ -337,7 +337,7 @@ where
 pub const SEND_MESSAGE_TO_L1: &str =
     "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub fn send_message_to_l1<S>(
+pub fn send_message_to_l1<PCS>(
     _vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     _ids_data: &HashMap<String, HintReference>,
@@ -345,9 +345,9 @@ pub fn send_message_to_l1<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
 
     syscall_handler.send_message_to_l1();
 
@@ -356,16 +356,16 @@ where
 
 pub const STORAGE_READ: &str = "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn storage_read_async<S>(
+pub async fn storage_read_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.storage_read(syscall_ptr, vm).await?;
@@ -373,7 +373,7 @@ where
     Ok(())
 }
 
-pub fn storage_read<S>(
+pub fn storage_read<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -381,23 +381,23 @@ pub fn storage_read<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(storage_read_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(storage_read_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const STORAGE_WRITE: &str = "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)";
 
-pub async fn storage_write_async<S>(
+pub async fn storage_write_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
     ap_tracking: &ApTracking,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<S>>(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
     syscall_handler.storage_write(syscall_ptr).await?;
@@ -405,7 +405,7 @@ where
     Ok(())
 }
 
-pub fn storage_write<S>(
+pub fn storage_write<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -413,9 +413,9 @@ pub fn storage_write<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
-    execute_coroutine(storage_write_async::<S>(vm, exec_scopes, ids_data, ap_tracking))?
+    execute_coroutine(storage_write_async::<PCS>(vm, exec_scopes, ids_data, ap_tracking))?
 }
 
 pub const SET_SYSCALL_PTR: &str = indoc! {r#"
@@ -425,7 +425,7 @@ pub const SET_SYSCALL_PTR: &str = indoc! {r#"
 	syscall_handler.set_syscall_ptr(syscall_ptr=ids.syscall_ptr)"#
 };
 
-pub fn set_syscall_ptr<S>(
+pub fn set_syscall_ptr<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,
     ids_data: &HashMap<String, HintReference>,
@@ -433,7 +433,7 @@ pub fn set_syscall_ptr<S>(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError>
 where
-    S: Storage + 'static,
+    PCS: PerContractStorage + 'static,
 {
     let os_context = vm.add_memory_segment();
     let syscall_ptr = vm.add_memory_segment();
@@ -441,7 +441,7 @@ where
     insert_value_from_var_name(vars::ids::OS_CONTEXT, os_context, vm, ids_data, ap_tracking)?;
     insert_value_from_var_name(vars::ids::SYSCALL_PTR, syscall_ptr, vm, ids_data, ap_tracking)?;
 
-    let syscall_handler: OsSyscallHandlerWrapper<S> = exec_scopes.get(vars::scopes::SYSCALL_HANDLER)?;
+    let syscall_handler: OsSyscallHandlerWrapper<PCS> = exec_scopes.get(vars::scopes::SYSCALL_HANDLER)?;
     execute_coroutine(syscall_handler.set_syscall_ptr(syscall_ptr))?;
 
     Ok(())
@@ -835,20 +835,23 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use super::*;
+    use crate::crypto::pedersen::PedersenHash;
     use crate::execution::helper::ContractStorageMap;
     use crate::hints::tests::tests::{block_context, old_block_number_and_hash};
+    use crate::starknet::starknet_storage::OsSingleStarknetStorage;
     use crate::storage::dict_storage::DictStorage;
     use crate::ExecutionHelperWrapper;
+
+    #[allow(clippy::upper_case_acronyms)]
+    type PCS = OsSingleStarknetStorage<DictStorage, PedersenHash>;
+    #[allow(clippy::upper_case_acronyms)]
+    type EHW = ExecutionHelperWrapper<PCS>;
 
     #[fixture]
     fn exec_scopes(block_context: BlockContext, old_block_number_and_hash: (Felt252, Felt252)) -> ExecutionScopes {
         let execution_infos = vec![];
-        let exec_helper = ExecutionHelperWrapper::<DictStorage>::new(
-            ContractStorageMap::default(),
-            execution_infos,
-            &block_context,
-            old_block_number_and_hash,
-        );
+        let exec_helper =
+            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, old_block_number_and_hash);
         let syscall_handler = OsSyscallHandlerWrapper::new(exec_helper);
 
         let mut exec_scopes = ExecutionScopes::new();
@@ -873,7 +876,7 @@ mod tests {
         let ap_tracking = ApTracking::new();
         let constants = HashMap::new();
 
-        set_syscall_ptr::<DictStorage>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
+        set_syscall_ptr::<PCS>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &constants).unwrap();
 
         let os_context = get_ptr_from_var_name(vars::ids::OS_CONTEXT, &vm, &ids_data, &ap_tracking).unwrap();
         let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, &vm, &ids_data, &ap_tracking).unwrap();
@@ -881,7 +884,7 @@ mod tests {
         assert_eq!(os_context, Relocatable::from((2, 0)));
         assert_eq!(syscall_ptr, Relocatable::from((3, 0)));
 
-        let syscall_handler: OsSyscallHandlerWrapper<DictStorage> =
+        let syscall_handler: OsSyscallHandlerWrapper<OsSingleStarknetStorage<DictStorage, PedersenHash>> =
             exec_scopes.get(vars::scopes::SYSCALL_HANDLER).unwrap();
         assert_eq!(syscall_handler.syscall_ptr().await, Some(syscall_ptr));
     }

--- a/crates/starknet-os/src/storage/storage_utils.rs
+++ b/crates/starknet-os/src/storage/storage_utils.rs
@@ -83,7 +83,7 @@ pub async fn unpack_blockifier_state_async<S: Storage + Send + Sync, H: HashFunc
 /// is obtained by extracting the state diff from the `CachedState` part.
 pub async fn build_starknet_storage_async<S: Storage + Send + Sync, H: HashFunctionType + Send + Sync>(
     blockifier_state: CachedState<SharedState<S, H>>,
-) -> Result<(ContractStorageMap<S, H>, SharedState<S, H>, SharedState<S, H>), TreeError> {
+) -> Result<(ContractStorageMap<OsSingleStarknetStorage<S, H>>, SharedState<S, H>, SharedState<S, H>), TreeError> {
     let mut storage_by_address = ContractStorageMap::new();
 
     // TODO: would be cleaner if `get_leaf()` took &ffc instead of &mut ffc

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -18,7 +18,7 @@ use starknet_os::io::InternalTransaction;
 use starknet_os::starknet::business_logic::fact_state::contract_class_objects::ContractClassLeaf;
 use starknet_os::starknet::business_logic::fact_state::contract_state_objects::ContractState;
 use starknet_os::starknet::business_logic::fact_state::state::SharedState;
-use starknet_os::starknet::starknet_storage::CommitmentInfo;
+use starknet_os::starknet::starknet_storage::{CommitmentInfo, OsSingleStarknetStorage};
 use starknet_os::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use starknet_os::storage::storage::Storage;
 use starknet_os::storage::storage_utils::build_starknet_storage_async;
@@ -35,7 +35,7 @@ pub async fn os_hints<S>(
     tx_execution_infos: Vec<TransactionExecutionInfo>,
     deprecated_compiled_classes: HashMap<ClassHash, GenericDeprecatedCompiledClass>,
     compiled_classes: HashMap<ClassHash, GenericCasmContractClass>,
-) -> (StarknetOsInput, ExecutionHelperWrapper<S>)
+) -> (StarknetOsInput, ExecutionHelperWrapper<OsSingleStarknetStorage<S, PedersenHash>>)
 where
     S: Storage,
 {

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -35,6 +35,7 @@ use starknet_os::io::output::StarknetOsOutput;
 use starknet_os::io::InternalTransaction;
 use starknet_os::starknet::business_logic::fact_state::state::SharedState;
 use starknet_os::starknet::core::os::transaction_hash::{L1_GAS, L2_GAS};
+use starknet_os::starknet::starknet_storage::OsSingleStarknetStorage;
 use starknet_os::storage::storage::Storage;
 use starknet_os::utils::felt_api2vm;
 use starknet_os::{config, run_os};
@@ -776,7 +777,7 @@ async fn execute_txs<S>(
     txs: Vec<Transaction>,
     deprecated_contract_classes: HashMap<ClassHash, GenericDeprecatedCompiledClass>,
     contract_classes: HashMap<ClassHash, GenericCasmContractClass>,
-) -> (StarknetOsInput, ExecutionHelperWrapper<S>)
+) -> (StarknetOsInput, ExecutionHelperWrapper<OsSingleStarknetStorage<S, PedersenHash>>)
 where
     S: Storage,
 {


### PR DESCRIPTION
Problem: we are facing issues integrating the model of `OsSingleStarknetStorage` with Pathfinder, as we do not have a method to traverse the tree to reach arbitrary leaves.

Solution: Make the OS generic on the per-contract storage type instead of just the storage. This allows users to further customize the behaviour of the OS when it comes to storage.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes
- [ ] no
