### PR TITLE
Fix: Get classes out of subcalls

### DIFF
--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -101,8 +101,9 @@ async fn add_compiled_class_from_contract_to_os_input(
         block_id,
         class_hash_to_compiled_class_hash,
         compiled_contract_classes,
-        deprecated_compiled_contract_classes
-    ).await
+        deprecated_compiled_contract_classes,
+    )
+    .await
 }
 
 /// Fetches (+ compile) the contract class for the specified class at the specified block
@@ -120,8 +121,7 @@ async fn add_compiled_class_from_class_hash_to_os_input(
         return Ok(());
     }
 
-    let compiled_class =
-        get_compiled_class_for_class_hash(provider, block_id, class_hash).await?;
+    let compiled_class = get_compiled_class_for_class_hash(provider, block_id, class_hash).await?;
     let compiled_class_hash = compiled_class.class_hash()?;
 
     class_hash_to_compiled_class_hash.insert(class_hash, compiled_class_hash.into());

--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -42,7 +42,7 @@ pub(crate) async fn get_formatted_state_update(
     // Extract other contracts used in our block from the block trace
     // We need this to get all the class hashes used and correctly feed address_to_class_hash
     let traces = provider.trace_block_transactions(block_id).await.expect("Failed to get block tx traces");
-    let accessed_addresses: HashSet<Felt252> = get_subcalled_contracts_from_tx_traces(&traces);
+    let (accessed_addresses, accessed_classes) = get_subcalled_contracts_from_tx_traces(&traces);
 
     // TODO: Handle deprecated classes
     let mut class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252> = format_declared_classes(&state_diff);
@@ -52,6 +52,7 @@ pub(crate) async fn get_formatted_state_update(
             previous_block_id,
             block_id,
             &accessed_addresses,
+            &accessed_classes,
             &mut class_hash_to_compiled_class_hash,
         )
         .await?;
@@ -59,14 +60,13 @@ pub(crate) async fn get_formatted_state_update(
     Ok(FormattedStateUpdate { class_hash_to_compiled_class_hash, compiled_classes: compiled_contract_classes })
 }
 
-/// Retrieves the compiled class associated to the contract address at a specific block
+/// Retrieves the compiled class for the given class hash at a specific block
 /// by getting the class from the RPC and compiling it to CASM if necessary (Cairo 1).
-async fn get_compiled_class_for_contract(
+async fn get_compiled_class_for_class_hash(
     provider: &JsonRpcClient<HttpTransport>,
     block_id: BlockId,
-    contract_address: ContractAddress,
+    class_hash: Felt252,
 ) -> Result<GenericCompiledClass, ProveBlockError> {
-    let class_hash = provider.get_class_hash_at(block_id, contract_address.0.key()).await?;
     let contract_class = provider.get_class(block_id, class_hash).await?;
 
     let compiled_class = match contract_class {
@@ -86,7 +86,7 @@ async fn get_compiled_class_for_contract(
 
 /// Fetches (+ compile) the contract class for the specified contract at the specified block
 /// and adds it to the hashmaps that will then be added to the OS input.
-async fn add_compiled_class_to_os_input(
+async fn add_compiled_class_from_contract_to_os_input(
     provider: &JsonRpcClient<HttpTransport>,
     contract_address: Felt,
     block_id: BlockId,
@@ -95,14 +95,33 @@ async fn add_compiled_class_to_os_input(
     deprecated_compiled_contract_classes: &mut HashMap<Felt, GenericDeprecatedCompiledClass>,
 ) -> Result<(), ProveBlockError> {
     let class_hash = provider.get_class_hash_at(block_id, contract_address).await?;
+    add_compiled_class_from_class_hash_to_os_input(
+        provider,
+        class_hash,
+        block_id,
+        class_hash_to_compiled_class_hash,
+        compiled_contract_classes,
+        deprecated_compiled_contract_classes
+    ).await
+}
 
+/// Fetches (+ compile) the contract class for the specified class at the specified block
+/// and adds it to the hashmaps that will then be added to the OS input.
+async fn add_compiled_class_from_class_hash_to_os_input(
+    provider: &JsonRpcClient<HttpTransport>,
+    class_hash: Felt,
+    block_id: BlockId,
+    class_hash_to_compiled_class_hash: &mut HashMap<Felt252, Felt252>,
+    compiled_contract_classes: &mut HashMap<Felt, GenericCasmContractClass>,
+    deprecated_compiled_contract_classes: &mut HashMap<Felt, GenericDeprecatedCompiledClass>,
+) -> Result<(), ProveBlockError> {
     // Avoid fetching and compiling contract data if we already have this class.
     if class_hash_to_compiled_class_hash.contains_key(&class_hash) {
         return Ok(());
     }
 
     let compiled_class =
-        get_compiled_class_for_contract(provider, block_id, contract_address.try_into().unwrap()).await?;
+        get_compiled_class_for_class_hash(provider, block_id, class_hash).await?;
     let compiled_class_hash = compiled_class.class_hash()?;
 
     class_hash_to_compiled_class_hash.insert(class_hash, compiled_class_hash.into());
@@ -131,6 +150,7 @@ async fn build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash
     previous_block_id: BlockId,
     block_id: BlockId,
     accessed_addresses: &HashSet<Felt252>,
+    accessed_classes: &HashSet<Felt252>,
     class_hash_to_compiled_class_hash: &mut HashMap<Felt252, Felt252>,
 ) -> Result<
     (HashMap<Felt252, GenericCasmContractClass>, HashMap<Felt252, GenericDeprecatedCompiledClass>),
@@ -142,7 +162,7 @@ async fn build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash
     for contract_address in accessed_addresses {
         // In case there is a class change, we need to get the compiled class for
         // the block to prove and for the previous block as they may differ.
-        add_compiled_class_to_os_input(
+        add_compiled_class_from_contract_to_os_input(
             provider,
             *contract_address,
             previous_block_id,
@@ -151,7 +171,7 @@ async fn build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash
             &mut deprecated_compiled_contract_classes,
         )
         .await?;
-        add_compiled_class_to_os_input(
+        add_compiled_class_from_contract_to_os_input(
             provider,
             *contract_address,
             block_id,
@@ -161,6 +181,19 @@ async fn build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash
         )
         .await?;
     }
+
+    for class_hash in accessed_classes {
+        add_compiled_class_from_class_hash_to_os_input(
+            provider,
+            *class_hash,
+            previous_block_id,
+            class_hash_to_compiled_class_hash,
+            &mut compiled_contract_classes,
+            &mut deprecated_compiled_contract_classes,
+        )
+        .await?;
+    }
+
     Ok((compiled_contract_classes, deprecated_compiled_contract_classes))
 }
 

--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -4,7 +4,6 @@ use cairo_vm::Felt252;
 use starknet::core::types::{BlockId, MaybePendingStateUpdate, StateDiff};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
-use starknet_api::core::ContractAddress;
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::compiled_class::GenericCompiledClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;

--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -12,7 +12,9 @@ use starknet_api::state::StorageKey;
 // TODO: check if we can handle this just reexecuting tx using blockifier
 //
 // Returns a HashSet of contracts and a HashSet of classes encountered along the way.
-pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceWithHash]) -> (HashSet<Felt252>, HashSet<Felt252>) {
+pub(crate) fn get_subcalled_contracts_from_tx_traces(
+    traces: &[TransactionTraceWithHash],
+) -> (HashSet<Felt252>, HashSet<Felt252>) {
     let mut contracts_subcalled: HashSet<Felt252> = HashSet::new();
     let mut classes_subcalled: HashSet<Felt252> = HashSet::new();
     for trace in traces {
@@ -42,7 +44,11 @@ pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceW
 /// Utility to extract all contract address in a nested call structure. Any given call can have
 /// nested calls, creating a tree structure of calls, so this fn traverses this structure and
 /// returns a set of all contracts encountered along the way.
-fn process_function_invocations(inv: &FunctionInvocation, contracts: &mut HashSet<Felt252>, classes: &mut HashSet<Felt252>) {
+fn process_function_invocations(
+    inv: &FunctionInvocation,
+    contracts: &mut HashSet<Felt252>,
+    classes: &mut HashSet<Felt252>,
+) {
     contracts.insert(inv.contract_address);
     classes.insert(inv.class_hash);
     for call in &inv.calls {

--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -10,39 +10,43 @@ use starknet_api::state::StorageKey;
 /// Receives the transaction traces of a given block
 /// And extract the contracts addresses that where subcalled
 // TODO: check if we can handle this just reexecuting tx using blockifier
-pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceWithHash]) -> HashSet<Felt252> {
+//
+// Returns a HashSet of contracts and a HashSet of classes encountered along the way.
+pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceWithHash]) -> (HashSet<Felt252>, HashSet<Felt252>) {
     let mut contracts_subcalled: HashSet<Felt252> = HashSet::new();
+    let mut classes_subcalled: HashSet<Felt252> = HashSet::new();
     for trace in traces {
         match &trace.trace_root {
             TransactionTrace::Invoke(invoke_trace) => {
                 if let Some(inv) = &invoke_trace.validate_invocation {
-                    process_function_invocations(inv, &mut contracts_subcalled);
+                    process_function_invocations(inv, &mut contracts_subcalled, &mut classes_subcalled);
                 }
                 match &invoke_trace.execute_invocation {
                     ExecuteInvocation::Success(inv) => {
-                        process_function_invocations(inv, &mut contracts_subcalled);
+                        process_function_invocations(inv, &mut contracts_subcalled, &mut classes_subcalled);
                     }
                     ExecuteInvocation::Reverted(_) => {
                         // Nothing to do
                     }
                 }
                 if let Some(inv) = &invoke_trace.fee_transfer_invocation {
-                    process_function_invocations(inv, &mut contracts_subcalled);
+                    process_function_invocations(inv, &mut contracts_subcalled, &mut classes_subcalled);
                 }
             }
             _ => unimplemented!("process other txn traces"),
         }
     }
-    contracts_subcalled
+    (contracts_subcalled, classes_subcalled)
 }
 
 /// Utility to extract all contract address in a nested call structure. Any given call can have
 /// nested calls, creating a tree structure of calls, so this fn traverses this structure and
 /// returns a set of all contracts encountered along the way.
-fn process_function_invocations(inv: &FunctionInvocation, contracts: &mut HashSet<Felt252>) {
+fn process_function_invocations(inv: &FunctionInvocation, contracts: &mut HashSet<Felt252>, classes: &mut HashSet<Felt252>) {
     contracts.insert(inv.contract_address);
+    classes.insert(inv.class_hash);
     for call in &inv.calls {
-        process_function_invocations(call, contracts);
+        process_function_invocations(call, contracts, classes);
     }
 }
 


### PR DESCRIPTION
Problem: Library calls do not have a distinct contract address (they use the caller's address in their context), so looking only at contract addresses in subcalls prevents us from ever loading these classes.

Solution: Record classes while traversing subcall tree and load them.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
