### PR TITLE
Fix: use correct transaction version for invoke v3

### DIFF
--- a/crates/bin/prove_block/src/types.rs
+++ b/crates/bin/prove_block/src/types.rs
@@ -60,7 +60,7 @@ fn invoke_tx_v3_to_internal_tx(tx: InvokeTransactionV3) -> InternalTransaction {
         account_deployment_data: Some(tx.account_deployment_data),
         nonce_data_availability_mode: Some(da_to_felt(tx.nonce_data_availability_mode)),
         fee_data_availability_mode: Some(da_to_felt(tx.fee_data_availability_mode)),
-        version: Some(Felt252::TWO),
+        version: Some(Felt252::THREE),
         contract_address: Some(tx.sender_address),
         entry_point_selector: Some(EXECUTE_ENTRY_POINT_FELT),
         entry_point_type: Some("EXTERNAL".to_string()),


### PR DESCRIPTION
Problem: the version for this tx type is set to 2, causing an issue with these txs where the OS fails on `tx.max_fee is None`.

Solution: set the transaction version to 3.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
