### PR TITLE
Feature: support Sierra 1.6

### DIFF
--- a/.github/workflows/prove_blocks.yml
+++ b/.github/workflows/prove_blocks.yml
@@ -52,4 +52,5 @@ jobs:
           # * 76793: the first block that we managed to prove, only has a few invoke txs
           # * 76766 / 76775: additional basic blocks
           # * 86507 / 124533: a failing assert that happened because we used the wrong VersionedConstants
-          bash scripts/prove-blocks.sh -p ${{ secrets.PATHFINDER_RPC_URL }} -b 76793,76766,76775,86507,124533
+          # * 87019: diff assert values in contract subcall
+          bash scripts/prove-blocks.sh -p ${{ secrets.PATHFINDER_RPC_URL }} -b 76793,76766,76775,86507,87019,124533

--- a/.github/workflows/prove_blocks.yml
+++ b/.github/workflows/prove_blocks.yml
@@ -47,4 +47,9 @@ jobs:
           bash scripts/setup-tests.sh
 
       - name: Prove Blocks
-        run: bash scripts/prove-blocks.sh -p ${{ secrets.PATHFINDER_RPC_URL }} -b 76793,76766,76775
+        run: |
+          # These blocks verify the following issues:
+          # * 76793: the first block that we managed to prove, only has a few invoke txs
+          # * 76766 / 76775: additional basic blocks
+          # * 86507 / 124533: a failing assert that happened because we used the wrong VersionedConstants
+          bash scripts/prove-blocks.sh -p ${{ secrets.PATHFINDER_RPC_URL }} -b 76793,76766,76775,86507,124533

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ assert_matches = "1.5.0"
 base64 = "0.21.3"
 bitvec = { version = "1.0.1", features = ["serde"] }
 # Point to the latest commit of branch msl/snos-0.6.0-rc.2
-blockifier = { git = "https://github.com/Moonsong-Labs/blockifier", rev = "983e3b1cdb6621c5e6fa600f47cd69bf9e287621", features = ["testing"] }
-cairo-lang-starknet = { version = "2.6.3" }
-cairo-lang-starknet-classes = { version = "2.6.3" }
-cairo-lang-utils = { version = "2.6.3" }
-cairo-lang-casm = { version = "2.6.3" }
+blockifier = { git = "https://github.com/Moonsong-Labs/sequencer", rev = "01b97d9354faefa5f0cd520b5efbe73178213f7e", features = ["testing"] }
+cairo-lang-starknet = { version = "=2.7.1" }
+cairo-lang-starknet-classes = { version = "=2.7.1" }
+cairo-lang-utils = { version = "=2.7.1" }
+cairo-lang-casm = { version = "=2.7.1" }
 cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
-cairo-vm = { version = "=1.0.0-rc5", features = ["extensive_hints", "cairo-1-hints"] }
+cairo-vm = { version = "=1.0.1", features = ["extensive_hints", "cairo-1-hints"] }
 clap = { version = "4.5.4", features = ["derive"] }
 env_logger = "0.11.3"
 flate2 = "1.0.32"
@@ -58,7 +58,7 @@ serde_json = { version = "1.0.105", features = ["arbitrary_precision"] }
 serde_with = "3.3.0"
 serde_yaml = "0.9.25"
 starknet = "0.11.0"
-starknet_api = { version = "=0.10", features = ["testing"] }
+starknet_api = { git = "https://github.com/Moonsong-Labs/sequencer", rev = "01b97d9354faefa5f0cd520b5efbe73178213f7e", features = ["testing"] }
 starknet-core = "0.11.1"
 starknet-crypto = "0.6.2"
 starknet-os = { path = "crates/starknet-os" }

--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -24,7 +24,6 @@ use starknet_os::starknet::business_logic::fact_state::contract_state_objects::C
 use starknet_os::starknet::starknet_storage::CommitmentInfo;
 use starknet_os::starkware_utils::commitment_tree::base_types::Height;
 use starknet_os::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
-use starknet_os::utils::felt_api2vm;
 use starknet_os::{config, run_os};
 use starknet_os_types::chain_id::chain_id_from_felt;
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
@@ -292,7 +291,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .visited_pcs
         .iter()
         .map(|(class_hash, visited_pcs)| {
-            (felt_api2vm(class_hash.0), visited_pcs.iter().copied().map(Felt252::from).collect::<Vec<_>>())
+            (class_hash.0, visited_pcs.iter().copied().map(Felt252::from).collect::<Vec<_>>())
         })
         .collect();
 

--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 
-use blockifier::state::cached_state::{CachedState, GlobalContractCache};
+use blockifier::state::cached_state::CachedState;
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError::VmException;
 use cairo_vm::Felt252;
@@ -26,11 +26,12 @@ use starknet_os::starkware_utils::commitment_tree::base_types::Height;
 use starknet_os::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use starknet_os::utils::felt_api2vm;
 use starknet_os::{config, run_os};
+use starknet_os_types::chain_id::chain_id_from_felt;
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 use starknet_types_core::felt::Felt;
 
 use crate::reexecute::format_commitment_facts;
-use crate::rpc_utils::PathfinderClassProof;
+use crate::rpc_utils::{get_starknet_version, PathfinderClassProof};
 use crate::state_utils::get_processed_state_update;
 use crate::types::starknet_rs_tx_to_internal_tx;
 
@@ -113,7 +114,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         reqwest::ClientBuilder::new().build().unwrap_or_else(|e| panic!("Could not build reqwest client: {e}"));
 
     // Step 1: build the block context
-    let chain_id = provider.chain_id().await?.to_string();
+    let chain_id = chain_id_from_felt(provider.chain_id().await?);
     log::debug!("provider's chain_id: {}", chain_id);
     let block_with_txs = match provider.get_block_with_txs(block_id).await? {
         MaybePendingBlockWithTxs::Block(block_with_txs) => block_with_txs,
@@ -121,6 +122,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             panic!("Block is still pending!");
         }
     };
+
+    let starknet_version = get_starknet_version(&block_with_txs);
+    log::debug!("Starknet version: {:?}", starknet_version);
 
     // We only need to get the older block number and hash. No need to fetch all the txs
     let older_block = match provider
@@ -134,7 +138,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let block_context = build_block_context(chain_id.clone(), &block_with_txs);
+    let block_context = build_block_context(chain_id.clone(), &block_with_txs, starknet_version);
 
     let old_block_number = Felt252::from(older_block.block_number);
     let old_block_hash = older_block.block_hash;
@@ -155,7 +159,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     ));
     let blockifier_state_reader = AsyncRpcStateReader::new(provider_for_blockifier, BlockId::Number(block_number - 1));
 
