### PR TITLE
Feature: handle all tx traces

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -13,6 +13,7 @@ use rpc_utils::{get_class_proofs, get_storage_proofs};
 use starknet::core::types::{BlockId, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider, ProviderError, Url};
+use starknet_api::StarknetApiError;
 use starknet_os::config::{StarknetGeneralConfig, StarknetOsConfig, STORED_BLOCK_HASH_BUFFER};
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::crypto::poseidon::PoseidonHash;
@@ -57,6 +58,8 @@ pub enum ProveBlockError {
     SnOsError(#[from] SnOsError),
     #[error("Legacy class decompression Error: {0}")]
     LegacyContractDecompressionError(#[from] LegacyContractDecompressionError),
+    #[error("Starknet API Error: {0}")]
+    StarknetApiError(StarknetApiError),
 }
 
 fn compute_class_commitment(

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -163,7 +163,7 @@ pub async fn prove_block(
     let mut blockifier_state = CachedState::new(blockifier_state_reader);
     let mut txs = Vec::new();
     for tx in block_with_txs.transactions.iter() {
-        let transaction = starknet_rs_to_blockifier(tx, &provider, block_number).await.unwrap();
+        let transaction = starknet_rs_to_blockifier(tx, &provider, block_number).await?;
         txs.push(transaction);
     }
     let tx_execution_infos = reexecute_transactions_with_blockifier(&mut blockifier_state, &block_context, txs)?;

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -166,7 +166,8 @@ pub async fn prove_block(
     let mut blockifier_state = CachedState::new(blockifier_state_reader);
     let mut txs = Vec::new();
     for tx in block_with_txs.transactions.iter() {
-        let transaction = starknet_rs_to_blockifier(tx, &provider, block_number).await?;
+        let transaction =
+            starknet_rs_to_blockifier(tx, &provider, block_number).await.map_err(ProveBlockError::from)?;
         txs.push(transaction);
     }
     let tx_execution_infos = reexecute_transactions_with_blockifier(&mut blockifier_state, &block_context, txs)?;

--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -34,5 +34,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let result = prove_block::prove_block(block_number, &args.rpc_provider, layout).await;
     let (_pie, _output) = result.map_err(debug_prove_error).expect("Block could not be proven");
+
     Ok(())
 }

--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use cairo_vm::Felt252;
-use starknet::core::types::{BlockId, MaybePendingStateUpdate, StateDiff};
+use starknet::core::types::{BlockId, MaybePendingStateUpdate, StateDiff, TransactionTraceWithHash};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 use starknet_api::core::ContractAddress;
@@ -30,7 +30,7 @@ pub(crate) async fn get_formatted_state_update(
     provider: &JsonRpcClient<HttpTransport>,
     previous_block_id: BlockId,
     block_id: BlockId,
-) -> Result<FormattedStateUpdate, ProveBlockError> {
+) -> Result<(FormattedStateUpdate, Vec<TransactionTraceWithHash>), ProveBlockError> {
     let state_update = match provider.get_state_update(block_id).await.expect("Failed to get state update") {
         MaybePendingStateUpdate::Update(update) => update,
         MaybePendingStateUpdate::PendingUpdate(_) => {
@@ -56,7 +56,10 @@ pub(crate) async fn get_formatted_state_update(
         )
         .await?;
 
-    Ok(FormattedStateUpdate { class_hash_to_compiled_class_hash, compiled_classes: compiled_contract_classes })
+    Ok((
+        FormattedStateUpdate { class_hash_to_compiled_class_hash, compiled_classes: compiled_contract_classes },
+        traces,
+    ))
 }
 
 /// Retrieves the compiled class associated to the contract address at a specific block

--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -18,13 +18,8 @@ pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceW
                 if let Some(inv) = &invoke_trace.validate_invocation {
                     process_function_invocations(inv, &mut contracts_subcalled);
                 }
-                match &invoke_trace.execute_invocation {
-                    ExecuteInvocation::Success(inv) => {
-                        process_function_invocations(inv, &mut contracts_subcalled);
-                    }
-                    ExecuteInvocation::Reverted(_) => {
-                        // Nothing to do
-                    }
+                if let ExecuteInvocation::Success(inv) = &invoke_trace.execute_invocation {
+                    process_function_invocations(inv, &mut contracts_subcalled);
                 }
                 if let Some(inv) = &invoke_trace.fee_transfer_invocation {
                     process_function_invocations(inv, &mut contracts_subcalled);

--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -30,7 +30,29 @@ pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceW
                     process_function_invocations(inv, &mut contracts_subcalled);
                 }
             }
-            _ => unimplemented!("process other txn traces"),
+
+            TransactionTrace::DeployAccount(deploy_trace) => {
+                if let Some(inv) = &deploy_trace.validate_invocation {
+                    process_function_invocations(inv, &mut contracts_subcalled);
+                }
+                if let Some(inv) = &deploy_trace.fee_transfer_invocation {
+                    process_function_invocations(inv, &mut contracts_subcalled);
+                }
+                process_function_invocations(&deploy_trace.constructor_invocation, &mut contracts_subcalled);
+            }
+
+            TransactionTrace::L1Handler(l1handler_trace) => {
+                process_function_invocations(&l1handler_trace.function_invocation, &mut contracts_subcalled);
+            }
+
+            TransactionTrace::Declare(declare_trace) => {
+                if let Some(inv) = &declare_trace.validate_invocation {
+                    process_function_invocations(inv, &mut contracts_subcalled);
+                }
+                if let Some(inv) = &declare_trace.fee_transfer_invocation {
+                    process_function_invocations(inv, &mut contracts_subcalled);
+                }
+            }
         }
     }
     contracts_subcalled

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -18,6 +18,7 @@ use rstest::rstest;
 #[case::failing_assert_on_versioned_constants_2(124533)]
 #[case::fix_diff_assert_values_in_contract_subcall(87019)]
 #[case::invoke_with_replace_class(90000)]
+#[case::l1_handler(98000)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -41,7 +41,7 @@ fn da_mode_core_to_api(
 pub fn starknet_rs_to_blockifier(
     sn_core_tx: &starknet::core::types::Transaction,
 ) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
-    let blockifier_tx: AccountTransaction = match sn_core_tx {
+    let blockifier_tx = match sn_core_tx {
         Transaction::Invoke(tx) => {
             let (tx_hash, api_tx) = match tx {
                 InvokeTransaction::V0(tx) => {
@@ -90,9 +90,13 @@ pub fn starknet_rs_to_blockifier(
                     (tx_hash, api_tx)
                 }
             };
+
             let invoke =
                 blockifier::transaction::transactions::InvokeTransaction { tx: api_tx, tx_hash, only_query: false };
-            AccountTransaction::Invoke(invoke)
+
+            blockifier::transaction::transaction_execution::Transaction::AccountTransaction(AccountTransaction::Invoke(
+                invoke,
+            ))
         }
         Transaction::DeployAccount(_tx) => {
             unimplemented!("starknet_rs_tx_to_blockifier() with Deploy txn");
@@ -106,5 +110,5 @@ pub fn starknet_rs_to_blockifier(
         _ => unimplemented!(),
     };
 
-    Ok(blockifier::transaction::transaction_execution::Transaction::AccountTransaction(blockifier_tx))
+    Ok(blockifier_tx)
 }

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -54,7 +54,7 @@ fn invoke_v1_to_blockifier(
         max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
         signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
         nonce: starknet_api::core::Nonce(tx.nonce),
-        sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address).unwrap()),
+        sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
         calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
     });
 
@@ -73,7 +73,7 @@ fn invoke_v3_to_blockifier(
         tip: starknet_api::transaction::Tip(tx.tip),
         signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
         nonce: starknet_api::core::Nonce(tx.nonce),
-        sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address).unwrap()),
+        sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
         calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
         nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
         fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
@@ -267,7 +267,7 @@ fn l1_handler_to_blockifier(
     let api_tx = starknet_api::transaction::L1HandlerTransaction {
         version: starknet_api::transaction::TransactionVersion(tx.version),
         nonce: starknet_api::core::Nonce(Felt::from(tx.nonce)),
-        contract_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.contract_address).unwrap()),
+        contract_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.contract_address)?),
         entry_point_selector: starknet_api::core::EntryPointSelector(tx.entry_point_selector),
         calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.clone())),
     };

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -2,10 +2,17 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::Arc;
 
