### PR TITLE
Fix: support invoke txs that call the deploy syscall

### DIFF
--- a/crates/bin/prove_block/src/reexecute.rs
+++ b/crates/bin/prove_block/src/reexecute.rs
@@ -159,13 +159,12 @@ impl PerContractStorage for ProverPerContractStorage {
 
         let commitment_facts = format_commitment_facts::<PedersenHash>(&contract_data.storage_proofs);
 
-        let previous_contract_data = self
-            .previous_storage_proof
-            .contract_data
-            .as_ref()
-            .expect("previous storage proof should have a contract_data field");
-
-        let previous_commitment_facts = format_commitment_facts::<PedersenHash>(&previous_contract_data.storage_proofs);
+        let previous_commitment_facts = match &self.previous_storage_proof.contract_data {
+            None => HashMap::default(),
+            Some(previous_contract_data) => {
+                format_commitment_facts::<PedersenHash>(&previous_contract_data.storage_proofs)
+            }
+        };
 
         let commitment_facts = commitment_facts.into_iter().chain(previous_commitment_facts.into_iter()).collect();
 

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -175,7 +175,12 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
     let mut storage_proof =
         fetch_storage_proof_for_contract(client, rpc_provider, contract_address_felt, &keys, block_number).await?;
 
-    let contract_data = storage_proof.contract_data.as_ref().expect("Storage proof should have contract_data");
+    let contract_data = match &storage_proof.contract_data {
+        None => {
+            return Ok(storage_proof);
+        }
+        Some(contract_data) => contract_data,
+    };
     let additional_keys = verify_storage_proof(contract_data, &keys);
 
     // Fetch additional proofs required to fill gaps in the storage trie that could make

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -20,6 +20,7 @@ use rstest::rstest;
 #[case::invoke_with_replace_class(90000)]
 #[case::write_to_zero_with_edge_node(125622)]
 #[case::l1_handler(98000)]
+#[case::invoke_with_call_to_deploy_syscall(124534)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {


### PR DESCRIPTION
Problem: the setup for `prove_block` assumes that we are always able to fetch the class hash, class and storage proof for the contract addresses found in invoke txs in the previous block. This is not always the case as invoke txs are able to deploy contracts.

Solution: accept "contract not found" errors and storage proofs where the `contract_data` field is missing. Note that we should implement a way to double-check our expectations as this fix will accept an incomplete storage proof in the current block as well, which is not ideal.

Issue Number: N/A

## Type

- [x] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