-    let mut blockifier_state = CachedState::new(blockifier_state_reader, GlobalContractCache::new(1024));
+    let mut blockifier_state = CachedState::new(blockifier_state_reader);
     let tx_execution_infos = reexecute_transactions_with_blockifier(
         &mut blockifier_state,
         &block_context,
@@ -189,9 +193,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let general_config = StarknetGeneralConfig {
         starknet_os_config: StarknetOsConfig {
-            // TODO: the string given by provider is in decimal, the OS expects hex
-            // chain_id: starknet_api::core::ChainId(chain_id.clone()),
-            chain_id: starknet_api::core::ChainId("SN_SEPOLIA".to_string()),
+            chain_id,
             fee_token_address: block_context.chain_info().fee_token_addresses.strk_fee_token_address,
             deprecated_fee_token_address: block_context.chain_info().fee_token_addresses.eth_fee_token_address,
         },

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -305,6 +305,7 @@ pub(crate) fn get_starknet_version(block_with_txs: &BlockWithTxs) -> blockifier:
         "0.13.0" => blockifier::versioned_constants::StarknetVersion::V0_13_0,
         "0.13.1" => blockifier::versioned_constants::StarknetVersion::V0_13_1,
         "0.13.1.1" => blockifier::versioned_constants::StarknetVersion::V0_13_1_1,
+        "0.13.2" => blockifier::versioned_constants::StarknetVersion::Latest,
         other => {
             unimplemented!("Unsupported Starknet version: {}", other)
         }

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -14,7 +14,7 @@ use starknet_os::starkware_utils::commitment_tree::base_types::{Length, NodePath
 use starknet_os::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
 use starknet_os::storage::dict_storage::DictStorage;
 use starknet_os::storage::storage::{Fact, HashFunctionType};
-use starknet_os::utils::{felt_api2vm, felt_vm2api};
+use starknet_os::utils::felt_api2vm;
 use starknet_types_core::felt::Felt;
 
 use crate::utils::get_all_accessed_keys;
@@ -137,7 +137,7 @@ pub(crate) async fn get_storage_proofs(
 ) -> Result<HashMap<Felt, PathfinderProof>, reqwest::Error> {
     let accessed_keys_by_address = {
         let mut keys = get_all_accessed_keys(tx_execution_infos);
-        keys.entry(contract_address!("0x1")).or_default().insert(felt_vm2api(old_block_number).try_into().unwrap());
+        keys.entry(contract_address!("0x1")).or_default().insert(old_block_number.try_into().unwrap());
         keys
     };
 

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -14,7 +14,6 @@ use starknet_os::starkware_utils::commitment_tree::base_types::{Length, NodePath
 use starknet_os::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
 use starknet_os::storage::dict_storage::DictStorage;
 use starknet_os::storage::storage::{Fact, HashFunctionType};
-use starknet_os::utils::felt_api2vm;
 use starknet_types_core::felt::Felt;
 
 use crate::utils::get_all_accessed_keys;
@@ -149,9 +148,9 @@ pub(crate) async fn get_storage_proofs(
     }
 
     for (contract_address, storage_keys) in accessed_keys_by_address {
-        let contract_address_felt = felt_api2vm(*contract_address.key());
+        let contract_address_felt = *contract_address.key();
 
-        let keys: Vec<_> = storage_keys.iter().map(|storage_key| felt_api2vm(*storage_key.key())).collect();
+        let keys: Vec<_> = storage_keys.iter().map(|storage_key| *storage_key.key()).collect();
 
         let storage_proof = if keys.is_empty() {
             pathfinder_get_proof(client, rpc_provider, block_number, contract_address_felt, &[]).await?

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -5,9 +5,9 @@ use cairo_vm::Felt252;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::json;
+use starknet::core::types::BlockWithTxs;
 use starknet_api::core::{ContractAddress, PatriciaKey};
-use starknet_api::hash::StarkHash;
-use starknet_api::{contract_address, patricia_key};
+use starknet_api::{contract_address, felt, patricia_key};
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::crypto::poseidon::PoseidonHash;
 use starknet_os::starkware_utils::commitment_tree::base_types::{Length, NodePath};
@@ -298,4 +298,16 @@ pub(crate) fn verify_proof<H: HashFunctionType>(key: Felt, commitment: Felt, pro
     }
 
     Ok(())
+}
+
+pub(crate) fn get_starknet_version(block_with_txs: &BlockWithTxs) -> blockifier::versioned_constants::StarknetVersion {
+    let starknet_version_str = &block_with_txs.starknet_version;
+    match starknet_version_str.as_ref() {
+        "0.13.0" => blockifier::versioned_constants::StarknetVersion::V0_13_0,
+        "0.13.1" => blockifier::versioned_constants::StarknetVersion::V0_13_1,
+        "0.13.1.1" => blockifier::versioned_constants::StarknetVersion::V0_13_1_1,
+        other => {
+            unimplemented!("Unsupported Starknet version: {}", other)
+        }
+    }
 }

--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -6,7 +6,6 @@ use cairo_vm::Felt252;
 use starknet::core::types::{ExecuteInvocation, FunctionInvocation, TransactionTrace, TransactionTraceWithHash};
 use starknet_api::core::ContractAddress;
 use starknet_api::state::StorageKey;
-use starknet_os::utils::felt_api2vm;
 
 /// Receives the transaction traces of a given block
 /// And extract the contracts addresses that where subcalled
@@ -96,8 +95,7 @@ fn get_accessed_storage_keys(call_info: &CallInfo) -> HashMap<ContractAddress, H
         .or_default()
         .extend(call_info.accessed_storage_keys.iter().copied());
 
-    let storage_keys: Vec<_> =
-        call_info.accessed_storage_keys.iter().map(|x| felt_api2vm(*x.key()).to_hex_string()).collect();
+    let storage_keys: Vec<_> = call_info.accessed_storage_keys.iter().map(|x| x.key().to_hex_string()).collect();
     log::debug!("{}: {:?}", contract_address.to_string(), storage_keys);
 
     for inner_call in &call_info.inner_calls {

--- a/crates/rpc-replay/src/rpc_state_reader.rs
+++ b/crates/rpc-replay/src/rpc_state_reader.rs
@@ -10,7 +10,7 @@ use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass
 use starknet_os_types::hash::GenericClassHash;
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 
-use crate::utils::{execute_coroutine, felt_api2vm};
+use crate::utils::execute_coroutine;
 
 pub struct AsyncRpcStateReader<T>
 where
@@ -44,7 +44,7 @@ where
     pub async fn get_storage_at_async(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt> {
         let storage_value = self
             .provider
-            .get_storage_at(felt_api2vm(*contract_address.key()), felt_api2vm(*key.0.key()), self.block_id)
+            .get_storage_at(*contract_address.key(), *key.0.key(), self.block_id)
             .await
             .map_err(provider_error_to_state_error)?;
 
@@ -54,7 +54,7 @@ where
     pub async fn get_nonce_at_async(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         let nonce = self
             .provider
-            .get_nonce(self.block_id, felt_api2vm(*contract_address.key()))
+            .get_nonce(self.block_id, *contract_address.key())
             .await
             .map_err(provider_error_to_state_error)?;
 
@@ -64,7 +64,7 @@ where
     pub async fn get_class_hash_at_async(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         let nonce = self
             .provider
-            .get_class_hash_at(self.block_id, felt_api2vm(*contract_address.key()))
+            .get_class_hash_at(self.block_id, *contract_address.key())
             .await
             .map_err(provider_error_to_state_error)?;
 
@@ -72,11 +72,8 @@ where
     }
 
     pub async fn get_compiled_contract_class_async(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
-        let contract_class = self
-            .provider
-            .get_class(self.block_id, felt_api2vm(class_hash.0))
-            .await
-            .map_err(provider_error_to_state_error)?;
+        let contract_class =
+            self.provider.get_class(self.block_id, class_hash.0).await.map_err(provider_error_to_state_error)?;
 
         let contract_class: ContractClass = match contract_class {
             starknet::core::types::ContractClass::Sierra(sierra_class) => {
@@ -94,11 +91,8 @@ where
     }
 
     pub async fn get_compiled_class_hash_async(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
-        let contract_class = self
-            .provider
-            .get_class(self.block_id, felt_api2vm(class_hash.0))
-            .await
-            .map_err(provider_error_to_state_error)?;
+        let contract_class =
+            self.provider.get_class(self.block_id, class_hash.0).await.map_err(provider_error_to_state_error)?;
 
         let class_hash: GenericClassHash = match contract_class {
             starknet::core::types::ContractClass::Sierra(sierra_class) => {

--- a/crates/rpc-replay/src/rpc_state_reader.rs
+++ b/crates/rpc-replay/src/rpc_state_reader.rs
@@ -10,7 +10,7 @@ use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass
 use starknet_os_types::hash::GenericClassHash;
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 
-use crate::utils::{execute_coroutine, felt_api2vm, felt_vm2api};
+use crate::utils::{execute_coroutine, felt_api2vm};
 
 pub struct AsyncRpcStateReader<T>
 where
@@ -48,7 +48,7 @@ where
             .await
             .map_err(provider_error_to_state_error)?;
 
-        Ok(felt_vm2api(storage_value))
+        Ok(storage_value)
     }
 
     pub async fn get_nonce_at_async(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
@@ -58,7 +58,7 @@ where
             .await
             .map_err(provider_error_to_state_error)?;
 
-        Ok(Nonce(felt_vm2api(nonce)))
+        Ok(Nonce(nonce))
     }
 
     pub async fn get_class_hash_at_async(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
@@ -68,7 +68,7 @@ where
             .await
             .map_err(provider_error_to_state_error)?;
 
-        Ok(ClassHash(felt_vm2api(nonce)))
+        Ok(ClassHash(nonce))
     }
 
     pub async fn get_compiled_contract_class_async(&self, class_hash: ClassHash) -> StateResult<ContractClass> {

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -73,21 +73,15 @@ pub fn starknet_rs_to_blockifier(
                         starknet_api::transaction::InvokeTransactionV3 {
                             resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
                             tip: starknet_api::transaction::Tip(tx.tip),
-                            signature: starknet_api::transaction::TransactionSignature(
-                                tx.signature.to_vec(),
-                            ),
+                            signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
                             nonce: starknet_api::core::Nonce(tx.nonce),
                             sender_address: starknet_api::core::ContractAddress(
                                 PatriciaKey::try_from(tx.sender_address).unwrap(),
                             ),
-                            calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.calldata.to_vec(),
-                            )),
+                            calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
                             nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
                             fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
-                            paymaster_data: starknet_api::transaction::PaymasterData(
-                                tx.paymaster_data.to_vec(),
-                            ),
+                            paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.to_vec()),
                             account_deployment_data: starknet_api::transaction::AccountDeploymentData(
                                 tx.account_deployment_data.to_vec(),
                             ),

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -7,8 +7,6 @@ use starknet::core::types::{InvokeTransaction, ResourceBoundsMapping, Transactio
 use starknet_api::core::PatriciaKey;
 use starknet_api::transaction::TransactionHash;
 
-use crate::utils::felt_vm2api;
-
 pub fn resource_bounds_core_to_api(
     resource_bounds: &ResourceBoundsMapping,
 ) -> starknet_api::transaction::ResourceBoundsMapping {
@@ -47,51 +45,51 @@ pub fn starknet_rs_to_blockifier(
         Transaction::Invoke(tx) => {
             let (tx_hash, api_tx) = match tx {
                 InvokeTransaction::V0(tx) => {
-                    let _tx_hash = TransactionHash(felt_vm2api(tx.transaction_hash));
+                    let _tx_hash = TransactionHash(tx.transaction_hash);
                     unimplemented!("starknet_rs_to_blockifier with InvokeTransaction::V0");
                 }
                 InvokeTransaction::V1(tx) => {
-                    let tx_hash = TransactionHash(felt_vm2api(tx.transaction_hash));
+                    let tx_hash = TransactionHash(tx.transaction_hash);
                     let api_tx = starknet_api::transaction::InvokeTransaction::V1(
                         starknet_api::transaction::InvokeTransactionV1 {
                             max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
                             signature: starknet_api::transaction::TransactionSignature(
-                                tx.signature.clone().into_iter().map(felt_vm2api).collect(),
+                                tx.signature.clone().into_iter().collect(),
                             ),
-                            nonce: starknet_api::core::Nonce(felt_vm2api(tx.nonce)),
+                            nonce: starknet_api::core::Nonce(tx.nonce),
                             sender_address: starknet_api::core::ContractAddress(
-                                PatriciaKey::try_from(felt_vm2api(tx.sender_address)).unwrap(),
+                                PatriciaKey::try_from(tx.sender_address).unwrap(),
                             ),
                             calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.calldata.clone().into_iter().map(felt_vm2api).collect(),
+                                tx.calldata.clone().into_iter().collect(),
                             )),
                         },
                     );
                     (tx_hash, api_tx)
                 }
                 InvokeTransaction::V3(tx) => {
-                    let tx_hash = TransactionHash(felt_vm2api(tx.transaction_hash));
+                    let tx_hash = TransactionHash(tx.transaction_hash);
                     let api_tx = starknet_api::transaction::InvokeTransaction::V3(
                         starknet_api::transaction::InvokeTransactionV3 {
                             resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
                             tip: starknet_api::transaction::Tip(tx.tip),
                             signature: starknet_api::transaction::TransactionSignature(
-                                tx.signature.iter().copied().map(felt_vm2api).collect(),
+                                tx.signature.iter().copied().collect(),
                             ),
-                            nonce: starknet_api::core::Nonce(felt_vm2api(tx.nonce)),
+                            nonce: starknet_api::core::Nonce(tx.nonce),
                             sender_address: starknet_api::core::ContractAddress(
-                                PatriciaKey::try_from(felt_vm2api(tx.sender_address)).unwrap(),
+                                PatriciaKey::try_from(tx.sender_address).unwrap(),
                             ),
                             calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.calldata.iter().copied().map(felt_vm2api).collect(),
+                                tx.calldata.iter().copied().collect(),
                             )),
                             nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
                             fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
                             paymaster_data: starknet_api::transaction::PaymasterData(
-                                tx.paymaster_data.iter().copied().map(felt_vm2api).collect(),
+                                tx.paymaster_data.iter().copied().collect(),
                             ),
                             account_deployment_data: starknet_api::transaction::AccountDeploymentData(
-                                tx.account_deployment_data.iter().copied().map(felt_vm2api).collect(),
+                                tx.account_deployment_data.iter().copied().collect(),
                             ),
                         },
                     );

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -74,22 +74,22 @@ pub fn starknet_rs_to_blockifier(
                             resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
                             tip: starknet_api::transaction::Tip(tx.tip),
                             signature: starknet_api::transaction::TransactionSignature(
-                                tx.signature.iter().copied().collect(),
+                                tx.signature.to_vec(),
                             ),
                             nonce: starknet_api::core::Nonce(tx.nonce),
                             sender_address: starknet_api::core::ContractAddress(
                                 PatriciaKey::try_from(tx.sender_address).unwrap(),
                             ),
                             calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.calldata.iter().copied().collect(),
+                                tx.calldata.to_vec(),
                             )),
                             nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
                             fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
                             paymaster_data: starknet_api::transaction::PaymasterData(
-                                tx.paymaster_data.iter().copied().collect(),
+                                tx.paymaster_data.to_vec(),
                             ),
                             account_deployment_data: starknet_api::transaction::AccountDeploymentData(
-                                tx.account_deployment_data.iter().copied().collect(),
+                                tx.account_deployment_data.to_vec(),
                             ),
                         },
                     );

--- a/crates/rpc-replay/src/utils.rs
+++ b/crates/rpc-replay/src/utils.rs
@@ -10,10 +10,6 @@ where
     Ok(tokio::task::block_in_place(|| tokio_runtime_handle.block_on(coroutine)))
 }
 
-pub fn felt_api2vm(felt: Felt) -> Felt {
-    felt
-}
-
 pub fn felt_to_u128(felt: &Felt) -> u128 {
     let digits = felt.to_be_digits();
     ((digits[2] as u128) << 64) + digits[3] as u128

--- a/crates/rpc-replay/src/utils.rs
+++ b/crates/rpc-replay/src/utils.rs
@@ -1,5 +1,4 @@
 use starknet::core::types::Felt;
-use starknet_api::hash::StarkFelt;
 
 /// Executes a coroutine from a synchronous context.
 /// Fails if no Tokio runtime is present.
@@ -11,12 +10,12 @@ where
     Ok(tokio::task::block_in_place(|| tokio_runtime_handle.block_on(coroutine)))
 }
 
-pub fn felt_api2vm(felt: StarkFelt) -> Felt {
-    Felt::from_bytes_be_slice(felt.bytes())
+pub fn felt_api2vm(felt: Felt) -> Felt {
+    felt
 }
 
-pub fn felt_vm2api(felt: Felt) -> StarkFelt {
-    StarkFelt::new_unchecked(felt.to_bytes_be())
+pub fn felt_vm2api(felt: Felt) -> Felt {
+    felt
 }
 
 pub fn felt_to_u128(felt: &Felt) -> u128 {

--- a/crates/rpc-replay/src/utils.rs
+++ b/crates/rpc-replay/src/utils.rs
@@ -14,10 +14,6 @@ pub fn felt_api2vm(felt: Felt) -> Felt {
     felt
 }
 
-pub fn felt_vm2api(felt: Felt) -> Felt {
-    felt
-}
-
 pub fn felt_to_u128(felt: &Felt) -> u128 {
     let digits = felt.to_be_digits();
     ((digits[2] as u128) << 64) + digits[3] as u128

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -1,5 +1,6 @@
 use blockifier::state::cached_state::CachedState;
 use blockifier::transaction::transactions::ExecutableTransaction as _;
+use blockifier::versioned_constants::StarknetVersion;
 use rpc_replay::block_context::build_block_context;
 use rpc_replay::rpc_state_reader::AsyncRpcStateReader;
 use rpc_replay::transactions::starknet_rs_to_blockifier;
@@ -7,6 +8,7 @@ use rstest::rstest;
 use starknet::core::types::{BlockId, BlockWithTxs};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Url};
+use starknet_api::core::ChainId;
 
 #[rstest]
 #[ignore = "Requires a local Pathfinder node"]
@@ -27,7 +29,7 @@ async fn test_replay_block() {
     let state_reader = AsyncRpcStateReader::new(provider, BlockId::Number(block_with_txs.block_number - 1));
     let mut state = CachedState::from(state_reader);
 
-    let block_context = build_block_context("SN_SEPOLIA".to_string(), &block_with_txs);
+    let block_context = build_block_context(ChainId::Sepolia, &block_with_txs, StarknetVersion::V0_13_1);
 
     for tx in block_with_txs.transactions.iter() {
         let blockifier_tx = starknet_rs_to_blockifier(tx).unwrap();

--- a/crates/starknet-os-types/src/casm_contract_class.rs
+++ b/crates/starknet-os-types/src/casm_contract_class.rs
@@ -95,7 +95,7 @@ impl GenericCasmContractClass {
         let compiled_class = self.get_cairo_lang_contract_class()?;
         let class_hash_felt = compiled_class.compiled_class_hash();
 
-        Ok(GenericClassHash::from_bytes_be(class_hash_felt.to_be_bytes()))
+        Ok(GenericClassHash::from_bytes_be(class_hash_felt.to_bytes_be()))
     }
 
     pub fn class_hash(&self) -> Result<GenericClassHash, ContractClassError> {

--- a/crates/starknet-os-types/src/chain_id.rs
+++ b/crates/starknet-os-types/src/chain_id.rs
@@ -5,3 +5,21 @@ use starknet_types_core::felt::Felt;
 pub fn chain_id_to_felt(chain_id: &ChainId) -> Felt {
     Felt::from_bytes_be_slice(chain_id.to_string().as_bytes())
 }
+
+pub fn chain_id_from_felt(felt: Felt) -> ChainId {
+    let chain_id_bytes: Vec<_> = felt.to_bytes_be().into_iter().skip_while(|byte| *byte == 0u8).collect();
+    let chain_id_str = String::from_utf8_lossy(&chain_id_bytes);
+    ChainId::from(chain_id_str.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chain_id_from_felt() {
+        let chain_id_felt = Felt::from_dec_str("393402133025997798000961").unwrap();
+        let chain_id = chain_id_from_felt(chain_id_felt);
+        assert_eq!(chain_id, ChainId::Sepolia);
+    }
+}

--- a/crates/starknet-os-types/src/chain_id.rs
+++ b/crates/starknet-os-types/src/chain_id.rs
@@ -6,7 +6,10 @@ pub fn chain_id_to_felt(chain_id: &ChainId) -> Felt {
     Felt::from_bytes_be_slice(chain_id.to_string().as_bytes())
 }
 
+/// Builds a ChainId from a felt.
+/// This function reads the felt as ASCII bytes. Leading zeroes are skipped.
 pub fn chain_id_from_felt(felt: Felt) -> ChainId {
+    // Skip leading zeroes
     let chain_id_bytes: Vec<_> = felt.to_bytes_be().into_iter().skip_while(|byte| *byte == 0u8).collect();
     let chain_id_str = String::from_utf8_lossy(&chain_id_bytes);
     ChainId::from(chain_id_str.into_owned())

--- a/crates/starknet-os-types/src/hash.rs
+++ b/crates/starknet-os-types/src/hash.rs
@@ -3,8 +3,6 @@ use std::ops::Deref;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::{ClassHash, CompiledClassHash};
-use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::StarknetApiError;
 use starknet_types_core::felt::Felt;
 
 const EMPTY_HASH: [u8; 32] = [0; 32];
@@ -80,27 +78,15 @@ impl From<Felt> for Hash {
     }
 }
 
-impl TryFrom<Hash> for StarkFelt {
-    type Error = StarknetApiError;
-
-    fn try_from(hash: Hash) -> Result<Self, Self::Error> {
-        Self::new(hash.0)
+impl From<Hash> for CompiledClassHash {
+    fn from(hash: Hash) -> Self {
+        Self(hash.into())
     }
 }
 
-impl TryFrom<Hash> for CompiledClassHash {
-    type Error = StarknetApiError;
-
-    fn try_from(hash: Hash) -> Result<Self, Self::Error> {
-        Ok(Self(hash.try_into()?))
-    }
-}
-
-impl TryFrom<Hash> for ClassHash {
-    type Error = StarknetApiError;
-
-    fn try_from(hash: Hash) -> Result<Self, Self::Error> {
-        Ok(Self(hash.try_into()?))
+impl From<Hash> for ClassHash {
+    fn from(hash: Hash) -> Self {
+        Self(hash.into())
     }
 }
 
@@ -119,22 +105,20 @@ impl GenericClassHash {
 
 impl From<ClassHash> for GenericClassHash {
     fn from(class_hash: ClassHash) -> Self {
-        let hash = Hash::from_bytes_be_slice(class_hash.0.bytes());
+        let hash = Hash(class_hash.0.to_bytes_be());
         Self(hash)
     }
 }
 
 impl From<GenericClassHash> for ClassHash {
     fn from(class_hash: GenericClassHash) -> Self {
-        let stark_hash = StarkHash::new_unchecked(class_hash.0.0);
-        ClassHash(stark_hash)
+        class_hash.0.into()
     }
 }
 
 impl From<GenericClassHash> for CompiledClassHash {
     fn from(class_hash: GenericClassHash) -> Self {
-        let stark_hash = StarkHash::new_unchecked(class_hash.0.0);
-        CompiledClassHash(stark_hash)
+        class_hash.0.into()
     }
 }
 

--- a/crates/starknet-os/src/execution/helper.rs
+++ b/crates/starknet-os/src/execution/helper.rs
@@ -150,7 +150,7 @@ where
             .iter()
             .filter_map(|call| {
                 if matches!(call.call.entry_point_type, EntryPointType::Constructor) {
-                    Some(Felt252::from_bytes_be_slice(call.call.storage_address.0.key().bytes()))
+                    Some(Felt252::from(call.call.storage_address))
                 } else {
                     None
                 }
@@ -171,13 +171,7 @@ where
             .into_iter();
 
         // unpack storage reads
-        eh_ref.execute_code_read_iter = call_info
-            .storage_read_values
-            .iter()
-            .map(|felt| Felt252::from_bytes_be_slice(felt.bytes()))
-            .collect::<Vec<Felt252>>()
-            .into_iter();
-
+        eh_ref.execute_code_read_iter = call_info.storage_read_values.clone().into_iter();
         eh_ref.call_info = Some(call_info);
     }
     pub async fn exit_call(&mut self) {
@@ -224,6 +218,7 @@ where
 
         let mut commitments = HashMap::new();
         for (key, storage) in storage_by_address.iter_mut() {
+            log::debug!("Computing commitment for contract address {}", key.to_hex_string());
             let commitment_info = storage.compute_commitment().await?;
             commitments.insert(*key, commitment_info);
         }

--- a/crates/starknet-os/src/execution/syscall_handler.rs
+++ b/crates/starknet-os/src/execution/syscall_handler.rs
@@ -22,7 +22,6 @@ use crate::execution::syscall_handler_utils::{
     ReadOnlySegment, SyscallExecutionError, SyscallHandler, SyscallResult, SyscallSelector, WriteResponseResult,
 };
 use crate::starknet::starknet_storage::PerContractStorage;
-use crate::utils::felt_api2vm;
 
 /// DeprecatedSyscallHandler implementation for execution of system calls in the StarkNet OS
 #[derive(Debug)]
@@ -162,14 +161,14 @@ impl SyscallHandler for CallContractHandler {
 
         *remaining_gas -= result.gas_consumed;
 
-        let retdata = result.retdata.0.iter().map(|sf| felt_api2vm(*sf)).collect();
+        let retdata = result.retdata.0;
 
         if result.failed {
             return Err(SyscallExecutionError::SyscallError { error_data: retdata });
         }
 
         let start_ptr = vm.add_temporary_segment();
-        vm.load_data(start_ptr, &retdata.iter().map(MaybeRelocatable::from).collect())?;
+        vm.load_data(start_ptr, &retdata.iter().map(MaybeRelocatable::from).collect::<Vec<_>>())?;
         Ok(ReadOnlySegment { start_ptr, length: retdata.len() })
     }
 
@@ -216,14 +215,14 @@ impl SyscallHandler for DeployHandler {
 
         *remaining_gas -= result.gas_consumed;
 
-        let retdata = result.retdata.0.iter().map(|sf| felt_api2vm(*sf)).collect();
+        let retdata = result.retdata.0;
 
         if result.failed {
             return Err(SyscallExecutionError::SyscallError { error_data: retdata });
         }
 
         let start_ptr = vm.add_temporary_segment();
-        vm.load_data(start_ptr, &retdata.iter().map(MaybeRelocatable::from).collect())?;
+        vm.load_data(start_ptr, &retdata.iter().map(MaybeRelocatable::from).collect::<Vec<_>>())?;
 
         let constructor_retdata = ReadOnlySegment { start_ptr, length: retdata.len() };
 
@@ -377,14 +376,14 @@ impl SyscallHandler for LibraryCallHandler {
 
         *remaining_gas -= result.gas_consumed;
 
-        let retdata = result.retdata.0.iter().map(|sf| felt_api2vm(*sf)).collect();
+        let retdata = result.retdata.0;
 
         if result.failed {
             return Err(SyscallExecutionError::SyscallError { error_data: retdata });
         }
 
         let start_ptr = vm.add_temporary_segment();
-        vm.load_data(start_ptr, &retdata.iter().map(MaybeRelocatable::from).collect())?;
+        vm.load_data(start_ptr, &retdata.iter().map(MaybeRelocatable::from).collect::<Vec<_>>())?;
         Ok(ReadOnlySegment { start_ptr, length: retdata.len() })
     }
 

--- a/crates/starknet-os/src/execution/syscall_handler_utils.rs
+++ b/crates/starknet-os/src/execution/syscall_handler_utils.rs
@@ -261,7 +261,8 @@ fn write_failure(
 
     // Write the error data to a new memory segment.
     let revert_reason_start = vm.add_memory_segment();
-    let revert_reason_end = vm.load_data(revert_reason_start, &error_data.into_iter().map(Into::into).collect())?;
+    let revert_reason_end =
+        vm.load_data(revert_reason_start, &error_data.into_iter().map(Into::into).collect::<Vec<_>>())?;
 
     // Write the start and end pointers of the error data.
     write_maybe_relocatable(vm, ptr, revert_reason_start)?;

--- a/crates/starknet-os/src/hints/block_context.rs
+++ b/crates/starknet-os/src/hints/block_context.rs
@@ -24,7 +24,7 @@ use crate::hints::vars;
 use crate::io::classes::write_class;
 use crate::io::input::StarknetOsInput;
 use crate::starknet::core::os::contract_class::compiled_class_hash_objects::BytecodeSegmentStructureImpl;
-use crate::utils::{custom_hint_error, felt_api2vm, get_constant};
+use crate::utils::{custom_hint_error, get_constant};
 
 pub const LOAD_CLASS_FACTS: &str = indoc! {r#"
     ids.compiled_class_facts = segments.add()
@@ -234,7 +234,7 @@ pub fn fee_token_address(
     let os_input = exec_scopes.get::<StarknetOsInput>(vars::scopes::OS_INPUT)?;
     let fee_token_address = *os_input.general_config.starknet_os_config.fee_token_address.0.key();
     log::debug!("fee_token_address: {}", fee_token_address);
-    insert_value_into_ap(vm, felt_api2vm(fee_token_address))
+    insert_value_into_ap(vm, fee_token_address)
 }
 
 pub const DEPRECATED_FEE_TOKEN_ADDRESS: &str =
@@ -249,7 +249,7 @@ pub fn deprecated_fee_token_address(
     let os_input = exec_scopes.get::<StarknetOsInput>(vars::scopes::OS_INPUT)?;
     let deprecated_fee_token_address = *os_input.general_config.starknet_os_config.deprecated_fee_token_address.0.key();
     log::debug!("deprecated_fee_token_address: {}", deprecated_fee_token_address);
-    insert_value_into_ap(vm, felt_api2vm(deprecated_fee_token_address))
+    insert_value_into_ap(vm, deprecated_fee_token_address)
 }
 
 pub const SEQUENCER_ADDRESS: &str = "memory[ap] = to_felt_or_relocatable(syscall_handler.block_info.sequencer_address)";
@@ -261,7 +261,7 @@ pub fn sequencer_address(
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
     let block_context = exec_scopes.get_ref::<BlockContext>(vars::scopes::BLOCK_CONTEXT)?;
-    insert_value_into_ap(vm, felt_api2vm(*block_context.block_info().sequencer_address.0.key()))
+    insert_value_into_ap(vm, *block_context.block_info().sequencer_address.0.key())
 }
 
 pub const GET_BLOCK_MAPPING: &str = indoc! {r#"

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -138,7 +138,8 @@ pub fn prepare_constructor_execution(
         ap_tracking,
     )?;
 
-    let constructor_calldata = tx.constructor_calldata.unwrap_or_default().iter().map(|felt| felt.into()).collect();
+    let constructor_calldata =
+        tx.constructor_calldata.unwrap_or_default().iter().map(|felt| felt.into()).collect::<Vec<_>>();
     let constructor_calldata_base = vm.add_memory_segment();
     vm.load_data(constructor_calldata_base, &constructor_calldata)?;
     insert_value_from_var_name(vars::ids::CONSTRUCTOR_CALLDATA, constructor_calldata_base, vm, ids_data, ap_tracking)
@@ -586,7 +587,7 @@ pub fn tx_calldata(
 ) -> Result<(), HintError> {
     let tx = exec_scopes.get::<InternalTransaction>(vars::scopes::TX)?;
     let calldata =
-        tx.calldata.ok_or(custom_hint_error("tx.calldata is None"))?.iter().map(|felt| felt.into()).collect();
+        tx.calldata.ok_or(custom_hint_error("tx.calldata is None"))?.iter().map(|felt| felt.into()).collect::<Vec<_>>();
     let calldata_base = vm.add_memory_segment();
     vm.load_data(calldata_base, &calldata)?;
     insert_value_into_ap(vm, calldata_base)
@@ -849,7 +850,7 @@ pub fn gen_signature_arg(
     let tx = exec_scopes.get::<InternalTransaction>(vars::scopes::TX)?;
     let signature = tx.signature.ok_or(custom_hint_error("tx.signature is None"))?;
     let signature_start_base = vm.add_memory_segment();
-    let signature = signature.iter().map(|f| MaybeRelocatable::Int(*f)).collect();
+    let signature = signature.iter().map(|f| MaybeRelocatable::Int(*f)).collect::<Vec<_>>();
     vm.load_data(signature_start_base, &signature)?;
 
     insert_value_from_var_name(vars::ids::SIGNATURE_START, signature_start_base, vm, ids_data, ap_tracking)?;

--- a/crates/starknet-os/src/hints/mod.rs
+++ b/crates/starknet-os/src/hints/mod.rs
@@ -567,7 +567,7 @@ where
             .tx_execution_info
             .as_ref()
             .ok_or(HintError::CustomHint("ExecutionHelper should have tx_execution_info".to_owned().into_boxed_str()))
-            .map(|tx_execution_info| tx_execution_info.actual_fee)
+            .map(|tx_execution_info| tx_execution_info.transaction_receipt.fee)
     })??;
 
     insert_value_into_ap(vm, Felt252::from(actual_fee.0))

--- a/crates/starknet-os/src/hints/tests.rs
+++ b/crates/starknet-os/src/hints/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 pub mod tests {
     use blockifier::context::BlockContext;
+    use blockifier::fee::actual_cost::TransactionReceipt;
     use blockifier::transaction::objects::TransactionExecutionInfo;
     use cairo_vm::serde::deserialize_program::ApTracking;
     use cairo_vm::types::exec_scope::ExecutionScopes;
@@ -60,11 +61,13 @@ pub mod tests {
             validate_call_info: None,
             execute_call_info: None,
             fee_transfer_call_info: None,
-            actual_fee: Fee(1234),
-            da_gas: Default::default(),
-            actual_resources: Default::default(),
             revert_error: None,
-            bouncer_resources: Default::default(),
+            transaction_receipt: TransactionReceipt {
+                fee: Fee(1234),
+                gas: Default::default(),
+                da_gas: Default::default(),
+                resources: Default::default(),
+            },
         }
     }
 

--- a/crates/starknet-os/src/io/classes.rs
+++ b/crates/starknet-os/src/io/classes.rs
@@ -14,7 +14,7 @@ use crate::starknet::core::os::contract_class::compiled_class_hash_objects::{
     BytecodeLeaf, BytecodeSegment, BytecodeSegmentStructureImpl, BytecodeSegmentedNode,
 };
 use crate::starkware_utils::commitment_tree::base_types::Length;
-use crate::utils::{custom_hint_error, felt_api2vm};
+use crate::utils::custom_hint_error;
 
 /// Returns the serialization of a contract as a list of field elements.
 pub fn get_deprecated_contract_class_struct(
@@ -26,7 +26,7 @@ pub fn get_deprecated_contract_class_struct(
 
     let mut externals: Vec<MaybeRelocatable> = Vec::new();
     for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::External).unwrap().iter() {
-        externals.push(MaybeRelocatable::from(felt_api2vm(elem.selector.0)));
+        externals.push(MaybeRelocatable::from(elem.selector.0));
         externals.push(MaybeRelocatable::from(Felt252::from(elem.offset.0)));
     }
     vm.insert_value((class_base + 1)?, Felt252::from(externals.len() / 2))?;
@@ -37,7 +37,7 @@ pub fn get_deprecated_contract_class_struct(
 
     let mut l1_handlers: Vec<MaybeRelocatable> = Vec::new();
     for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::L1Handler).unwrap().iter() {
-        l1_handlers.push(MaybeRelocatable::from(felt_api2vm(elem.selector.0)));
+        l1_handlers.push(MaybeRelocatable::from(elem.selector.0));
         l1_handlers.push(MaybeRelocatable::from(Felt252::from(elem.offset.0)));
     }
     vm.insert_value((class_base + 3)?, Felt252::from(l1_handlers.len() / 2))?;
@@ -48,7 +48,7 @@ pub fn get_deprecated_contract_class_struct(
 
     let mut constructors: Vec<MaybeRelocatable> = Vec::new();
     for elem in deprecated_class.entry_points_by_type.get(&EntryPointType::Constructor).unwrap().iter() {
-        constructors.push(MaybeRelocatable::from(felt_api2vm(elem.selector.0)));
+        constructors.push(MaybeRelocatable::from(elem.selector.0));
         constructors.push(MaybeRelocatable::from(Felt252::from(elem.offset.0)));
     }
     vm.insert_value((class_base + 5)?, Felt252::from(constructors.len() / 2))?;

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
@@ -8,9 +8,7 @@ use blockifier::state::state_api::{StateReader, StateResult};
 use cairo_vm::types::errors::math_errors::MathError;
 use cairo_vm::Felt252;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
-use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
-use starknet_crypto::FieldElement;
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 use starknet_os_types::hash::Hash;
@@ -28,6 +26,7 @@ use crate::starknet::starknet_storage::StorageLeaf;
 use crate::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use crate::starkware_utils::commitment_tree::binary_fact_tree::BinaryFactTree;
 use crate::starkware_utils::commitment_tree::errors::TreeError;
+use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use crate::storage::storage::{DbObject, FactFetchingContext, HashFunctionType, Storage, StorageError};
 use crate::utils::{execute_coroutine, felt_api2vm, felt_vm2api};
@@ -166,7 +165,7 @@ where
     ) -> Result<Self, TreeError> {
         let empty_state = Self::empty(ffc).await?;
 
-        let mut storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StarkFelt>> = HashMap::new();
+        let mut storage_updates: HashMap<ContractAddress, HashMap<StorageKey, Felt252>> = HashMap::new();
         for ((address, key), value) in blockifier_state.storage_view {
             storage_updates.entry(address).or_default().insert(key, value);
         }
@@ -205,7 +204,7 @@ where
         address_to_class_hash: HashMap<ContractAddress, ClassHash>,
         address_to_nonce: HashMap<ContractAddress, Nonce>,
         class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
-        storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StarkFelt>>,
+        storage_updates: HashMap<ContractAddress, HashMap<StorageKey, Felt252>>,
     ) -> Result<Self, TreeError> {
         let address_to_class_hash: HashMap<_, _> = address_to_class_hash
             .into_iter()
@@ -361,6 +360,7 @@ where
 
                 log::debug!("Should get something from get_leaf()...");
 
+                // TODO: `get_leaf()` should not return an option
                 let contract_class_leaf =
                     <PatriciaTree as BinaryFactTree<S, PoseidonHash, ContractClassLeaf>>::get_leaf(
                         contract_class_tree,
@@ -369,6 +369,11 @@ where
                     )
                     .await?
                     .ok_or(StateError::UndeclaredClassHash(class_hash))?;
+
+                // Return an error if we get an empty leaf
+                if <ContractClassLeaf as LeafFact<S, H>>::is_empty(&contract_class_leaf) {
+                    return Err(StateError::UndeclaredClassHash(class_hash))?;
+                }
 
                 contract_class_leaf.compiled_class_hash
             }
@@ -381,30 +386,30 @@ where
     }
 
     async fn get_deprecated_compiled_class(
-        &mut self,
+        &self,
         compiled_class_hash: CompiledClassHash,
     ) -> Result<Option<GenericDeprecatedCompiledClass>, StorageError> {
         let storage = self.ffc.acquire_storage().await;
 
-        DeprecatedCompiledClassFact::get(storage.deref(), compiled_class_hash.0.bytes())
+        DeprecatedCompiledClassFact::get(storage.deref(), &compiled_class_hash.0.to_bytes_be())
             .await
             .map(|option| option.map(|fact| fact.contract_definition))
     }
 
     async fn get_compiled_class(
-        &mut self,
+        &self,
         compiled_class_hash: CompiledClassHash,
     ) -> Result<Option<GenericCasmContractClass>, StorageError> {
         let storage = self.ffc.acquire_storage().await;
 
-        CompiledClassFact::get(storage.deref(), compiled_class_hash.0.bytes())
+        CompiledClassFact::get(storage.deref(), &compiled_class_hash.0.to_bytes_be())
             .await
             .map(|option| option.map(|fact| fact.compiled_class))
     }
 
     /// Returns the contract class of the given class hash.
     async fn get_compiled_contract_class_async(
-        &mut self,
+        &self,
         compiled_class_hash: CompiledClassHash,
     ) -> StateResult<ContractClass> {
         log::debug!("SharedState as StateReader: get_compiled_contract_class {:?}", compiled_class_hash);
@@ -430,17 +435,15 @@ where
         Err(StateError::UndeclaredClassHash(ClassHash(compiled_class_hash.0)))
     }
 
-    async fn get_storage_at_async(
-        &mut self,
-        contract_address: ContractAddress,
-        key: StorageKey,
-    ) -> StateResult<StarkFelt> {
+    async fn get_storage_at_async(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt252> {
         let storage_key: TreeIndex = felt_api2vm(*key.0.key()).to_biguint();
+
+        let mut ffc = self.ffc.clone();
 
         let contract_state = self.get_contract_state_async(contract_address).await?;
 
         let storage_items: HashMap<TreeIndex, StorageLeaf> =
-            contract_state.storage_commitment_tree.get_leaves(&mut self.ffc, &[storage_key.clone()], &mut None).await?;
+            contract_state.storage_commitment_tree.get_leaves(&mut ffc, &[storage_key.clone()], &mut None).await?;
         let state = storage_items
             .get(&storage_key)
             .ok_or(StateError::StateReadError(format!("get_storage_at_async: {:?}", storage_key)))?;
@@ -457,7 +460,7 @@ where
     /// Returns the storage value under the given key in the given contract instance (represented by
     /// its address).
     /// Default: 0 for an uninitialized contract address.
-    fn get_storage_at(&mut self, contract_address: ContractAddress, key: StorageKey) -> StateResult<StarkFelt> {
+    fn get_storage_at(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt252> {
         log::debug!("SharedState as StateReader: get_storage_at {:?} / {:?}", contract_address, key);
         let value = execute_coroutine(self.get_storage_at_async(contract_address, key)).unwrap(); // TODO: unwrap
         log::debug!("       -> {:?}", value);
@@ -466,7 +469,7 @@ where
 
     /// Returns the nonce of the given contract instance.
     /// Default: 0 for an uninitialized contract address.
-    fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
+    fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         log::debug!("SharedState as StateReader: get_nonce_at {:?}", contract_address);
         let contract_state = self.get_contract_state(contract_address)?;
         let nonce = Nonce(felt_vm2api(contract_state.nonce));
@@ -476,30 +479,27 @@ where
 
     /// Returns the class hash of the contract class at the given contract instance.
     /// Default: 0 (uninitialized class hash) for an uninitialized contract address.
-    fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
+    fn get_class_hash_at(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
         log::debug!("SharedState as StateReader: get_class_hash_at {:?}", contract_address);
         let contract_state = self.get_contract_state(contract_address)?;
         // TODO: this can be simplified once hashes are stored as [u8; 32]. Until then, this is fine.
-        let felt = FieldElement::from_byte_slice_be(&contract_state.contract_hash)
-            .expect("Conversion to felt should not fail");
+        let felt = Felt252::from_bytes_be_slice(&contract_state.contract_hash);
         log::debug!("       -> {:?}", felt);
-        Ok(ClassHash(StarkFelt::from(felt)))
+        Ok(ClassHash(felt))
     }
 
     /// Returns the contract class of the given class hash.
-    fn get_compiled_contract_class(&mut self, class_hash: ClassHash) -> StateResult<ContractClass> {
+    fn get_compiled_contract_class(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
         execute_coroutine(async {
-            let compiled_class_hash = self.get_compiled_class_hash_async(class_hash).await.unwrap();
+            let compiled_class_hash = self.get_compiled_class_hash_async(class_hash).await?;
             self.get_compiled_contract_class_async(compiled_class_hash).await
         })
         .unwrap() // TODO: unwrap
     }
 
     /// Returns the compiled class hash of the given class hash.
-    fn get_compiled_class_hash(&mut self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+    fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         log::debug!("SharedState as StateReader: get_compiled_class_hash {:?}", class_hash);
         execute_coroutine(self.get_compiled_class_hash_async(class_hash)).unwrap() // TODO: unwrap
     }
-
-    // TODO: do we care about `fn get_free_token_balance()`?
 }

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
@@ -29,7 +29,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use crate::storage::storage::{DbObject, FactFetchingContext, HashFunctionType, Storage, StorageError};
-use crate::utils::{execute_coroutine, felt_api2vm};
+use crate::utils::execute_coroutine;
 
 /// A class representing a combination of the onchain and offchain state.
 #[derive(Debug)]
@@ -206,31 +206,21 @@ where
         class_hash_to_compiled_class_hash: HashMap<ClassHash, CompiledClassHash>,
         storage_updates: HashMap<ContractAddress, HashMap<StorageKey, Felt252>>,
     ) -> Result<Self, TreeError> {
-        let address_to_class_hash: HashMap<_, _> = address_to_class_hash
-            .into_iter()
-            .map(|(address, class_hash)| (felt_api2vm(*address.0.key()), felt_api2vm(class_hash.0)))
-            .collect();
+        let address_to_class_hash: HashMap<_, _> =
+            address_to_class_hash.into_iter().map(|(address, class_hash)| (*address.0.key(), class_hash.0)).collect();
 
-        let address_to_nonce: HashMap<_, _> = address_to_nonce
-            .into_iter()
-            .map(|(address, nonce)| (felt_api2vm(*address.0.key()), felt_api2vm(nonce.0)))
-            .collect();
+        let address_to_nonce: HashMap<_, _> =
+            address_to_nonce.into_iter().map(|(address, nonce)| (*address.0.key(), nonce.0)).collect();
 
         let class_hash_to_compiled_class_hash: HashMap<_, _> = class_hash_to_compiled_class_hash
             .into_iter()
-            .map(|(class_hash, compiled_class_hash)| (felt_api2vm(class_hash.0), felt_api2vm(compiled_class_hash.0)))
+            .map(|(class_hash, compiled_class_hash)| (class_hash.0, compiled_class_hash.0))
             .collect();
 
         let storage_updates: HashMap<_, HashMap<_, _>> = storage_updates
             .into_iter()
             .map(|(address, contract_storage_updates)| {
-                (
-                    felt_api2vm(*address.0.key()),
-                    contract_storage_updates
-                        .into_iter()
-                        .map(|(k, v)| (felt_api2vm(*k.0.key()), felt_api2vm(v)))
-                        .collect(),
-                )
+                (*address.0.key(), contract_storage_updates.into_iter().map(|(k, v)| (*k.0.key(), v)).collect())
             })
             .collect();
 
@@ -324,7 +314,7 @@ where
     }
 
     async fn get_contract_state_async(&self, contract_address: ContractAddress) -> StateResult<ContractState> {
-        let contract_address: TreeIndex = felt_api2vm(*contract_address.0.key()).to_biguint();
+        let contract_address: TreeIndex = contract_address.0.key().to_biguint();
 
         let mut ffc = self.ffc.clone();
 
@@ -349,7 +339,7 @@ where
     }
 
     async fn get_compiled_class_hash_async(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
-        let class_hash_as_index: TreeIndex = felt_api2vm(class_hash.0).to_biguint();
+        let class_hash_as_index: TreeIndex = class_hash.0.to_biguint();
 
         log::debug!("class_hash_as_index: {:?}", class_hash_as_index);
         log::debug!("have contract_class_tree? {:?}", self.contract_classes.is_some());
@@ -436,7 +426,7 @@ where
     }
 
     async fn get_storage_at_async(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt252> {
-        let storage_key: TreeIndex = felt_api2vm(*key.0.key()).to_biguint();
+        let storage_key: TreeIndex = key.0.key().to_biguint();
 
         let mut ffc = self.ffc.clone();
 

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
@@ -29,7 +29,7 @@ use crate::starkware_utils::commitment_tree::errors::TreeError;
 use crate::starkware_utils::commitment_tree::leaf_fact::LeafFact;
 use crate::starkware_utils::commitment_tree::patricia_tree::patricia_tree::PatriciaTree;
 use crate::storage::storage::{DbObject, FactFetchingContext, HashFunctionType, Storage, StorageError};
-use crate::utils::{execute_coroutine, felt_api2vm, felt_vm2api};
+use crate::utils::{execute_coroutine, felt_api2vm};
 
 /// A class representing a combination of the onchain and offchain state.
 #[derive(Debug)]
@@ -382,7 +382,7 @@ where
             None => Felt252::ZERO,
         };
 
-        Ok(CompiledClassHash(felt_vm2api(compiled_class_hash)))
+        Ok(CompiledClassHash(compiled_class_hash))
     }
 
     async fn get_deprecated_compiled_class(
@@ -448,7 +448,7 @@ where
             .get(&storage_key)
             .ok_or(StateError::StateReadError(format!("get_storage_at_async: {:?}", storage_key)))?;
 
-        Ok(felt_vm2api(state.value))
+        Ok(state.value)
     }
 }
 
@@ -472,7 +472,7 @@ where
     fn get_nonce_at(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         log::debug!("SharedState as StateReader: get_nonce_at {:?}", contract_address);
         let contract_state = self.get_contract_state(contract_address)?;
-        let nonce = Nonce(felt_vm2api(contract_state.nonce));
+        let nonce = Nonce(contract_state.nonce);
         log::debug!("       -> {:?}", nonce);
         Ok(nonce)
     }

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/errors.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/errors.rs
@@ -27,6 +27,7 @@ pub enum UpdateTreeError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum TreeError {
+    #[error()]
     #[error(transparent)]
     Storage(#[from] StorageError),
 

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/errors.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/errors.rs
@@ -27,7 +27,6 @@ pub enum UpdateTreeError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum TreeError {
-    #[error()]
     #[error(transparent)]
     Storage(#[from] StorageError),
 

--- a/crates/starknet-os/src/storage/storage_utils.rs
+++ b/crates/starknet-os/src/storage/storage_utils.rs
@@ -1,5 +1,4 @@
 use blockifier::state::cached_state::CachedState;
-use blockifier::state::state_api::State;
 use cairo_vm::Felt252;
 use starknet_os_types::hash::Hash;
 
@@ -68,7 +67,7 @@ pub async fn unpack_blockifier_state_async<S: Storage + Send + Sync, H: HashFunc
 ) -> Result<(SharedState<S, H>, SharedState<S, H>), TreeError> {
     let final_state = {
         let state = blockifier_state.state.clone();
-        state.apply_commitment_state_diff(blockifier_state.to_state_diff()).await?
+        state.apply_commitment_state_diff(blockifier_state.to_state_diff().expect("todo").into()).await?
     };
 
     let initial_state = blockifier_state.state;

--- a/crates/starknet-os/src/storage/storage_utils.rs
+++ b/crates/starknet-os/src/storage/storage_utils.rs
@@ -62,12 +62,16 @@ where
     }
 }
 
+// TODO: move this function to where it is used, this should not be a public function of
+//       the starknet-os library
 pub async fn unpack_blockifier_state_async<S: Storage + Send + Sync, H: HashFunctionType + Send + Sync>(
     mut blockifier_state: CachedState<SharedState<S, H>>,
 ) -> Result<(SharedState<S, H>, SharedState<S, H>), TreeError> {
     let final_state = {
         let state = blockifier_state.state.clone();
-        state.apply_commitment_state_diff(blockifier_state.to_state_diff().expect("todo").into()).await?
+        state
+            .apply_commitment_state_diff(blockifier_state.to_state_diff().expect("failed to build state diff").into())
+            .await?
     };
 
     let initial_state = blockifier_state.state;

--- a/crates/starknet-os/src/utils.rs
+++ b/crates/starknet-os/src/utils.rs
@@ -10,10 +10,6 @@ use starknet_api::core::ChainId;
 use starknet_os_types::chain_id::chain_id_to_felt;
 use tokio::task;
 
-pub fn felt_api2vm(felt: Felt252) -> Felt252 {
-    felt
-}
-
 pub(crate) struct Felt252Str;
 
 impl<'de> DeserializeAs<'de, Felt252> for Felt252Str {

--- a/crates/starknet-os/src/utils.rs
+++ b/crates/starknet-os/src/utils.rs
@@ -10,10 +10,6 @@ use starknet_api::core::ChainId;
 use starknet_os_types::chain_id::chain_id_to_felt;
 use tokio::task;
 
-pub fn felt_vm2api(felt: Felt252) -> Felt252 {
-    felt
-}
-
 pub fn felt_api2vm(felt: Felt252) -> Felt252 {
     felt
 }

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -21,7 +21,7 @@ use starknet_os::starknet::starknet_storage::{CommitmentInfo, OsSingleStarknetSt
 use starknet_os::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use starknet_os::storage::storage::Storage;
 use starknet_os::storage::storage_utils::build_starknet_storage_async;
-use starknet_os::utils::{felt_api2vm, felt_vm2api};
+use starknet_os::utils::felt_api2vm;
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
@@ -45,7 +45,7 @@ where
         .map(|address_biguint| {
             // TODO: biguint is exacerbating the type conversion problem, ideas...?
             let address: ContractAddress =
-                ContractAddress(PatriciaKey::try_from(felt_vm2api(Felt252::from(address_biguint))).unwrap());
+                ContractAddress(PatriciaKey::try_from(Felt252::from(address_biguint)).unwrap());
             let contract_state = blockifier_state.state.get_contract_state(address).unwrap();
             (*address.0.key(), contract_state)
         })

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -25,8 +25,6 @@ use starknet_os::utils::{felt_api2vm, felt_vm2api};
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
-use crate::common::transaction_utils::to_felt252;
-
 pub async fn os_hints<S>(
     block_context: &BlockContext,
     mut blockifier_state: CachedState<SharedState<S, PedersenHash>>,
@@ -49,7 +47,7 @@ where
             let address: ContractAddress =
                 ContractAddress(PatriciaKey::try_from(felt_vm2api(Felt252::from(address_biguint))).unwrap());
             let contract_state = blockifier_state.state.get_contract_state(address).unwrap();
-            (to_felt252(address.0.key()), contract_state)
+            (*address.0.key(), contract_state)
         })
         .collect();
 
@@ -59,7 +57,7 @@ where
     let deployed_addresses = state_diff.address_to_class_hash;
     for (address, _class_hash) in &deployed_addresses {
         contracts.insert(
-            to_felt252(address.0.key()),
+            *address.0.key(),
             ContractState::empty(Height(251), &mut blockifier_state.state.ffc).await.unwrap(),
         );
     }
@@ -83,7 +81,7 @@ where
                     compiled_classes.get(&class_hash).unwrap_or_else(|| panic!("No class given for {:?}", class_hash));
                 let compiled_class_hash = compiled_class.class_hash().expect("Failed to compute class hash");
                 let compiled_class_hash = Felt252::from(compiled_class_hash);
-                class_hash_to_compiled_class_hash.insert(to_felt252(&class_hash.0), compiled_class_hash);
+                class_hash_to_compiled_class_hash.insert(class_hash.0, compiled_class_hash);
 
                 compiled_class_hash_to_compiled_class.insert(compiled_class_hash, compiled_class.clone());
             }

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -21,7 +21,6 @@ use starknet_os::starknet::starknet_storage::{CommitmentInfo, OsSingleStarknetSt
 use starknet_os::starkware_utils::commitment_tree::base_types::{Height, TreeIndex};
 use starknet_os::storage::storage::Storage;
 use starknet_os::storage::storage_utils::build_starknet_storage_async;
-use starknet_os::utils::felt_api2vm;
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 
@@ -67,7 +66,7 @@ where
     let mut class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252> = state_diff
         .class_hash_to_compiled_class_hash
         .iter()
-        .map(|(class_hash, _compiled_class_hash)| (felt_api2vm(class_hash.0), Felt252::ZERO))
+        .map(|(class_hash, _compiled_class_hash)| (class_hash.0, Felt252::ZERO))
         .collect();
 
     for c in contracts.keys() {
@@ -138,7 +137,7 @@ where
         .visited_pcs
         .iter()
         .map(|(class_hash, visited_pcs)| {
-            let class_hash_felt = felt_api2vm(class_hash.0);
+            let class_hash_felt = class_hash.0;
             let compiled_class_hash_felt = class_hash_to_compiled_class_hash.get(&class_hash_felt).unwrap();
             (*compiled_class_hash_felt, visited_pcs.iter().copied().map(Felt252::from).collect::<Vec<_>>())
         })
@@ -181,7 +180,7 @@ where
         .unwrap_or_else(|e| panic!("Could not create contract class commitment info: {:?}", e));
 
     let deprecated_compiled_classes: HashMap<_, _> =
-        deprecated_compiled_classes.into_iter().map(|(k, v)| (felt_api2vm(k.0), v)).collect();
+        deprecated_compiled_classes.into_iter().map(|(k, v)| (k.0, v)).collect();
 
     let os_input = StarknetOsInput {
         contract_state_commitment_info,

--- a/tests/integration/common/state.rs
+++ b/tests/integration/common/state.rs
@@ -10,8 +10,6 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use rstest::fixture;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
-use starknet_api::hash::StarkFelt;
-use starknet_api::stark_felt;
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::starknet::business_logic::fact_state::state::SharedState;
 use starknet_os::starknet::business_logic::utils::{write_class_facts, write_deprecated_compiled_class_fact};
@@ -272,7 +270,7 @@ impl<'a> StarknetStateBuilder<'a> {
         for (name, contract) in cairo0_contracts {
             let deprecated_compiled_class = contract.deprecated_compiled_class;
             let class_hash = write_deprecated_compiled_class_fact(deprecated_compiled_class.clone(), ffc).await?;
-            let class_hash = ClassHash::try_from(class_hash).expect("Class hash is not in prime field");
+            let class_hash = ClassHash::from(class_hash);
 
             Self::add_cairo0_contract_to_state(class_hash, deprecated_compiled_class.clone(), dict_state_reader);
 
@@ -299,7 +297,7 @@ impl<'a> StarknetStateBuilder<'a> {
             let deprecated_compiled_class = contract.contract.deprecated_compiled_class;
 
             let class_hash = write_deprecated_compiled_class_fact(deprecated_compiled_class.clone(), ffc).await?;
-            let class_hash = ClassHash::try_from(class_hash).expect("Class hash is not in prime field");
+            let class_hash = ClassHash::from(class_hash);
 
             // Add entries in the dict state
             Self::add_cairo0_contract_to_state(class_hash, deprecated_compiled_class.clone(), dict_state_reader);
@@ -345,9 +343,8 @@ impl<'a> StarknetStateBuilder<'a> {
 
             let (contract_class_hash, compiled_class_hash) =
                 write_class_facts(contract_class.clone().into(), compiled_contract_class.clone(), ffc).await?;
-            let class_hash = ClassHash::try_from(contract_class_hash).expect("Class hash is not in prime field");
-            let compiled_class_hash =
-                CompiledClassHash::try_from(compiled_class_hash).expect("Compiled class hash is not in prime field");
+            let class_hash = ClassHash::from(contract_class_hash);
+            let compiled_class_hash = CompiledClassHash::from(compiled_class_hash);
 
             Self::add_cairo1_contract_to_state(
                 class_hash,
@@ -385,9 +382,8 @@ impl<'a> StarknetStateBuilder<'a> {
 
             let (contract_class_hash, compiled_class_hash) =
                 write_class_facts(contract_class.clone().into(), compiled_contract_class.clone(), ffc).await?;
-            let class_hash = ClassHash::try_from(contract_class_hash).expect("Class hash is not in prime field");
-            let compiled_class_hash =
-                CompiledClassHash::try_from(compiled_class_hash).expect("Compiled class hash is not in prime field");
+            let class_hash = ClassHash::from(contract_class_hash);
+            let compiled_class_hash = CompiledClassHash::from(compiled_class_hash);
 
             // Add entries in the dict state
             Self::add_cairo1_contract_to_state(
@@ -445,8 +441,8 @@ impl<'a> StarknetStateBuilder<'a> {
     ) {
         let storage_view = &mut dict_state_reader.storage_view;
         let balance_key = get_fee_token_var_address(account_address);
-        storage_view.insert((fee_config.eth_fee_token_address, balance_key), stark_felt!(balance.eth));
-        storage_view.insert((fee_config.strk_fee_token_address, balance_key), stark_felt!(balance.strk));
+        storage_view.insert((fee_config.eth_fee_token_address, balance_key), balance.eth.into());
+        storage_view.insert((fee_config.strk_fee_token_address, balance_key), balance.strk.into());
     }
 
     /// Converts the dict state reader and FFC into a shared state object.

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -36,7 +36,6 @@ use starknet_os::starknet::business_logic::fact_state::state::SharedState;
 use starknet_os::starknet::core::os::transaction_hash::{L1_GAS, L2_GAS};
 use starknet_os::starknet::starknet_storage::OsSingleStarknetStorage;
 use starknet_os::storage::storage::Storage;
-use starknet_os::utils::felt_api2vm;
 use starknet_os::{config, run_os};
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::chain_id::chain_id_to_felt;
@@ -419,8 +418,8 @@ fn account_tx_to_internal_tx(account_tx: &AccountTransaction, chain_id: &ChainId
     }
 }
 fn to_internal_l1_handler_tx(l1_tx: &L1HandlerTransaction, chain_id: &ChainId) -> InternalTransaction {
-    let contract_address = felt_api2vm(*l1_tx.tx.contract_address.0);
-    let entry_point_selector = felt_api2vm(l1_tx.tx.entry_point_selector.0);
+    let contract_address = *l1_tx.tx.contract_address.0;
+    let entry_point_selector = l1_tx.tx.entry_point_selector.0;
     let txinfo = l1_tx.create_tx_info();
     let signature = match txinfo {
         TransactionInfo::Deprecated(tx) => tx.common_fields.signature,
@@ -429,7 +428,7 @@ fn to_internal_l1_handler_tx(l1_tx: &L1HandlerTransaction, chain_id: &ChainId) -
     let signature = signature.0.iter().copied().collect();
     let calldata: Vec<_> = l1_tx.tx.calldata.0.iter().copied().collect();
     let chain_id_felt = chain_id_to_felt(chain_id);
-    let nonce = felt_api2vm(l1_tx.tx.nonce.0);
+    let nonce = l1_tx.tx.nonce.0;
     let fee = Felt252::ZERO;
     let hash_value = l1_tx_compute_hash(contract_address, entry_point_selector, &calldata, fee, chain_id_felt, nonce);
 
@@ -460,13 +459,13 @@ pub fn to_internal_declare_v1_tx(
     let max_fee = tx.max_fee.0.into();
     let signature = tx.signature.0.iter().copied().collect();
     let chain_id_felt = chain_id_to_felt(chain_id);
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
 
     match account_tx.create_tx_info() {
         TransactionInfo::Current(_) => unreachable!("v1 transactions can only contain a `Deprecated` variant"),
         TransactionInfo::Deprecated(context) => {
-            sender_address = felt_api2vm(*context.common_fields.sender_address.0.key());
-            class_hash = felt_api2vm(tx.class_hash.0);
+            sender_address = *context.common_fields.sender_address.0.key();
+            class_hash = tx.class_hash.0;
 
             hash_value = tx_hash_declare_v1(sender_address, max_fee, class_hash, chain_id_felt, nonce);
         }
@@ -495,29 +494,27 @@ fn to_internal_deploy_v1_tx(
         TransactionInfo::Current(_) => unreachable!("TxV1 can only have deprecated variant"),
         TransactionInfo::Deprecated(context) => context.common_fields.sender_address,
     };
-    let sender_address_felt = felt_api2vm(*sender_address.key());
+    let sender_address_felt = *sender_address.key();
 
-    let contract_address = felt_api2vm(
-        *calculate_contract_address(
-            tx.contract_address_salt,
-            tx.class_hash,
-            &tx.constructor_calldata,
-            contract_address!("0x0"),
-        )
-        .unwrap()
-        .key(),
-    );
+    let contract_address = *calculate_contract_address(
+        tx.contract_address_salt,
+        tx.class_hash,
+        &tx.constructor_calldata,
+        contract_address!("0x0"),
+    )
+    .unwrap()
+    .key();
 
     let max_fee: Felt252 = tx.max_fee.0.into();
     let signature = Some(tx.signature.0.iter().copied().collect());
     let entry_point_selector = Some(Felt252::ZERO);
     let chain_id_felt = chain_id_to_felt(chain_id);
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
 
-    let class_hash = felt_api2vm(tx.class_hash.0);
+    let class_hash = tx.class_hash.0;
 
     let constructor_calldata: Vec<_> = tx.constructor_calldata.0.iter().copied().collect();
-    let contract_address_salt = felt_api2vm(tx.contract_address_salt.0);
+    let contract_address_salt = tx.contract_address_salt.0;
 
     let hash_value = tx_hash_deploy_account_v1(
         contract_address,
@@ -557,23 +554,17 @@ pub fn to_internal_declare_v2_tx(
     let class_hash;
     let max_fee = tx.max_fee.0.into();
     let signature = tx.signature.0.iter().copied().collect();
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
     let chain_id_felt = chain_id_to_felt(chain_id);
 
     match account_tx.create_tx_info() {
         TransactionInfo::Current(_) => panic!("Not implemented"),
         TransactionInfo::Deprecated(context) => {
-            sender_address = felt_api2vm(*context.common_fields.sender_address.0.key());
-            class_hash = felt_api2vm(tx.class_hash.0);
+            sender_address = *context.common_fields.sender_address.0.key();
+            class_hash = tx.class_hash.0;
 
-            hash_value = tx_hash_declare_v2(
-                sender_address,
-                max_fee,
-                class_hash,
-                felt_api2vm(tx.compiled_class_hash.0),
-                chain_id_felt,
-                nonce,
-            );
+            hash_value =
+                tx_hash_declare_v2(sender_address, max_fee, class_hash, tx.compiled_class_hash.0, chain_id_felt, nonce);
         }
     }
 
@@ -585,7 +576,7 @@ pub fn to_internal_declare_v2_tx(
         entry_point_type: Some("EXTERNAL".to_string()),
         signature: Some(signature),
         class_hash: Some(class_hash),
-        compiled_class_hash: Some(felt_api2vm(tx.compiled_class_hash.0)),
+        compiled_class_hash: Some(tx.compiled_class_hash.0),
         r#type: "DECLARE".to_string(),
         max_fee: Some(max_fee),
         ..Default::default()
@@ -597,9 +588,9 @@ pub fn to_internal_declare_v3_tx(tx: &DeclareTransactionV3, chain_id: &ChainId) 
     let signature = Some(tx.signature.0.iter().copied().collect());
     let entry_point_selector = selector_from_name("__execute__").0;
     let sender_address = *tx.sender_address.0.key();
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
     let chain_id_felt = chain_id_to_felt(chain_id);
-    let tip = felt_api2vm(tx.tip.0.into());
+    let tip = tx.tip.0.into();
 
     let nonce_data_availability_mode = Felt252::from(tx.nonce_data_availability_mode as u64);
     let fee_data_availability_mode = Felt252::from(tx.fee_data_availability_mode as u64);
@@ -607,8 +598,8 @@ pub fn to_internal_declare_v3_tx(tx: &DeclareTransactionV3, chain_id: &ChainId) 
 
     let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.iter().copied().collect();
     let account_deployment_data: Vec<Felt252> = tx.account_deployment_data.0.iter().copied().collect();
-    let class_hash = felt_api2vm(tx.class_hash.0);
-    let compiled_class_hash = felt_api2vm(tx.compiled_class_hash.0);
+    let class_hash = tx.class_hash.0;
+    let compiled_class_hash = tx.compiled_class_hash.0;
     let hash_value = tx_hash_declare_v3(
         nonce,
         sender_address,
@@ -678,7 +669,7 @@ pub fn to_internal_invoke_v1_tx(tx: &InvokeTransactionV1, chain_id: &ChainId) ->
     let entry_point_selector = Some(selector_from_name("__execute__").0);
     let calldata = Some(tx.calldata.0.iter().copied().collect());
     let contract_address = *tx.sender_address.0.key();
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
     let chain_id_felt = chain_id_to_felt(chain_id);
     let hash_value = tx_hash_invoke_v1(contract_address, calldata.clone().unwrap(), max_fee, chain_id_felt, nonce);
 
@@ -704,9 +695,9 @@ pub fn to_internal_invoke_v3_tx(tx: &InvokeTransactionV3, chain_id: &ChainId) ->
     let entry_point_selector = selector_from_name("__execute__").0;
     let calldata: Vec<_> = tx.calldata.0.iter().copied().collect();
     let sender_address = *tx.sender_address.0.key();
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
     let chain_id_felt = chain_id_to_felt(chain_id);
-    let tip = felt_api2vm(tx.tip.0.into());
+    let tip = tx.tip.0.into();
 
     let nonce_data_availability_mode = Felt252::from(tx.nonce_data_availability_mode as u64);
     let fee_data_availability_mode = Felt252::from(tx.fee_data_availability_mode as u64);
@@ -761,16 +752,16 @@ pub fn to_internal_deploy_v3_tx(
     let entry_point_selector = Some(Felt252::ZERO);
     let calldata: Vec<_> = tx.constructor_calldata.0.iter().copied().collect();
 
-    let nonce = felt_api2vm(tx.nonce.0);
+    let nonce = tx.nonce.0;
     let chain_id_felt = chain_id_to_felt(chain_id);
-    let tip = felt_api2vm(tx.tip.0.into());
+    let tip = tx.tip.0.into();
 
     let nonce_data_availability_mode = Felt252::from(tx.nonce_data_availability_mode as u64);
     let fee_data_availability_mode = Felt252::from(tx.fee_data_availability_mode as u64);
     let resource_bounds = &tx.resource_bounds;
 
     let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.iter().copied().collect();
-    let contract_address_salt = felt_api2vm(tx.contract_address_salt.0);
+    let contract_address_salt = tx.contract_address_salt.0;
     let class_hash = tx.class_hash.0;
 
     let contract_address = calculate_contract_address(
@@ -780,11 +771,11 @@ pub fn to_internal_deploy_v3_tx(
         ContractAddress::from(0_u8),
     )
     .unwrap();
-    let contract_address = felt_api2vm(*contract_address.0);
+    let contract_address_felt = *contract_address.0.key();
 
     let hash_value = tx_hash_deploy_v3(
         nonce,
-        contract_address,
+        contract_address_felt,
         chain_id_felt,
         nonce_data_availability_mode,
         fee_data_availability_mode,
@@ -801,7 +792,7 @@ pub fn to_internal_deploy_v3_tx(
         version: Some(Felt252::THREE),
         nonce: Some(nonce),
         sender_address: Some(*sender_address.0),
-        contract_address: Some(contract_address),
+        contract_address: Some(contract_address_felt),
         entry_point_selector,
         entry_point_type: Some("CONSTRUCTOR".to_string()),
         r#type: "DEPLOY_ACCOUNT".to_string(),

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -425,7 +425,7 @@ fn to_internal_l1_handler_tx(l1_tx: &L1HandlerTransaction, chain_id: &ChainId) -
         TransactionInfo::Deprecated(tx) => tx.common_fields.signature,
         TransactionInfo::Current(tx) => tx.common_fields.signature,
     };
-    let signature = signature.0.iter().copied().collect();
+    let signature = signature.0.to_vec();
     let calldata: Vec<_> = l1_tx.tx.calldata.0.iter().copied().collect();
     let chain_id_felt = chain_id_to_felt(chain_id);
     let nonce = l1_tx.tx.nonce.0;
@@ -457,7 +457,7 @@ pub fn to_internal_declare_v1_tx(
     let sender_address;
     let class_hash;
     let max_fee = tx.max_fee.0.into();
-    let signature = tx.signature.0.iter().copied().collect();
+    let signature = tx.signature.0.to_vec();
     let chain_id_felt = chain_id_to_felt(chain_id);
     let nonce = tx.nonce.0;
 
@@ -506,7 +506,7 @@ fn to_internal_deploy_v1_tx(
     .key();
 
     let max_fee: Felt252 = tx.max_fee.0.into();
-    let signature = Some(tx.signature.0.iter().copied().collect());
+    let signature = Some(tx.signature.0.to_vec());
     let entry_point_selector = Some(Felt252::ZERO);
     let chain_id_felt = chain_id_to_felt(chain_id);
     let nonce = tx.nonce.0;
@@ -553,7 +553,7 @@ pub fn to_internal_declare_v2_tx(
     let sender_address;
     let class_hash;
     let max_fee = tx.max_fee.0.into();
-    let signature = tx.signature.0.iter().copied().collect();
+    let signature = tx.signature.0.to_vec();
     let nonce = tx.nonce.0;
     let chain_id_felt = chain_id_to_felt(chain_id);
 
@@ -585,7 +585,7 @@ pub fn to_internal_declare_v2_tx(
 
 /// Convert a DeclareTransactionV2 to a SNOS InternalTransaction
 pub fn to_internal_declare_v3_tx(tx: &DeclareTransactionV3, chain_id: &ChainId) -> InternalTransaction {
-    let signature = Some(tx.signature.0.iter().copied().collect());
+    let signature = Some(tx.signature.0.to_vec());
     let entry_point_selector = selector_from_name("__execute__").0;
     let sender_address = *tx.sender_address.0.key();
     let nonce = tx.nonce.0;
@@ -596,8 +596,8 @@ pub fn to_internal_declare_v3_tx(tx: &DeclareTransactionV3, chain_id: &ChainId) 
     let fee_data_availability_mode = Felt252::from(tx.fee_data_availability_mode as u64);
     let resource_bounds = &tx.resource_bounds;
 
-    let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.iter().copied().collect();
-    let account_deployment_data: Vec<Felt252> = tx.account_deployment_data.0.iter().copied().collect();
+    let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.to_vec();
+    let account_deployment_data: Vec<Felt252> = tx.account_deployment_data.0.to_vec();
     let class_hash = tx.class_hash.0;
     let compiled_class_hash = tx.compiled_class_hash.0;
     let hash_value = tx_hash_declare_v3(
@@ -638,7 +638,7 @@ pub fn to_internal_declare_v3_tx(tx: &DeclareTransactionV3, chain_id: &ChainId) 
 /// Convert a InvokeTransactionV0 to a SNOS InternalTransaction
 pub fn to_internal_invoke_v0_tx(tx: &InvokeTransactionV0, chain_id: &ChainId) -> InternalTransaction {
     let max_fee = tx.max_fee.0.into();
-    let signature = Some(tx.signature.0.iter().copied().collect());
+    let signature = Some(tx.signature.0.to_vec());
     let entry_point_selector = tx.entry_point_selector.0;
     let calldata: Vec<_> = tx.calldata.0.iter().copied().collect();
     let contract_address = *tx.contract_address.0.key();
@@ -665,7 +665,7 @@ pub fn to_internal_invoke_v0_tx(tx: &InvokeTransactionV0, chain_id: &ChainId) ->
 /// Convert a InvokeTransactionV1 to a SNOS InternalTransaction
 pub fn to_internal_invoke_v1_tx(tx: &InvokeTransactionV1, chain_id: &ChainId) -> InternalTransaction {
     let max_fee = tx.max_fee.0.into();
-    let signature = Some(tx.signature.0.iter().copied().collect());
+    let signature = Some(tx.signature.0.to_vec());
     let entry_point_selector = Some(selector_from_name("__execute__").0);
     let calldata = Some(tx.calldata.0.iter().copied().collect());
     let contract_address = *tx.sender_address.0.key();
@@ -691,7 +691,7 @@ pub fn to_internal_invoke_v1_tx(tx: &InvokeTransactionV1, chain_id: &ChainId) ->
 
 /// Convert a InvokeTransactionV3 to a SNOS InternalTransaction
 pub fn to_internal_invoke_v3_tx(tx: &InvokeTransactionV3, chain_id: &ChainId) -> InternalTransaction {
-    let signature = Some(tx.signature.0.iter().copied().collect());
+    let signature = Some(tx.signature.0.to_vec());
     let entry_point_selector = selector_from_name("__execute__").0;
     let calldata: Vec<_> = tx.calldata.0.iter().copied().collect();
     let sender_address = *tx.sender_address.0.key();
@@ -703,8 +703,8 @@ pub fn to_internal_invoke_v3_tx(tx: &InvokeTransactionV3, chain_id: &ChainId) ->
     let fee_data_availability_mode = Felt252::from(tx.fee_data_availability_mode as u64);
     let resource_bounds = &tx.resource_bounds;
 
-    let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.iter().copied().collect();
-    let account_deployment_data: Vec<Felt252> = tx.account_deployment_data.0.iter().copied().collect();
+    let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.to_vec();
+    let account_deployment_data: Vec<Felt252> = tx.account_deployment_data.0.to_vec();
     let hash_value = tx_hash_invoke_v3(
         nonce,
         sender_address,
@@ -748,7 +748,7 @@ pub fn to_internal_deploy_v3_tx(
         AccountTransaction::DeployAccount(a) => a.contract_address,
         _ => unreachable!(),
     };
-    let signature = Some(tx.signature.0.iter().copied().collect());
+    let signature = Some(tx.signature.0.to_vec());
     let entry_point_selector = Some(Felt252::ZERO);
     let calldata: Vec<_> = tx.constructor_calldata.0.iter().copied().collect();
 
@@ -760,7 +760,7 @@ pub fn to_internal_deploy_v3_tx(
     let fee_data_availability_mode = Felt252::from(tx.fee_data_availability_mode as u64);
     let resource_bounds = &tx.resource_bounds;
 
-    let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.iter().copied().collect();
+    let paymaster_data: Vec<Felt252> = tx.paymaster_data.0.to_vec();
     let contract_address_salt = tx.contract_address_salt.0;
     let class_hash = tx.class_hash.0;
 

--- a/tests/integration/deploy_txn_tests.rs
+++ b/tests/integration/deploy_txn_tests.rs
@@ -4,11 +4,11 @@ use blockifier::test_utils::deploy_account::deploy_account_tx;
 use blockifier::test_utils::{NonceManager, BALANCE};
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::test_utils::max_fee;
+use cairo_vm::Felt252;
 use rstest::{fixture, rstest};
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress, PatriciaKey};
-use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::transaction::{Calldata, ContractAddressSalt, Fee, TransactionVersion};
-use starknet_api::{class_hash, contract_address, patricia_key, stark_felt};
+use starknet_api::{class_hash, contract_address, felt, patricia_key};
 
 use crate::common::block_context;
 use crate::common::blockifier_contracts::{load_cairo0_feature_contract, load_cairo1_feature_contract};
@@ -19,7 +19,7 @@ use crate::common::transaction_utils::execute_txs_and_run_os;
 struct DeployArgs {
     contract_address_salt: ContractAddressSalt,
     class_hash: ClassHash,
-    constructor_calldata: Vec<StarkFelt>,
+    constructor_calldata: Vec<Felt252>,
     deployer_address: ContractAddress,
 }
 
@@ -44,7 +44,7 @@ pub async fn initial_state_for_deploy_v1(
     let deploy_args = DeployArgs {
         contract_address_salt: ContractAddressSalt::default(),
         class_hash,
-        constructor_calldata: vec![stark_felt!(0u128), stark_felt!(101u128)],
+        constructor_calldata: vec![felt!(0u128), felt!(101u128)],
         // The deployer address is always be 0 for deploy v1
         deployer_address: contract_address!("0x0"),
     };
@@ -127,7 +127,7 @@ pub async fn initial_state_for_deploy_v3(
     let deploy_args = DeployArgs {
         contract_address_salt: ContractAddressSalt::default(),
         class_hash,
-        constructor_calldata: vec![stark_felt!(0u128), stark_felt!(101u128)],
+        constructor_calldata: vec![felt!(0u128), felt!(101u128)],
         // The deployer address is always be 0 for deploy v1
         deployer_address: contract_address!("0x0"),
     };

--- a/tests/integration/l1_handler_txn_tests.rs
+++ b/tests/integration/l1_handler_txn_tests.rs
@@ -7,8 +7,7 @@ use blockifier::transaction::transactions::L1HandlerTransaction;
 use futures::Future;
 use rstest::{fixture, rstest};
 use starknet_api::core::{ContractAddress, EntryPointSelector};
-use starknet_api::hash::StarkFelt;
-use starknet_api::stark_felt;
+use starknet_api::felt;
 use starknet_api::transaction::{Calldata, Fee, TransactionVersion};
 
 use crate::common::state::{init_logging, initial_state_cairo0, initial_state_syscalls, StarknetTestState};
@@ -49,7 +48,7 @@ async fn l1_handler<F>(
 
     let tx_version = TransactionVersion::ZERO;
 
-    let calldata_args = vec![stark_felt!(1234_u16), stark_felt!(42_u16)];
+    let calldata_args = vec![felt!(1234_u16), felt!(42_u16)];
     let l1_tx = L1HandlerTransaction {
         paid_fee_on_l1: max_fee,
         tx: starknet_api::transaction::L1HandlerTransaction {

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -3,9 +3,9 @@ use blockifier::invoke_tx_args;
 use blockifier::test_utils::{create_calldata, NonceManager};
 use blockifier::transaction::test_utils;
 use blockifier::transaction::test_utils::max_fee;
+use cairo_vm::Felt252;
 use rstest::rstest;
-use starknet_api::hash::StarkFelt;
-use starknet_api::stark_felt;
+use starknet_api::felt;
 use starknet_api::transaction::{Fee, TransactionVersion};
 use starknet_os::config::STORED_BLOCK_HASH_BUFFER;
 
@@ -35,7 +35,7 @@ async fn return_result_cairo0_account(
         calldata: create_calldata(
             contract_address,
             "return_result",
-            &[stark_felt!(123_u8)],
+            &[felt!(123_u8)],
         ),
         version: tx_version,
         nonce: nonce_manager.next(sender_address),
@@ -75,7 +75,7 @@ async fn return_result_cairo1_account(
         calldata: create_calldata(
             contract_address,
             "return_result",
-            &[stark_felt!(2_u8)],
+            &[felt!(2_u8)],
         ),
         version: tx_version,
         nonce: nonce_manager.next(sender_address),
@@ -111,12 +111,12 @@ async fn syscalls_cairo1(
     let contract_address = initial_state.deployed_cairo1_contracts.get("test_contract").unwrap().address;
 
     // test_emit_event
-    let keys = vec![stark_felt!(2019_u16), stark_felt!(2020_u16)];
-    let data = vec![stark_felt!(2021_u16), stark_felt!(2022_u16), stark_felt!(2023_u16)];
+    let keys = vec![felt!(2019_u16), felt!(2020_u16)];
+    let data = vec![felt!(2021_u16), felt!(2022_u16), felt!(2023_u16)];
     let entrypoint_args = &[
-        vec![stark_felt!(u128::try_from(keys.len()).unwrap())],
+        vec![felt!(u128::try_from(keys.len()).unwrap())],
         keys,
-        vec![stark_felt!(u128::try_from(data.len()).unwrap())],
+        vec![felt!(u128::try_from(data.len()).unwrap())],
         data,
     ]
     .concat();
@@ -133,7 +133,7 @@ async fn syscalls_cairo1(
     let test_storage_read_write_tx = test_utils::account_invoke_tx(invoke_tx_args! {
         max_fee,
         sender_address: sender_address,
-        calldata: create_calldata(contract_address, "test_storage_read_write", &[StarkFelt::TWO, StarkFelt::ONE]),
+        calldata: create_calldata(contract_address, "test_storage_read_write", &[Felt252::TWO, Felt252::ONE]),
         version: tx_version,
         nonce: nonce_manager.next(sender_address),
     });
@@ -142,15 +142,15 @@ async fn syscalls_cairo1(
     let test_get_block_hash_tx = test_utils::account_invoke_tx(invoke_tx_args! {
         max_fee,
         sender_address: sender_address,
-        calldata: create_calldata(contract_address, "test_get_block_hash", &[stark_felt!(block_context.block_info().block_number.0 - STORED_BLOCK_HASH_BUFFER)]),
+        calldata: create_calldata(contract_address, "test_get_block_hash", &[felt!(block_context.block_info().block_number.0 - STORED_BLOCK_HASH_BUFFER)]),
         version: tx_version,
         nonce: nonce_manager.next(sender_address),
     });
 
     // test_send_message_to_l1
-    let to_address = stark_felt!(1234_u16);
-    let payload = vec![stark_felt!(2019_u16), stark_felt!(2020_u16), stark_felt!(2021_u16)];
-    let entrypoint_args = &[vec![to_address, stark_felt!(payload.len() as u64)], payload].concat();
+    let to_address = felt!(1234_u16);
+    let payload = vec![felt!(2019_u16), felt!(2020_u16), felt!(2021_u16)];
+    let entrypoint_args = &[vec![to_address, felt!(payload.len() as u64)], payload].concat();
 
     let test_send_message_to_l1_tx = test_utils::account_invoke_tx(invoke_tx_args! {
         max_fee,
@@ -165,11 +165,11 @@ async fn syscalls_cairo1(
         initial_state.deployed_cairo1_contracts.get("test_contract").unwrap().declaration.class_hash.0;
     let entrypoint_args = &[
         test_contract_class_hash, // class hash
-        stark_felt!(255_u8),      // contract_address_salt
-        stark_felt!(2_u8),        // calldata length
-        stark_felt!(3_u8),        // calldata: arg1
-        stark_felt!(3_u8),        // calldata: arg2
-        stark_felt!(0_u8),        // deploy_from_zero
+        felt!(255_u8),            // contract_address_salt
+        felt!(2_u8),              // calldata length
+        felt!(3_u8),              // calldata: arg1
+        felt!(3_u8),              // calldata: arg2
+        felt!(0_u8),              // deploy_from_zero
     ];
 
     let test_deploy_tx = test_utils::account_invoke_tx(invoke_tx_args! {

--- a/tests/integration/run_os.rs
+++ b/tests/integration/run_os.rs
@@ -30,7 +30,6 @@ use starknet_os::io::output::StarknetOsOutput;
 use starknet_os::starknet::business_logic::fact_state::state::SharedState;
 use starknet_os::storage::dict_storage::DictStorage;
 use starknet_os::storage::storage_utils::unpack_blockifier_state_async;
-use starknet_os::utils::felt_api2vm;
 
 use crate::common::block_context;
 use crate::common::blockifier_contracts::load_cairo0_feature_contract;
@@ -524,19 +523,19 @@ fn validate_os_output(os_output: &StarknetOsOutput, tx_contracts: &[ContractAddr
     let output_messages_to_l1 = &os_output.messages_to_l1;
 
     let expected_messages_to_l1 = [
-        felt_api2vm(*tx_contracts[0].0.key()), // from address
-        85.into(),                             // to address
-        2.into(),                              // PAYLOAD_SIZE
-        12.into(),                             // PAYLOAD_1
-        34.into(),                             // PAYLOAD_1
+        *tx_contracts[0].0.key(), // from address
+        85.into(),                // to address
+        2.into(),                 // PAYLOAD_SIZE
+        12.into(),                // PAYLOAD_1
+        34.into(),                // PAYLOAD_1
     ];
     assert_eq!(output_messages_to_l1, &expected_messages_to_l1);
 
     let expected_messages_to_l2 = [
-        85.into(),                             // from address
-        felt_api2vm(*tx_contracts[3].0.key()), // the delegate_proxy_address
-        0.into(),                              // Nonce
-        felt_api2vm(selector_from_name("deposit").0),
+        85.into(),                // from address
+        *tx_contracts[3].0.key(), // the delegate_proxy_address
+        0.into(),                 // Nonce
+        selector_from_name("deposit").0,
         1u64.into(), // PAYLOAD_SIZE
         2u64.into(), // PAYLOAD_1
     ];

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -6,8 +6,7 @@ use blockifier::transaction::test_utils;
 use blockifier::transaction::test_utils::max_fee;
 use blockifier::transaction::transaction_execution::Transaction;
 use rstest::rstest;
-use starknet_api::hash::StarkFelt;
-use starknet_api::stark_felt;
+use starknet_api::felt;
 use starknet_api::transaction::{Fee, TransactionVersion};
 
 use crate::common::block_context;
@@ -38,7 +37,7 @@ async fn test_syscall_library_call_cairo1(
     let test_contract_class_hash = test_contract.declaration.class_hash;
     let selector_felt = selector_from_name("recurse");
 
-    let return_result_calldata = vec![stark_felt!(1u128), stark_felt!(42u128)];
+    let return_result_calldata = vec![felt!(1u128), felt!(42u128)];
 
     let entrypoint_args = &[vec![test_contract_class_hash.0], vec![selector_felt.0], return_result_calldata].concat();
 


### PR DESCRIPTION
Problem: some contracts on Sepolia are built with Sierra 1.6, which is
not supported by the version of the CASM compiler we use. But bumping
the version of the compiler requires bumping cairo-vm and Blockifier as
well.

Solution: bump everything! We now use:
* cairo-vm 1.0.1
* cairo-lang 2.7.1
* blockifier 0.8.0-rc.2

With this, we can now compile any contract on Sepolia.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
