### PR TITLE
Fix: decompress starknet-core legacy class

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
 cairo-vm = { version = "=1.0.0-rc5", features = ["extensive_hints", "cairo-1-hints"] }
 clap = { version = "4.5.4", features = ["derive"] }
 env_logger = "0.11.3"
+flate2 = "1.0.32"
 futures = "0.3.30"
 futures-core = "0.3.30"
 futures-util = "0.3.30"

--- a/crates/rpc-replay/src/rpc_state_reader.rs
+++ b/crates/rpc-replay/src/rpc_state_reader.rs
@@ -90,7 +90,7 @@ where
                 compiled_class.to_blockifier_contract_class().map(Into::into).map_err(to_state_err)?
             }
             starknet::core::types::ContractClass::Legacy(legacy_class) => {
-                let contract_class = GenericDeprecatedCompiledClass::from(legacy_class);
+                let contract_class = GenericDeprecatedCompiledClass::try_from(legacy_class).map_err(to_state_err)?;
                 contract_class.to_blockifier_contract_class().map(Into::into).map_err(to_state_err)?
             }
         };
@@ -112,7 +112,7 @@ where
                 compiled_class.class_hash().map_err(to_state_err)?
             }
             starknet::core::types::ContractClass::Legacy(legacy_class) => {
-                let contract_class = GenericDeprecatedCompiledClass::from(legacy_class);
+                let contract_class = GenericDeprecatedCompiledClass::try_from(legacy_class).map_err(to_state_err)?;
                 contract_class.class_hash().map_err(to_state_err)?
             }
         };

--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -10,6 +10,7 @@ blockifier = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
 cairo-vm = { workspace = true }
 num-bigint = { workspace = true }
+flate2 = { workspace = true }
 pathfinder-gateway-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/starknet-os-types/src/deprecated_compiled_class.rs
+++ b/crates/starknet-os-types/src/deprecated_compiled_class.rs
@@ -136,6 +136,9 @@ impl From<StarknetApiDeprecatedClass> for GenericDeprecatedCompiledClass {
     }
 }
 