+use blockifier::execution::contract_class::ClassInfo;
 use blockifier::transaction::account_transaction::AccountTransaction;
-use starknet::core::types::{InvokeTransaction, ResourceBoundsMapping, Transaction};
-use starknet_api::core::PatriciaKey;
-use starknet_api::transaction::TransactionHash;
+use starknet::core::types::{
+    BlockId, DeclareTransaction, DeployAccountTransaction, InvokeTransaction, ResourceBoundsMapping, Transaction,
+};
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::{JsonRpcClient, Provider};
+use starknet_api::core::{calculate_contract_address, ContractAddress, PatriciaKey};
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::{Fee, TransactionHash};
+use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 
 pub fn resource_bounds_core_to_api(
     resource_bounds: &ResourceBoundsMapping,
@@ -38,8 +45,10 @@ fn da_mode_core_to_api(
 }
 
 /// Maps starknet-core transactions to Blockifier-compatible types.
-pub fn starknet_rs_to_blockifier(
+pub async fn starknet_rs_to_blockifier(
     sn_core_tx: &starknet::core::types::Transaction,
+    provider: &JsonRpcClient<HttpTransport>,
+    block_number: u64,
 ) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
     let blockifier_tx = match sn_core_tx {
         Transaction::Invoke(tx) => {
@@ -173,8 +182,106 @@ pub fn starknet_rs_to_blockifier(
                 AccountTransaction::DeployAccount(deploy_account),
             )
         }
-        Transaction::Declare(_tx) => {
-            unimplemented!("starknet_rs_tx_to_blockifier() with Declare txn");
+        Transaction::Declare(tx) => {
+            let (tx_hash, api_tx, class_hash) = match tx {
+                DeclareTransaction::V1(tx) => {
+                    let tx_hash = TransactionHash(felt_vm2api(tx.transaction_hash));
+                    let api_tx = starknet_api::transaction::DeclareTransaction::V1(
+                        starknet_api::transaction::DeclareTransactionV0V1 {
+                            max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                            signature: starknet_api::transaction::TransactionSignature(
+                                tx.signature.clone().into_iter().map(felt_vm2api).collect(),
+                            ),
+                            nonce: starknet_api::core::Nonce(felt_vm2api(tx.nonce)),
+                            class_hash: starknet_api::core::ClassHash(felt_vm2api(tx.class_hash)),
+                            sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(felt_vm2api(
+                                tx.sender_address,
+                            ))?),
+                        },
+                    );
+
+                    (tx_hash, api_tx, tx.class_hash)
+                }
+                DeclareTransaction::V2(tx) => {
+                    let tx_hash = TransactionHash(felt_vm2api(tx.transaction_hash));
+                    let api_tx = starknet_api::transaction::DeclareTransaction::V2(
+                        starknet_api::transaction::DeclareTransactionV2 {
+                            max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                            signature: starknet_api::transaction::TransactionSignature(
+                                tx.signature.clone().into_iter().map(felt_vm2api).collect(),
+                            ),
+                            nonce: starknet_api::core::Nonce(felt_vm2api(tx.nonce)),
+                            class_hash: starknet_api::core::ClassHash(felt_vm2api(tx.class_hash)),
+                            compiled_class_hash: starknet_api::core::CompiledClassHash(felt_vm2api(
+                                tx.compiled_class_hash,
+                            )),
+                            sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(felt_vm2api(
+                                tx.sender_address,
+                            ))?),
+                        },
+                    );
+
+                    (tx_hash, api_tx, tx.class_hash)
+                }
+                DeclareTransaction::V3(tx) => {
+                    let tx_hash = TransactionHash(felt_vm2api(tx.transaction_hash));
+                    let api_tx = starknet_api::transaction::DeclareTransaction::V3(
+                        starknet_api::transaction::DeclareTransactionV3 {
+                            resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
+                            tip: starknet_api::transaction::Tip(tx.tip),
+                            signature: starknet_api::transaction::TransactionSignature(
+                                tx.signature.clone().into_iter().map(felt_vm2api).collect(),
+                            ),
+                            nonce: starknet_api::core::Nonce(felt_vm2api(tx.nonce)),
+                            class_hash: starknet_api::core::ClassHash(felt_vm2api(tx.class_hash)),
+                            compiled_class_hash: starknet_api::core::CompiledClassHash(felt_vm2api(
+                                tx.compiled_class_hash,
+                            )),
+                            sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(felt_vm2api(
+                                tx.sender_address,
+                            ))?),
+                            nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
+                            fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
+                            paymaster_data: starknet_api::transaction::PaymasterData(
+                                tx.paymaster_data.iter().copied().map(felt_vm2api).collect(),
+                            ),
+                            account_deployment_data: starknet_api::transaction::AccountDeploymentData(
+                                tx.account_deployment_data.iter().copied().map(felt_vm2api).collect(),
+                            ),
+                        },
+                    );
+
+                    (tx_hash, api_tx, tx.class_hash)
+                }
+
+                _ => unimplemented!("DeclareTransaction V0 not supported"),
+            };
+
+            // TODO: improve this to avoid retrieving this twice. Already done in main.rs from prove_block
+            let starknet_contract_class = provider.get_class(BlockId::Number(block_number), class_hash).await?;
+            let generic_sierra_cc = match starknet_contract_class {
+                starknet::core::types::ContractClass::Sierra(flattened_sierra_cc) => {
+                    GenericSierraContractClass::from(flattened_sierra_cc)
+                }
+                starknet::core::types::ContractClass::Legacy(_) => {
+                    unimplemented!("Fixme: Support legacy contract class")
+                }
+            };
+
+            let flattened_sierra = generic_sierra_cc.clone().to_starknet_core_contract_class()?;
+            let contract_class = generic_sierra_cc.compile()?.get_blockifier_contract_class()?.clone();
+
+            let class_info = ClassInfo::new(
+                &contract_class.into(),
+                flattened_sierra.sierra_program.len(),
+                flattened_sierra.abi.len(),
+            )?;
+
+            let declare = blockifier::transaction::transactions::DeclareTransaction::new(api_tx, tx_hash, class_info)?;
+
+            blockifier::transaction::transaction_execution::Transaction::AccountTransaction(
+                AccountTransaction::Declare(declare),
+            )
         }
         Transaction::L1Handler(_tx) => {
             unimplemented!("starknet_rs_tx_to_blockifier() with L1Handler txn");

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::Arc;
 
-use blockifier::execution::contract_class::ClassInfo;
+use blockifier::execution::contract_class::{self, ClassInfo};
 use blockifier::transaction::account_transaction::AccountTransaction;
 use starknet::core::types::{
-    BlockId, DeclareTransaction, DeployAccountTransaction, Felt, InvokeTransaction, ResourceBoundsMapping, Transaction,
+    BlockId, DeclareTransaction, DeployAccountTransaction, Felt, InvokeTransaction, L1HandlerTransaction,
+    ResourceBoundsMapping, Transaction,
 };
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
@@ -43,6 +44,224 @@ fn da_mode_core_to_api(
     }
 }
 
+fn invoke_txn_to_blockifier(
+    tx: &InvokeTransaction,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
+    let tx_hash = TransactionHash(*tx.transaction_hash());
+
+    let api_tx = match tx {
+        InvokeTransaction::V0(_tx) => {
+            unimplemented!("starknet_rs_to_blockifier with InvokeTransaction::V0");
+        }
+        InvokeTransaction::V1(tx) => {
+            let api_tx =
+                starknet_api::transaction::InvokeTransaction::V1(starknet_api::transaction::InvokeTransactionV1 {
+                    max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    sender_address: starknet_api::core::ContractAddress(
+                        PatriciaKey::try_from(tx.sender_address).unwrap(),
+                    ),
+                    calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
+                });
+            api_tx
+        }
+        InvokeTransaction::V3(tx) => {
+            let api_tx =
+                starknet_api::transaction::InvokeTransaction::V3(starknet_api::transaction::InvokeTransactionV3 {
+                    resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
+                    tip: starknet_api::transaction::Tip(tx.tip),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    sender_address: starknet_api::core::ContractAddress(
+                        PatriciaKey::try_from(tx.sender_address).unwrap(),
+                    ),
+                    calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
+                    nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
+                    fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
+                    paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.to_vec()),
+                    account_deployment_data: starknet_api::transaction::AccountDeploymentData(
+                        tx.account_deployment_data.to_vec(),
+                    ),
+                });
+            api_tx
+        }
+    };
+
+    let invoke = blockifier::transaction::transactions::InvokeTransaction { tx: api_tx, tx_hash, only_query: false };
+    Ok(blockifier::transaction::transaction_execution::Transaction::AccountTransaction(AccountTransaction::Invoke(
+        invoke,
+    )))
+}
+
+fn deploy_account_to_blockifier(
+    tx: &DeployAccountTransaction,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
+    let tx_hash = TransactionHash(*tx.transaction_hash());
+
+    let api_tx = match tx {
+        DeployAccountTransaction::V1(tx) => {
+            let api_tx = starknet_api::transaction::DeployAccountTransaction::V1(
+                starknet_api::transaction::DeployAccountTransactionV1 {
+                    max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                    contract_address_salt: starknet_api::transaction::ContractAddressSalt(tx.contract_address_salt),
+                    constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
+                        tx.constructor_calldata.clone(),
+                    )),
+                },
+            );
+            api_tx
+        }
+        DeployAccountTransaction::V3(tx) => {
+            let api_tx = starknet_api::transaction::DeployAccountTransaction::V3(
+                starknet_api::transaction::DeployAccountTransactionV3 {
+                    resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
+                    tip: starknet_api::transaction::Tip(tx.tip),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                    contract_address_salt: starknet_api::transaction::ContractAddressSalt(tx.contract_address_salt),
+                    constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
+                        tx.constructor_calldata.clone(),
+                    )),
+                    nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
+                    fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
+                    paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.clone()),
+                },
+            );
+            api_tx
+        }
+    };
+
+    let contract_address = calculate_contract_address(
+        api_tx.contract_address_salt(),
+        api_tx.class_hash(),
+        &api_tx.constructor_calldata(),
+        // When the contract is deployed via a DEPLOY_ACCOUNT transaction: 0
+        ContractAddress::from(0_u8),
+    )?;
+
+    let deploy_account = blockifier::transaction::transactions::DeployAccountTransaction {
+        tx: api_tx,
+        tx_hash,
+        contract_address,
+        only_query: false,
+    };
+
+    Ok(blockifier::transaction::transaction_execution::Transaction::AccountTransaction(
+        AccountTransaction::DeployAccount(deploy_account),
+    ))
+}
+
+async fn create_class_info(
+    class_hash: Felt,
+    provider: &JsonRpcClient<HttpTransport>,
+    block_number: u64,
+) -> Result<ClassInfo, Box<dyn Error>> {
+    // TODO: improve this to avoid retrieving this twice. Already done in main.rs from prove_block
+    let starknet_contract_class = provider.get_class(BlockId::Number(block_number), class_hash).await?;
+    let generic_sierra_cc = match starknet_contract_class {
+        starknet::core::types::ContractClass::Sierra(flattened_sierra_cc) => {
+            GenericSierraContractClass::from(flattened_sierra_cc)
+        }
+        starknet::core::types::ContractClass::Legacy(_) => {
+            unimplemented!("Fixme: Support legacy contract class")
+        }
+    };
+
+    let flattened_sierra = generic_sierra_cc.clone().to_starknet_core_contract_class()?;
+    let contract_class = generic_sierra_cc.compile()?.to_blockifier_contract_class()?;
+
+    Ok(ClassInfo::new(&contract_class.into(), flattened_sierra.sierra_program.len(), flattened_sierra.abi.len())?)
+}
+
+async fn declare_to_blockifier(
+    tx: &DeclareTransaction,
+    provider: &JsonRpcClient<HttpTransport>,
+    block_number: u64,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
+    let tx_hash = TransactionHash(*tx.transaction_hash());
+
+    let (api_tx, class_hash) = match tx {
+        DeclareTransaction::V1(tx) => {
+            let api_tx =
+                starknet_api::transaction::DeclareTransaction::V1(starknet_api::transaction::DeclareTransactionV0V1 {
+                    max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                    sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
+                });
+
+            (api_tx, tx.class_hash)
+        }
+        DeclareTransaction::V2(tx) => {
+            let api_tx =
+                starknet_api::transaction::DeclareTransaction::V2(starknet_api::transaction::DeclareTransactionV2 {
+                    max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                    compiled_class_hash: starknet_api::core::CompiledClassHash(tx.compiled_class_hash),
+                    sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
+                });
+
+            (api_tx, tx.class_hash)
+        }
+        DeclareTransaction::V3(tx) => {
+            let api_tx =
+                starknet_api::transaction::DeclareTransaction::V3(starknet_api::transaction::DeclareTransactionV3 {
+                    resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
+                    tip: starknet_api::transaction::Tip(tx.tip),
+                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                    nonce: starknet_api::core::Nonce(tx.nonce),
+                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                    compiled_class_hash: starknet_api::core::CompiledClassHash(tx.compiled_class_hash),
+                    sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
+                    nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
+                    fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
+                    paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.clone()),
+                    account_deployment_data: starknet_api::transaction::AccountDeploymentData(
+                        tx.account_deployment_data.clone(),
+                    ),
+                });
+
+            (api_tx, tx.class_hash)
+        }
+        _ => unimplemented!("DeclareTransaction V0 not supported"),
+    };
+
+    let class_info = create_class_info(class_hash, provider, block_number).await?;
+    let declare = blockifier::transaction::transactions::DeclareTransaction::new(api_tx, tx_hash, class_info)?;
+
+    Ok(blockifier::transaction::transaction_execution::Transaction::AccountTransaction(AccountTransaction::Declare(
+        declare,
+    )))
+}
+
+fn l1_handler_to_blockifier(
+    tx: &L1HandlerTransaction,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
+    let tx_hash = TransactionHash(tx.transaction_hash);
+    let api_tx = starknet_api::transaction::L1HandlerTransaction {
+        version: starknet_api::transaction::TransactionVersion(tx.version),
+        nonce: starknet_api::core::Nonce(Felt::from(tx.nonce)),
+        contract_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.contract_address).unwrap()),
+        entry_point_selector: starknet_api::core::EntryPointSelector(tx.entry_point_selector),
+        calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.clone())),
+    };
+
+    // Fees are 0 for L1Handler transactions
+    let fee = Fee(0);
+    let l1_handler =
+        blockifier::transaction::transactions::L1HandlerTransaction { tx: api_tx, tx_hash, paid_fee_on_l1: fee };
+
+    Ok(blockifier::transaction::transaction_execution::Transaction::L1HandlerTransaction(l1_handler))
+}
+
 /// Maps starknet-core transactions to Blockifier-compatible types.
 pub async fn starknet_rs_to_blockifier(
     sn_core_tx: &starknet::core::types::Transaction,
@@ -50,242 +269,10 @@ pub async fn starknet_rs_to_blockifier(
     block_number: u64,
 ) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
     let blockifier_tx = match sn_core_tx {
-        Transaction::Invoke(tx) => {
-            let (tx_hash, api_tx) = match tx {
-                InvokeTransaction::V0(tx) => {
-                    let _tx_hash = TransactionHash(tx.transaction_hash);
-                    unimplemented!("starknet_rs_to_blockifier with InvokeTransaction::V0");
-                }
-                InvokeTransaction::V1(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::InvokeTransaction::V1(
-                        starknet_api::transaction::InvokeTransactionV1 {
-                            max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
-                            signature: starknet_api::transaction::TransactionSignature(
-                                tx.signature.clone().into_iter().collect(),
-                            ),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            sender_address: starknet_api::core::ContractAddress(
-                                PatriciaKey::try_from(tx.sender_address).unwrap(),
-                            ),
-                            calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.calldata.clone().into_iter().collect(),
-                            )),
-                        },
-                    );
-                    (tx_hash, api_tx)
-                }
-                InvokeTransaction::V3(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::InvokeTransaction::V3(
-                        starknet_api::transaction::InvokeTransactionV3 {
-                            resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
-                            tip: starknet_api::transaction::Tip(tx.tip),
-                            signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            sender_address: starknet_api::core::ContractAddress(
-                                PatriciaKey::try_from(tx.sender_address).unwrap(),
-                            ),
-                            calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
-                            nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
-                            fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
-                            paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.to_vec()),
-                            account_deployment_data: starknet_api::transaction::AccountDeploymentData(
-                                tx.account_deployment_data.to_vec(),
-                            ),
-                        },
-                    );
-                    (tx_hash, api_tx)
-                }
-            };
-
-            let invoke =
-                blockifier::transaction::transactions::InvokeTransaction { tx: api_tx, tx_hash, only_query: false };
-
-            blockifier::transaction::transaction_execution::Transaction::AccountTransaction(AccountTransaction::Invoke(
-                invoke,
-            ))
-        }
-        Transaction::DeployAccount(tx) => {
-            let (tx_hash, api_tx, contract_address) = match tx {
-                DeployAccountTransaction::V1(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::DeployAccountTransaction::V1(
-                        starknet_api::transaction::DeployAccountTransactionV1 {
-                            max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
-                            signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                            contract_address_salt: starknet_api::transaction::ContractAddressSalt(
-                                tx.contract_address_salt,
-                            ),
-                            constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.constructor_calldata.clone(),
-                            )),
-                        },
-                    );
-                    let contract_address = calculate_contract_address(
-                        api_tx.contract_address_salt(),
-                        api_tx.class_hash(),
-                        &api_tx.constructor_calldata(),
-                        ContractAddress::from(0_u8),
-                    )?;
-
-                    (tx_hash, api_tx, contract_address)
-                }
-                DeployAccountTransaction::V3(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::DeployAccountTransaction::V3(
-                        starknet_api::transaction::DeployAccountTransactionV3 {
-                            resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
-                            tip: starknet_api::transaction::Tip(tx.tip),
-                            signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                            contract_address_salt: starknet_api::transaction::ContractAddressSalt(
-                                tx.contract_address_salt,
-                            ),
-                            constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
-                                tx.constructor_calldata.clone(),
-                            )),
-                            nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
-                            fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
-                            paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.clone()),
-                        },
-                    );
-                    let contract_address = calculate_contract_address(
-                        api_tx.contract_address_salt(),
-                        api_tx.class_hash(),
-                        &api_tx.constructor_calldata(),
-                        ContractAddress::from(0_u8),
-                    )?;
-
-                    (tx_hash, api_tx, contract_address)
-                }
-            };
-
-            let deploy_account = blockifier::transaction::transactions::DeployAccountTransaction {
-                tx: api_tx,
-                tx_hash,
-                contract_address,
-                only_query: false,
-            };
-
-            blockifier::transaction::transaction_execution::Transaction::AccountTransaction(
-                AccountTransaction::DeployAccount(deploy_account),
-            )
-        }
-        Transaction::Declare(tx) => {
-            let (tx_hash, api_tx, class_hash) = match tx {
-                DeclareTransaction::V1(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::DeclareTransaction::V1(
-                        starknet_api::transaction::DeclareTransactionV0V1 {
-                            max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
-                            signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                            sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(
-                                tx.sender_address,
-                            )?),
-                        },
-                    );
-
-                    (tx_hash, api_tx, tx.class_hash)
-                }
-                DeclareTransaction::V2(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::DeclareTransaction::V2(
-                        starknet_api::transaction::DeclareTransactionV2 {
-                            max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
-                            signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                            compiled_class_hash: starknet_api::core::CompiledClassHash(tx.compiled_class_hash),
-                            sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(
-                                tx.sender_address,
-                            )?),
-                        },
-                    );
-
-                    (tx_hash, api_tx, tx.class_hash)
-                }
-                DeclareTransaction::V3(tx) => {
-                    let tx_hash = TransactionHash(tx.transaction_hash);
-                    let api_tx = starknet_api::transaction::DeclareTransaction::V3(
-                        starknet_api::transaction::DeclareTransactionV3 {
-                            resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
-                            tip: starknet_api::transaction::Tip(tx.tip),
-                            signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                            nonce: starknet_api::core::Nonce(tx.nonce),
-                            class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                            compiled_class_hash: starknet_api::core::CompiledClassHash(tx.compiled_class_hash),
-                            sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(
-                                tx.sender_address,
-                            )?),
-                            nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
-                            fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
-                            paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.clone()),
-                            account_deployment_data: starknet_api::transaction::AccountDeploymentData(
-                                tx.account_deployment_data.clone(),
-                            ),
-                        },
-                    );
-
-                    (tx_hash, api_tx, tx.class_hash)
-                }
-
-                _ => unimplemented!("DeclareTransaction V0 not supported"),
-            };
-
-            // TODO: improve this to avoid retrieving this twice. Already done in main.rs from prove_block
-            let starknet_contract_class = provider.get_class(BlockId::Number(block_number), class_hash).await?;
-            let generic_sierra_cc = match starknet_contract_class {
-                starknet::core::types::ContractClass::Sierra(flattened_sierra_cc) => {
-                    GenericSierraContractClass::from(flattened_sierra_cc)
-                }
-                starknet::core::types::ContractClass::Legacy(_) => {
-                    unimplemented!("Fixme: Support legacy contract class")
-                }
-            };
-
-            let flattened_sierra = generic_sierra_cc.clone().to_starknet_core_contract_class()?;
-            let contract_class = generic_sierra_cc.compile()?.get_blockifier_contract_class()?.clone();
-
-            let class_info = ClassInfo::new(
-                &contract_class.into(),
-                flattened_sierra.sierra_program.len(),
-                flattened_sierra.abi.len(),
-            )?;
-
-            let declare = blockifier::transaction::transactions::DeclareTransaction::new(api_tx, tx_hash, class_info)?;
-
-            blockifier::transaction::transaction_execution::Transaction::AccountTransaction(
-                AccountTransaction::Declare(declare),
-            )
-        }
-        Transaction::L1Handler(tx) => {
-            let tx_hash = TransactionHash(tx.transaction_hash);
-            let api_tx = starknet_api::transaction::L1HandlerTransaction {
-                version: starknet_api::transaction::TransactionVersion(tx.version),
-                nonce: starknet_api::core::Nonce(Felt::from(tx.nonce)),
-                contract_address: starknet_api::core::ContractAddress(
-                    PatriciaKey::try_from(tx.contract_address).unwrap(),
-                ),
-                entry_point_selector: starknet_api::core::EntryPointSelector(tx.entry_point_selector),
-                calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.clone())),
-            };
-
-            // TODO: Check Fee value
-            let fee = Fee(0);
-            let l1_handler = blockifier::transaction::transactions::L1HandlerTransaction {
-                tx: api_tx,
-                tx_hash,
-                paid_fee_on_l1: fee,
-            };
-
-            blockifier::transaction::transaction_execution::Transaction::L1HandlerTransaction(l1_handler)
-        }
+        Transaction::Invoke(tx) => invoke_txn_to_blockifier(tx)?,
+        Transaction::DeployAccount(tx) => deploy_account_to_blockifier(tx)?,
+        Transaction::Declare(tx) => declare_to_blockifier(tx, provider, block_number).await?,
+        Transaction::L1Handler(tx) => l1_handler_to_blockifier(tx)?,
         _ => unimplemented!(),
     };
 

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -55,37 +55,29 @@ fn invoke_txn_to_blockifier(
             unimplemented!("starknet_rs_to_blockifier with InvokeTransaction::V0");
         }
         InvokeTransaction::V1(tx) => {
-            let api_tx =
-                starknet_api::transaction::InvokeTransaction::V1(starknet_api::transaction::InvokeTransactionV1 {
-                    max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
-                    signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
-                    nonce: starknet_api::core::Nonce(tx.nonce),
-                    sender_address: starknet_api::core::ContractAddress(
-                        PatriciaKey::try_from(tx.sender_address).unwrap(),
-                    ),
-                    calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
-                });
-            api_tx
+            starknet_api::transaction::InvokeTransaction::V1(starknet_api::transaction::InvokeTransactionV1 {
+                max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
+                nonce: starknet_api::core::Nonce(tx.nonce),
+                sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address).unwrap()),
+                calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
+            })
         }
         InvokeTransaction::V3(tx) => {
-            let api_tx =
-                starknet_api::transaction::InvokeTransaction::V3(starknet_api::transaction::InvokeTransactionV3 {
-                    resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
-                    tip: starknet_api::transaction::Tip(tx.tip),
-                    signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
-                    nonce: starknet_api::core::Nonce(tx.nonce),
-                    sender_address: starknet_api::core::ContractAddress(
-                        PatriciaKey::try_from(tx.sender_address).unwrap(),
-                    ),
-                    calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
-                    nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
-                    fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
-                    paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.to_vec()),
-                    account_deployment_data: starknet_api::transaction::AccountDeploymentData(
-                        tx.account_deployment_data.to_vec(),
-                    ),
-                });
-            api_tx
+            starknet_api::transaction::InvokeTransaction::V3(starknet_api::transaction::InvokeTransactionV3 {
+                resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
+                tip: starknet_api::transaction::Tip(tx.tip),
+                signature: starknet_api::transaction::TransactionSignature(tx.signature.to_vec()),
+                nonce: starknet_api::core::Nonce(tx.nonce),
+                sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address).unwrap()),
+                calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.to_vec())),
+                nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
+                fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
+                paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.to_vec()),
+                account_deployment_data: starknet_api::transaction::AccountDeploymentData(
+                    tx.account_deployment_data.to_vec(),
+                ),
+            })
         }
     };
 
