### PR TITLE
Fix: Impl missing hints in Blob DA blocks

### DIFF
--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -483,6 +483,12 @@ pub const ENTER_CALL: &str = indoc! {r#"
 execution_helper.enter_call(
     cairo_execution_info=ids.execution_context.execution_info)"#};
 
+#[rustfmt::skip]
+pub const ENTER_CALL_WITH_EXECUTION_INFO_PTR: &str = indoc! {r#"
+    execution_helper.enter_call(
+        execution_info_ptr=ids.execution_context.execution_info.address_)"#
+};
+
 pub async fn enter_call_async<PCS>(
     vm: &mut VirtualMachine,
     exec_scopes: &mut ExecutionScopes,

--- a/crates/starknet-os/src/hints/mod.rs
+++ b/crates/starknet-os/src/hints/mod.rs
@@ -115,6 +115,7 @@ fn hints<PCS>() -> HashMap<String, HintImpl> where
     hints.insert(execution::CONTRACT_ADDRESS.into(), execution::contract_address);
     hints.insert(execution::END_TX.into(), execution::end_tx::<PCS>);
     hints.insert(execution::ENTER_CALL.into(), execution::enter_call::<PCS>);
+    hints.insert(execution::ENTER_CALL_WITH_EXECUTION_INFO_PTR.into(), execution::enter_call::<PCS>);
     hints.insert(execution::ENTER_SCOPE_DEPRECATED_SYSCALL_HANDLER.into(), execution::enter_scope_deprecated_syscall_handler::<PCS>);
     hints.insert(execution::ENTER_SCOPE_DESCEND_EDGE.into(), execution::enter_scope_descend_edge);
     hints.insert(execution::ENTER_SCOPE_LEFT_CHILD.into(), execution::enter_scope_left_child);
@@ -169,6 +170,7 @@ fn hints<PCS>() -> HashMap<String, HintImpl> where
     hints.insert(os::WRITE_FULL_OUTPUT_TO_MEM.into(), os::write_full_output_to_mem);
     hints.insert(os::SET_AP_TO_NEW_BLOCK_HASH.into(), os::set_ap_to_new_block_hash);
     hints.insert(os::SET_AP_TO_PREV_BLOCK_HASH.into(), os::set_ap_to_prev_block_hash);
+    hints.insert(os::SET_FP_PLUS_8_TO_TRANSACTIONS_LEN.into(), os::set_fp_plus_8_to_transactions_len);
     hints.insert(output::SET_STATE_UPDATES_START.into(), output::set_state_updates_start);
     hints.insert(output::SET_TREE_STRUCTURE.into(), output::set_tree_structure);
     hints.insert(patricia::ASSERT_CASE_IS_RIGHT.into(), patricia::assert_case_is_right);

--- a/crates/starknet-os/src/hints/os.rs
+++ b/crates/starknet-os/src/hints/os.rs
@@ -73,3 +73,18 @@ pub fn set_ap_to_new_block_hash(
 
     Ok(())
 }
+
+pub const SET_FP_PLUS_8_TO_TRANSACTIONS_LEN: &str = "memory[fp + 8] = to_felt_or_relocatable(len(os_input.transactions))";
+
+pub fn set_fp_plus_8_to_transactions_len(
+    vm: &mut VirtualMachine,
+    exec_scopes: &mut ExecutionScopes,
+    _ids_data: &HashMap<String, HintReference>,
+    _ap_tracking: &ApTracking,
+    _constants: &HashMap<String, Felt252>,
+) -> Result<(), HintError> {
+    let os_input: &StarknetOsInput = exec_scopes.get_ref(vars::scopes::OS_INPUT)?;
+    let num_txns = os_input.transactions.len();
+
+    vm.insert_value((vm.get_fp() + 8)?, Felt252::from(num_txns)).map_err(HintError::Memory)
+}


### PR DESCRIPTION
Problem: SNOS is missing some hints related to BLOB transactions

Solution: Add the missing hints

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
