### PR TITLE
Fix: support `replace_class()` calls in invoke txs

### DIFF
--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -8,6 +8,7 @@ use rstest::rstest;
 // # * 76832: contains a reverted tx
 // # * 86507 / 124533: a failing assert that happened because we used the wrong VersionedConstants
 // # * 87019: diff assert values in contract subcall
+// # * 90000: one of the subcalls results in a call to `replace_class()`.
 #[rstest]
 #[case::small_block_with_only_invoke_txs(76793)]
 #[case::additional_basic_blocks_1(76766)]
@@ -16,6 +17,7 @@ use rstest::rstest;
 #[case::failing_assert_on_versioned_constants_1(86507)]
 #[case::failing_assert_on_versioned_constants_2(124533)]
 #[case::fix_diff_assert_values_in_contract_subcall(87019)]
+#[case::invoke_with_replace_class(90000)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {

--- a/crates/starknet-os-types/src/compiled_class.rs
+++ b/crates/starknet-os-types/src/compiled_class.rs
@@ -1,0 +1,19 @@
+use crate::casm_contract_class::GenericCasmContractClass;
+use crate::deprecated_compiled_class::GenericDeprecatedCompiledClass;
+use crate::error::ContractClassError;
+use crate::hash::GenericClassHash;
+
+/// A generic compiled class encapsulating Cairo 0 or Cairo 1 classes.
+pub enum GenericCompiledClass {
+    Cairo0(GenericDeprecatedCompiledClass),
+    Cairo1(GenericCasmContractClass),
+}
+
+impl GenericCompiledClass {
+    pub fn class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        match self {
+            GenericCompiledClass::Cairo0(deprecated_class) => deprecated_class.class_hash(),
+            GenericCompiledClass::Cairo1(casm_class) => casm_class.class_hash(),
+        }
+    }
+}

--- a/crates/starknet-os-types/src/lib.rs
+++ b/crates/starknet-os-types/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod casm_contract_class;
 pub mod chain_id;
+pub mod compiled_class;
 pub mod deprecated_compiled_class;
 pub mod error;
 pub mod hash;


### PR DESCRIPTION
Problem: some blocks fail on divergences in the global state tree caused by calls to the `replace_class()` syscall.

Solution: use the class hash in block N-1 when building the `ContractClass` objects instead of the current block, and fetch the compiled class for both blocks to build the trees properly.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