@@ -101,40 +93,30 @@ fn deploy_account_to_blockifier(
     let tx_hash = TransactionHash(*tx.transaction_hash());
 
     let api_tx = match tx {
-        DeployAccountTransaction::V1(tx) => {
-            let api_tx = starknet_api::transaction::DeployAccountTransaction::V1(
-                starknet_api::transaction::DeployAccountTransactionV1 {
-                    max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
-                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                    nonce: starknet_api::core::Nonce(tx.nonce),
-                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                    contract_address_salt: starknet_api::transaction::ContractAddressSalt(tx.contract_address_salt),
-                    constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
-                        tx.constructor_calldata.clone(),
-                    )),
-                },
-            );
-            api_tx
-        }
-        DeployAccountTransaction::V3(tx) => {
-            let api_tx = starknet_api::transaction::DeployAccountTransaction::V3(
-                starknet_api::transaction::DeployAccountTransactionV3 {
-                    resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
-                    tip: starknet_api::transaction::Tip(tx.tip),
-                    signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-                    nonce: starknet_api::core::Nonce(tx.nonce),
-                    class_hash: starknet_api::core::ClassHash(tx.class_hash),
-                    contract_address_salt: starknet_api::transaction::ContractAddressSalt(tx.contract_address_salt),
-                    constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
-                        tx.constructor_calldata.clone(),
-                    )),
-                    nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
-                    fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
-                    paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.clone()),
-                },
-            );
-            api_tx
-        }
+        DeployAccountTransaction::V1(tx) => starknet_api::transaction::DeployAccountTransaction::V1(
+            starknet_api::transaction::DeployAccountTransactionV1 {
+                max_fee: starknet_api::transaction::Fee(tx.max_fee.to_biguint().try_into()?),
+                signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                nonce: starknet_api::core::Nonce(tx.nonce),
+                class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                contract_address_salt: starknet_api::transaction::ContractAddressSalt(tx.contract_address_salt),
+                constructor_calldata: starknet_api::transaction::Calldata(Arc::new(tx.constructor_calldata.clone())),
+            },
+        ),
+        DeployAccountTransaction::V3(tx) => starknet_api::transaction::DeployAccountTransaction::V3(
+            starknet_api::transaction::DeployAccountTransactionV3 {
+                resource_bounds: resource_bounds_core_to_api(&tx.resource_bounds),
+                tip: starknet_api::transaction::Tip(tx.tip),
+                signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+                nonce: starknet_api::core::Nonce(tx.nonce),
+                class_hash: starknet_api::core::ClassHash(tx.class_hash),
+                contract_address_salt: starknet_api::transaction::ContractAddressSalt(tx.contract_address_salt),
+                constructor_calldata: starknet_api::transaction::Calldata(Arc::new(tx.constructor_calldata.clone())),
+                nonce_data_availability_mode: da_mode_core_to_api(tx.nonce_data_availability_mode),
+                fee_data_availability_mode: da_mode_core_to_api(tx.fee_data_availability_mode),
+                paymaster_data: starknet_api::transaction::PaymasterData(tx.paymaster_data.clone()),
+            },
+        ),
     };
 
     let contract_address = calculate_contract_address(
@@ -187,7 +169,7 @@ async fn create_class_info(
         }
     };
 
