### PR TITLE
Log proof validation failure instead of panicking

### DIFF
--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -273,14 +273,15 @@ pub(crate) async fn get_storage_proofs(
             merge_chunked_storage_proofs(chunked_storage_proofs)
         };
 
-        assert!(
-            storage_proof
-                .contract_data
-                .as_ref()
-                .expect("Storage proof should have contract_data")
-                .verify(&keys)
-                .is_ok()
-        );
+        if let Err(e) =
+            storage_proof.contract_data.as_ref().expect("Storage proof should have contract_data").verify(&keys)
+        {
+            log::warn!(
+                "Contract {:x} failed storage proof validaiton, may cause problems later in OS, err: {}",
+                contract_address_felt,
+                e
+            );
+        }
 
         storage_proofs.insert(contract_address_felt, storage_proof);
     }


### PR DESCRIPTION
Problem: we panic on some [apparently] non-fatal errors during contract proof validation, namely that the proof depth is not always 251.

Solution: `log::warn!()` instead of panic.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
