### PR TITLE
Feature: SET_AP_TO_SEGMENT_HASH hint

### DIFF
--- a/crates/starknet-os/src/hints/compiled_class.rs
+++ b/crates/starknet-os/src/hints/compiled_class.rs
@@ -12,7 +12,7 @@ use starknet_os_types::hash::Hash;
 
 use crate::hints::vars;
 use crate::starknet::core::os::contract_class::compiled_class_hash_objects::{
-    BytecodeSegment, BytecodeSegmentStructureImpl, BytecodeSegmentedNode,
+    BytecodeSegment, BytecodeSegmentStructureImpl,
 };
 
 pub const ASSIGN_BYTECODE_SEGMENTS: &str = indoc! {r#"
@@ -141,16 +141,12 @@ pub fn set_ap_to_segment_hash(
 mod tests {
     use cairo_vm::any_box;
     use num_bigint::BigUint;
-    use pathfinder_crypto::hash::poseidon_hash_many;
-    use pathfinder_crypto::Felt;
 
     use super::*;
-    use crate::crypto::poseidon::poseidon_hash_many_bytes;
     use crate::starknet::core::os::contract_class::compiled_class_hash_objects::{
         BytecodeLeaf, BytecodeSegmentStructureImpl, BytecodeSegmentedNode,
     };
     use crate::starkware_utils::commitment_tree::base_types::Length;
-    use crate::starkware_utils::commitment_tree::binary_fact_tree::Leaf;
 
     #[test]
     fn test_bytecode_segment_hints() {

--- a/crates/starknet-os/src/hints/mod.rs
+++ b/crates/starknet-os/src/hints/mod.rs
@@ -234,6 +234,7 @@ fn hints<PCS>() -> HashMap<String, HintImpl> where
     hints.insert(transaction_hash::ADDITIONAL_DATA_NEW_SEGMENT.into(), transaction_hash::additional_data_new_segment);
     hints.insert(transaction_hash::DATA_TO_HASH_NEW_SEGMENT.into(), transaction_hash::data_to_hash_new_segment);
     hints.insert(block_context::WRITE_USE_ZKG_DA_TO_MEM.into(), block_context::write_use_zkg_da_to_mem);
+    hints.insert(compiled_class::SET_AP_TO_SEGMENT_HASH.into(), compiled_class::set_ap_to_segment_hash);
 
     hints
 }

--- a/crates/starknet-os/src/starknet/core/os/contract_class/compiled_class_hash_objects.rs
+++ b/crates/starknet-os/src/starknet/core/os/contract_class/compiled_class_hash_objects.rs
@@ -48,7 +48,7 @@ impl BytecodeSegmentStructureImpl {
                 match vec_field_elements {
                     Ok(elements) => poseidon_hash_many(&elements),
                     Err(_) => {
-                        return Err(SyscallExecutionError::InternalError("Invalid bytecode segment leaf".into()).into());
+                        return Err(SyscallExecutionError::InternalError("Invalid bytecode segment leaf".into()));
                     }
                 }
             }

--- a/crates/starknet-os/src/starknet/core/os/contract_class/compiled_class_hash_objects.rs
+++ b/crates/starknet-os/src/starknet/core/os/contract_class/compiled_class_hash_objects.rs
@@ -38,7 +38,7 @@ impl BytecodeSegmentStructureImpl {
         }
     }
 
-    fn hash(&self) -> Result<FieldElement, SyscallExecutionError> {
+    pub fn hash(&self) -> Result<FieldElement, SyscallExecutionError> {
         let ret = match self {
             BytecodeSegmentStructureImpl::SegmentedNode(node) => node.hash()?,
             BytecodeSegmentStructureImpl::Leaf(leaf) => {
@@ -101,7 +101,8 @@ impl BytecodeSegmentedNode {
             felts.push(segment.inner_structure.hash()?);
         }
 
-        Ok(poseidon_hash_many(&felts))
+        // hash([segment_lent, hash(inner_struct)]) + 1
+        Ok(poseidon_hash_many(&felts) + FieldElement::from(1u8))
     }
 }
 


### PR DESCRIPTION
This pull request implements SET_AP_TO_SEGMENT_HASH and hash functions for `BytecodeSegmentedNode` and `BytecodeSegmentStructureImpl`

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
