### PR TITLE
Use RPC data to fill out more StarknetGeneralConfig

### DIFF
--- a/crates/rpc-replay/Cargo.toml
+++ b/crates/rpc-replay/Cargo.toml
@@ -12,8 +12,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 starknet = { workspace = true }
 starknet_api = { workspace = true }
+starknet-os = { workspace = true }
 starknet-os-types = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+


### PR DESCRIPTION
Problem: `StarknetGeneralConfig` was leaving some data as default that may be needed

Solution: Use `BlockWithTxs` from Pathfinder RPC to fill in some info

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
