### PR TITLE
L1 handler tx

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -165,16 +165,11 @@ pub async fn prove_block(
 
     let mut blockifier_state = CachedState::new(blockifier_state_reader);
 
-    if block_with_txs.transactions.len() != traces.len() {
-        log::warn!("Transactions and traces must have the same length");
-        return Err(ProveBlockError::RpcError(ProviderError::ArrayLengthMismatch));
-    }
+    assert_eq!(block_with_txs.transactions.len(), traces.len(), "Transactions and traces must have the same length");
     let mut txs = Vec::new();
     for (tx, trace) in block_with_txs.transactions.iter().zip(traces.iter()) {
-        let transaction =
-            starknet_rs_to_blockifier(tx, trace, &block_context.block_info().gas_prices, &provider, block_number)
-                .await
-                .map_err(ProveBlockError::from)?;
+        let transaction = starknet_rs_to_blockifier(tx, trace, &block_context.block_info().gas_prices)
+            .map_err(ProveBlockError::from)?;
         txs.push(transaction);
     }
     let tx_execution_infos = reexecute_transactions_with_blockifier(&mut blockifier_state, &block_context, txs)?;

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -13,6 +13,7 @@ use rpc_utils::{get_class_proofs, get_storage_proofs};
 use starknet::core::types::{BlockId, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider, ProviderError, Url};
+use starknet_api::StarknetApiError;
 use starknet_os::config::{StarknetGeneralConfig, StarknetOsConfig, STORED_BLOCK_HASH_BUFFER};
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::crypto::poseidon::PoseidonHash;
@@ -57,6 +58,8 @@ pub enum ProveBlockError {
     SnOsError(#[from] SnOsError),
     #[error("Legacy class decompression Error: {0}")]
     LegacyContractDecompressionError(#[from] LegacyContractDecompressionError),
+    #[error("Starknet API Error: {0}")]
+    StarknetApiError(StarknetApiError),
 }
 
 fn compute_class_commitment(
@@ -150,7 +153,7 @@ pub async fn prove_block(
     let transactions: Vec<_> =
         block_with_txs.transactions.clone().into_iter().map(starknet_rs_tx_to_internal_tx).collect();
 
-    let processed_state_update = get_formatted_state_update(&provider, previous_block_id, block_id).await?;
+    let (processed_state_update, traces) = get_formatted_state_update(&provider, previous_block_id, block_id).await?;
 
     let class_hash_to_compiled_class_hash = processed_state_update.class_hash_to_compiled_class_hash;
 
@@ -161,11 +164,20 @@ pub async fn prove_block(
     let blockifier_state_reader = AsyncRpcStateReader::new(provider_for_blockifier, BlockId::Number(block_number - 1));
 
     let mut blockifier_state = CachedState::new(blockifier_state_reader);
-    let tx_execution_infos = reexecute_transactions_with_blockifier(
-        &mut blockifier_state,
-        &block_context,
-        block_with_txs.transactions.iter().map(|tx| starknet_rs_to_blockifier(tx).unwrap()).collect(),
-    )?;
+
+    if block_with_txs.transactions.len() != traces.len() {
+        log::warn!("Transactions and traces must have the same length");
+        return Err(ProveBlockError::RpcError(ProviderError::ArrayLengthMismatch));
+    }
+    let mut txs = Vec::new();
+    for (tx, trace) in block_with_txs.transactions.iter().zip(traces.iter()) {
+        let transaction =
+            starknet_rs_to_blockifier(tx, trace, &block_context.block_info().gas_prices, &provider, block_number)
+                .await
+                .map_err(ProveBlockError::from)?;
+        txs.push(transaction);
+    }
+    let tx_execution_infos = reexecute_transactions_with_blockifier(&mut blockifier_state, &block_context, txs)?;
 
     let storage_proofs =
         get_storage_proofs(&pathfinder_client, rpc_provider, block_number, &tx_execution_infos, old_block_number)

--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use cairo_vm::Felt252;
-use starknet::core::types::{BlockId, MaybePendingStateUpdate, StateDiff};
+use starknet::core::types::{BlockId, MaybePendingStateUpdate, StateDiff, TransactionTraceWithHash};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 use starknet_api::core::ContractAddress;
@@ -30,7 +30,7 @@ pub(crate) async fn get_formatted_state_update(
     provider: &JsonRpcClient<HttpTransport>,
     previous_block_id: BlockId,
     block_id: BlockId,
-) -> Result<FormattedStateUpdate, ProveBlockError> {
+) -> Result<(FormattedStateUpdate, Vec<TransactionTraceWithHash>), ProveBlockError> {
     let state_update = match provider.get_state_update(block_id).await.expect("Failed to get state update") {
         MaybePendingStateUpdate::Update(update) => update,
         MaybePendingStateUpdate::PendingUpdate(_) => {
@@ -56,7 +56,10 @@ pub(crate) async fn get_formatted_state_update(
         )
         .await?;
 
-    Ok(FormattedStateUpdate { class_hash_to_compiled_class_hash, compiled_classes: compiled_contract_classes })
+    Ok((
+        FormattedStateUpdate { class_hash_to_compiled_class_hash, compiled_classes: compiled_contract_classes },
+        traces,
+    ))
 }
 
 /// Retrieves the compiled class associated to the contract address at a specific block

--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -25,6 +25,10 @@ pub(crate) fn get_subcalled_contracts_from_tx_traces(traces: &[TransactionTraceW
                     process_function_invocations(inv, &mut contracts_subcalled);
                 }
             }
+            TransactionTrace::L1Handler(l1handler_trace) => {
+                process_function_invocations(&l1handler_trace.function_invocation, &mut contracts_subcalled);
+            }
+
             _ => unimplemented!("process other txn traces"),
         }
     }

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -19,6 +19,7 @@ use rstest::rstest;
 #[case::fix_diff_assert_values_in_contract_subcall(87019)]
 #[case::invoke_with_replace_class(90000)]
 #[case::write_to_zero_with_edge_node(125622)]
+#[case::l1_handler(98000)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -8,8 +8,6 @@ use starknet::core::types::{
     Felt, InvokeTransaction, InvokeTransactionV1, InvokeTransactionV3, L1HandlerTransaction, ResourceBoundsMapping,
     Transaction, TransactionTrace, TransactionTraceWithHash,
 };
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
 use starknet_api::core::PatriciaKey;
 use starknet_api::transaction::{Fee, TransactionHash};
 use starknet_api::StarknetApiError;
@@ -125,12 +123,10 @@ fn l1_handler_to_blockifier(
 }
 
 /// Maps starknet-core transactions to Blockifier-compatible types.
-pub async fn starknet_rs_to_blockifier(
+pub fn starknet_rs_to_blockifier(
     sn_core_tx: &starknet::core::types::Transaction,
     trace: &TransactionTraceWithHash,
     gas_prices: &GasPrices,
-    _provider: &JsonRpcClient<HttpTransport>,
-    _block_number: u64,
 ) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
     let blockifier_tx = match sn_core_tx {
         Transaction::Invoke(tx) => match tx {

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -2,10 +2,14 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::Arc;
 
+use blockifier::blockifier::block::GasPrices;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use starknet::core::types::{
-    InvokeTransaction, InvokeTransactionV1, InvokeTransactionV3, ResourceBoundsMapping, Transaction,
+    Felt, InvokeTransaction, InvokeTransactionV1, InvokeTransactionV3, L1HandlerTransaction, ResourceBoundsMapping,
+    Transaction, TransactionTrace, TransactionTraceWithHash,
 };
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
 use starknet_api::core::PatriciaKey;
 use starknet_api::transaction::{Fee, TransactionHash};
 use starknet_api::StarknetApiError;
@@ -83,25 +87,64 @@ fn invoke_v3_to_blockifier(
     )))
 }
 
+fn l1_handler_to_blockifier(
+    tx: &L1HandlerTransaction,
+    trace: &TransactionTraceWithHash,
+    gas_prices: &GasPrices,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, StarknetApiError> {
+    let tx_hash = TransactionHash(tx.transaction_hash);
+    let api_tx = starknet_api::transaction::L1HandlerTransaction {
+        version: starknet_api::transaction::TransactionVersion(tx.version),
+        nonce: starknet_api::core::Nonce(Felt::from(tx.nonce)),
+        contract_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.contract_address)?),
+        entry_point_selector: starknet_api::core::EntryPointSelector(tx.entry_point_selector),
+        calldata: starknet_api::transaction::Calldata(Arc::new(tx.calldata.clone())),
+    };
+
+    let (l1_gas, l1_data_gas) = match &trace.trace_root {
+        TransactionTrace::L1Handler(l1_handler) => (
+            l1_handler.execution_resources.data_resources.data_availability.l1_gas,
+            l1_handler.execution_resources.data_resources.data_availability.l1_data_gas,
+        ),
+        _ => unreachable!("Expected L1Handler type for TransactionTrace"),
+    };
+
+    let fee = if l1_gas == 0 {
+        gas_prices.eth_l1_data_gas_price.get() * l1_data_gas as u128
+    } else if l1_data_gas == 0 {
+        gas_prices.eth_l1_gas_price.get() * l1_gas as u128
+    } else {
+        unreachable!("Either l1_gas or l1_data_gas must be zero");
+    };
+
+    let paid_fee_on_l1 = Fee(fee);
+    let l1_handler =
+        blockifier::transaction::transactions::L1HandlerTransaction { tx: api_tx, tx_hash, paid_fee_on_l1 };
+
+    Ok(blockifier::transaction::transaction_execution::Transaction::L1HandlerTransaction(l1_handler))
+}
+
 /// Maps starknet-core transactions to Blockifier-compatible types.
-pub fn starknet_rs_to_blockifier(
+pub async fn starknet_rs_to_blockifier(
     sn_core_tx: &starknet::core::types::Transaction,
+    trace: &TransactionTraceWithHash,
+    gas_prices: &GasPrices,
+    _provider: &JsonRpcClient<HttpTransport>,
+    _block_number: u64,
 ) -> Result<blockifier::transaction::transaction_execution::Transaction, Box<dyn Error>> {
     let blockifier_tx = match sn_core_tx {
+        Transaction::Invoke(tx) => match tx {
+            InvokeTransaction::V0(_) => unimplemented!("starknet_rs_to_blockifier with InvokeTransaction::V0"),
+            InvokeTransaction::V1(tx) => invoke_v1_to_blockifier(tx)?,
+            InvokeTransaction::V3(tx) => invoke_v3_to_blockifier(tx)?,
+        },
+        Transaction::L1Handler(tx) => l1_handler_to_blockifier(tx, trace, gas_prices)?,
         Transaction::DeployAccount(_tx) => {
             unimplemented!("starknet_rs_tx_to_blockifier() with Deploy txn");
         }
         Transaction::Declare(_tx) => {
             unimplemented!("starknet_rs_tx_to_blockifier() with Declare txn");
         }
-        Transaction::L1Handler(_tx) => {
-            unimplemented!("starknet_rs_tx_to_blockifier() with L1Handler txn");
-        }
-        Transaction::Invoke(tx) => match tx {
-            InvokeTransaction::V0(_) => unimplemented!("starknet_rs_to_blockifier with InvokeTransaction::V0"),
-            InvokeTransaction::V1(tx) => invoke_v1_to_blockifier(tx)?,
-            InvokeTransaction::V3(tx) => invoke_v3_to_blockifier(tx)?,
-        },
         _ => unimplemented!(),
     };
 

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -40,15 +40,14 @@ async fn test_replay_block() {
 
     let traces = provider.trace_block_transactions(block_id).await.expect("Failed to get block tx traces");
     let gas_prices = GasPrices {
-        eth_l1_gas_price: 1u128.try_into().unwrap(), // TODO: update with 4844
+        eth_l1_gas_price: 1u128.try_into().unwrap(),
         strk_l1_gas_price: 1u128.try_into().unwrap(),
         eth_l1_data_gas_price: 1u128.try_into().unwrap(),
         strk_l1_data_gas_price: 1u128.try_into().unwrap(),
     };
 
     for (tx, trace) in block_with_txs.transactions.iter().zip(traces.iter()) {
-        let blockifier_tx =
-            starknet_rs_to_blockifier(tx, trace, &gas_prices, &provider, block_with_txs.block_number).await.unwrap();
+        let blockifier_tx = starknet_rs_to_blockifier(tx, trace, &gas_prices).unwrap();
         let tx_result = blockifier_tx.execute(&mut state, &block_context, true, true);
 
         match tx_result {

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -1,3 +1,4 @@
+use blockifier::blockifier::block::GasPrices;
 use blockifier::state::cached_state::CachedState;
 use blockifier::transaction::transactions::ExecutableTransaction as _;
 use blockifier::versioned_constants::StarknetVersion;
@@ -7,7 +8,7 @@ use rpc_replay::transactions::starknet_rs_to_blockifier;
 use rstest::rstest;
 use starknet::core::types::{BlockId, BlockWithTxs};
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Url};
+use starknet::providers::{JsonRpcClient, Provider, Url};
 use starknet_api::core::ChainId;
 
 #[rstest]
@@ -26,13 +27,28 @@ async fn test_replay_block() {
     let provider = JsonRpcClient::new(HttpTransport::new(
         Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
     ));
-    let state_reader = AsyncRpcStateReader::new(provider, BlockId::Number(block_with_txs.block_number - 1));
+    let block_id = BlockId::Number(block_with_txs.block_number - 1);
+    let state_reader = AsyncRpcStateReader::new(provider, block_id);
     let mut state = CachedState::from(state_reader);
 
     let block_context = build_block_context(ChainId::Sepolia, &block_with_txs, StarknetVersion::V0_13_1);
 
-    for tx in block_with_txs.transactions.iter() {
-        let blockifier_tx = starknet_rs_to_blockifier(tx).unwrap();
+    // Workaround for JsonRpcClient not implementing Clone
+    let provider = JsonRpcClient::new(HttpTransport::new(
+        Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
+    ));
+
+    let traces = provider.trace_block_transactions(block_id).await.expect("Failed to get block tx traces");
+    let gas_prices = GasPrices {
+        eth_l1_gas_price: 1u128.try_into().unwrap(), // TODO: update with 4844
+        strk_l1_gas_price: 1u128.try_into().unwrap(),
+        eth_l1_data_gas_price: 1u128.try_into().unwrap(),
+        strk_l1_data_gas_price: 1u128.try_into().unwrap(),
+    };
+
+    for (tx, trace) in block_with_txs.transactions.iter().zip(traces.iter()) {
+        let blockifier_tx =
+            starknet_rs_to_blockifier(tx, trace, &gas_prices, &provider, block_with_txs.block_number).await.unwrap();
         let tx_result = blockifier_tx.execute(&mut state, &block_context, true, true);
 
         match tx_result {


### PR DESCRIPTION
Problem PR https://github.com/keep-starknet-strange/snos/pull/330 was too big

Solution: split the PR into smaller PR where each one will implement a different transaction.
Support for L1 Handler transaction.
Block 98000 added to CI regression tests

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