+/// Builds a generic deprecated compiled class from a starknet-core compressed class.
+/// Decompresses the compressed class then builds a generic class from it. Refer
+/// to the doc of `decompress_starknet_core_contract_class` for more details.
 impl TryFrom<CompressedStarknetCoreDeprecatedClass> for GenericDeprecatedCompiledClass {
     type Error = LegacyContractDecompressionError;
 

--- a/crates/starknet-os-types/src/lib.rs
+++ b/crates/starknet-os-types/src/lib.rs
@@ -5,3 +5,4 @@ pub mod deprecated_compiled_class;
 pub mod error;
 pub mod hash;
 pub mod sierra_contract_class;
+pub(crate) mod starknet_core_addons;

--- a/crates/starknet-os-types/src/starknet_core_addons.rs
+++ b/crates/starknet-os-types/src/starknet_core_addons.rs
@@ -91,6 +91,10 @@ pub enum LegacyContractDecompressionError {
     Decompression(#[from] std::io::Error),
 }
 
+/// Decompresses a compressed legacy contract class.
+/// Compressed classes store the `program` field as a gzipped vector. This function
+/// decompresses the field and performs additional type conversions for the `abi` and
+/// `entry_points_by_type` fields.
 pub(crate) fn decompress_starknet_core_contract_class(
     compressed_legacy_class: CompressedLegacyContractClass,
 ) -> Result<LegacyContractClass, LegacyContractDecompressionError> {

--- a/crates/starknet-os-types/src/starknet_core_addons.rs
+++ b/crates/starknet-os-types/src/starknet_core_addons.rs
@@ -98,9 +98,6 @@ pub enum LegacyContractDecompressionError {
 pub(crate) fn decompress_starknet_core_contract_class(
     compressed_legacy_class: CompressedLegacyContractClass,
 ) -> Result<LegacyContractClass, LegacyContractDecompressionError> {
-    // Compressed classes have the program as a gzipped vector.
-    // We need to convert it to a legacy contract class first, as starknet-core does
-    // not provide conversion methods.
     let mut program_str = String::new();
     let mut decoder = GzDecoder::new(compressed_legacy_class.program.as_slice());
     decoder.read_to_string(&mut program_str)?;

--- a/crates/starknet-os-types/src/starknet_core_addons.rs
+++ b/crates/starknet-os-types/src/starknet_core_addons.rs
@@ -1,0 +1,141 @@
+//! Utility functions missing from starknet-rs.
+use std::io::Read;
+
+use flate2::read::GzDecoder;
+use starknet_core::types::contract::legacy::{
+    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyEntryPoint, RawLegacyEntryPoints,
+    RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
+};
+use starknet_core::types::{
+    CompressedLegacyContractClass, LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType,
+    LegacyFunctionAbiEntry, LegacyFunctionAbiType, LegacyStructMember,
+};
+
+fn raw_abi_entry_from_legacy_function_abi_entry(entry: LegacyFunctionAbiEntry) -> RawLegacyAbiEntry {
+    match entry.r#type {
+        LegacyFunctionAbiType::Function | LegacyFunctionAbiType::Constructor => {
+            RawLegacyAbiEntry::Function(RawLegacyFunction {
+                inputs: entry.inputs,
+                name: entry.name,
+                outputs: entry.outputs,
+                state_mutability: entry.state_mutability,
+            })
+        }
+        LegacyFunctionAbiType::L1Handler => RawLegacyAbiEntry::L1Handler(RawLegacyL1Handler {
+            inputs: entry.inputs,
+            name: entry.name,
+            outputs: entry.outputs,
+        }),
+    }
+}
+
+fn raw_legacy_member_from_legacy_struct_member(member: LegacyStructMember) -> RawLegacyMember {
+    RawLegacyMember { name: member.name, offset: member.offset, r#type: member.r#type }
+}
+
+/// Implementation of From<LegacyContractAbiEntry> for RawLegacyAbiEntry,
+/// as it is missing from starknet-rs and we need it to interpret compressed legacy contracts.
+fn raw_legacy_abi_entry_from_legacy_contract_abi_entry(
+    legacy_contract_abi_entry: LegacyContractAbiEntry,
+) -> RawLegacyAbiEntry {
+    match legacy_contract_abi_entry {
+        LegacyContractAbiEntry::Function(entry) => raw_abi_entry_from_legacy_function_abi_entry(entry),
+        LegacyContractAbiEntry::Struct(entry) => RawLegacyAbiEntry::Struct(RawLegacyStruct {
+            members: entry.members.into_iter().map(raw_legacy_member_from_legacy_struct_member).collect(),
+            name: entry.name,
+            size: entry.size,
+        }),
+        LegacyContractAbiEntry::Event(entry) => {
+            RawLegacyAbiEntry::Event(RawLegacyEvent { data: entry.data, keys: entry.keys, name: entry.name })
+        }
+    }
+}
+
+fn raw_legacy_entrypoint_from_legacy_entrypoint(legacy_entry_point: LegacyContractEntryPoint) -> RawLegacyEntryPoint {
+    RawLegacyEntryPoint {
+        offset: LegacyEntrypointOffset::U64AsHex(legacy_entry_point.offset),
+        selector: legacy_entry_point.selector,
+    }
+}
+
+/// Implementation of From<LegacyEntryPointsByType> for RawLegacyEntryPoints,
+/// as it is missing from starknet-rs and we need it to interpret compressed legacy contracts.
+fn raw_legacy_entrypoints_from_legacy_entrypoints(
+    legacy_entry_points_by_type: LegacyEntryPointsByType,
+) -> RawLegacyEntryPoints {
+    RawLegacyEntryPoints {
+        constructor: legacy_entry_points_by_type
+            .constructor
+            .into_iter()
+            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
+            .collect(),
+        external: legacy_entry_points_by_type
+            .external
+            .into_iter()
+            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
+            .collect(),
+        l1_handler: legacy_entry_points_by_type
+            .l1_handler
+            .into_iter()
+            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
+            .collect(),
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LegacyContractDecompressionError {
+    #[error("Failed to deserialize the program as JSON: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    #[error("Failed to decompress the program: {0}")]
+    Decompression(#[from] std::io::Error),
+}
+
+pub(crate) fn decompress_starknet_core_contract_class(
+    compressed_legacy_class: CompressedLegacyContractClass,
+) -> Result<LegacyContractClass, LegacyContractDecompressionError> {
+    // Compressed classes have the program as a gzipped vector.
+    // We need to convert it to a legacy contract class first, as starknet-core does
+    // not provide conversion methods.
+    let mut program_str = String::new();
+    let mut decoder = GzDecoder::new(compressed_legacy_class.program.as_slice());
+    decoder.read_to_string(&mut program_str)?;
+
+    let program: starknet_core::types::contract::legacy::LegacyProgram = serde_json::from_str(&program_str)?;
+    let abi = compressed_legacy_class
+        .abi
+        .unwrap_or_default()
+        .into_iter()
+        .map(raw_legacy_abi_entry_from_legacy_contract_abi_entry)
+        .collect();
+
+    Ok(LegacyContractClass {
+        abi,
+        entry_points_by_type: raw_legacy_entrypoints_from_legacy_entrypoints(
+            compressed_legacy_class.entry_points_by_type,
+        ),
+        program,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet_core::types::contract::legacy::LegacyContractClass;
+
+    use crate::starknet_core_addons::decompress_starknet_core_contract_class;
+
+    const DEPRECATED_CLASS: &[u8] = include_bytes!(
+        "../../../tests/integration/contracts/blockifier_contracts/feature_contracts/cairo0/compiled/\
+         test_contract_compiled.json"
+    );
+
+    #[test]
+    /// Test that compressing then decompressing a legacy class works.
+    /// `LegacyContractClass` does not implement `PartialEq` so we'll content ourselves
+    /// by checking that the test does not fail.
+    fn test_decompress_legacy_class() {
+        let legacy_class: LegacyContractClass = serde_json::from_slice(DEPRECATED_CLASS).unwrap();
+        let compressed_legacy_class = legacy_class.compress().unwrap();
+        let _decompressed_legacy_class = decompress_starknet_core_contract_class(compressed_legacy_class).unwrap();
+    }
+}


### PR DESCRIPTION
Problem: the conversion from starknet-core `CompressedLegacyContractClass` in `GenericDeprecatedContractClass` is untested and broken. This class cannot be used interchangeably with other deprecated contract classes because the `program` field is deserialized as a gzip bytes vector.

Solution: add conversion functions to decompress the program field and generate a `LegacyContractClass` from it before storing it in the generic class.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