-    Ok(ClassInfo::new(&blockifier_contract_class.into(), program_length, abi_length)?)
+    Ok(ClassInfo::new(&blockifier_contract_class, program_length, abi_length)?)
 }
 
 async fn declare_to_blockifier(

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -1,3 +1,4 @@
+use blockifier::blockifier::block::GasPrices;
 use blockifier::state::cached_state::CachedState;
 use blockifier::transaction::transactions::ExecutableTransaction as _;
 use blockifier::versioned_constants::StarknetVersion;
@@ -7,7 +8,7 @@ use rpc_replay::transactions::starknet_rs_to_blockifier;
 use rstest::rstest;
 use starknet::core::types::{BlockId, BlockWithTxs};
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Url};
+use starknet::providers::{JsonRpcClient, Provider, Url};
 use starknet_api::core::ChainId;
 
 #[rstest]
@@ -26,7 +27,8 @@ async fn test_replay_block() {
     let provider = JsonRpcClient::new(HttpTransport::new(
         Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
     ));
-    let state_reader = AsyncRpcStateReader::new(provider, BlockId::Number(block_with_txs.block_number - 1));
+    let block_id = BlockId::Number(block_with_txs.block_number - 1);
+    let state_reader = AsyncRpcStateReader::new(provider, block_id);
     let mut state = CachedState::from(state_reader);
 
     let block_context = build_block_context(ChainId::Sepolia, &block_with_txs, StarknetVersion::V0_13_1);
@@ -35,8 +37,18 @@ async fn test_replay_block() {
     let provider = JsonRpcClient::new(HttpTransport::new(
         Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
     ));
-    for tx in block_with_txs.transactions.iter() {
-        let blockifier_tx = starknet_rs_to_blockifier(tx, &provider, block_with_txs.block_number).await.unwrap();
+
+    let traces = provider.trace_block_transactions(block_id).await.expect("Failed to get block tx traces");
+    let gas_prices = GasPrices {
+        eth_l1_gas_price: 1u128.try_into().unwrap(), // TODO: update with 4844
+        strk_l1_gas_price: 1u128.try_into().unwrap(),
+        eth_l1_data_gas_price: 1u128.try_into().unwrap(),
+        strk_l1_data_gas_price: 1u128.try_into().unwrap(),
+    };
+
+    for (tx, trace) in block_with_txs.transactions.iter().zip(traces.iter()) {
+        let blockifier_tx =
+            starknet_rs_to_blockifier(tx, trace, &gas_prices, &provider, block_with_txs.block_number).await.unwrap();
         let tx_result = blockifier_tx.execute(&mut state, &block_context, true, true);
 
         match tx_result {

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -31,8 +31,12 @@ async fn test_replay_block() {
 
     let block_context = build_block_context(ChainId::Sepolia, &block_with_txs, StarknetVersion::V0_13_1);
 
+    // Workaround for JsonRpcClient not implementing Clone
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
+    ));
     for tx in block_with_txs.transactions.iter() {
-        let blockifier_tx = starknet_rs_to_blockifier(tx).unwrap();
+        let blockifier_tx = starknet_rs_to_blockifier(tx, &provider, block_with_txs.block_number).await.unwrap();
         let tx_result = blockifier_tx.execute(&mut state, &block_context, true, true);
 
         match tx_result {


### PR DESCRIPTION
Problem: at the moment only Invoke transactions were supported

Solution: process traces and add type conversion for reverted Invoke transaction, DeployAccount, Declare and L1Handler

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
