### PR TITLE
Feature: rpc-client crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ members = [
     "crates/bin/hint_tool",
     "crates/bin/prove_block",
     "crates/cairo-type-derive",
+    "crates/rpc-client",
+    "crates/rpc-replay",
     "crates/starknet-os",
     "crates/starknet-os-types",
-    "crates/rpc-replay",
     "tests",
 ]
 
@@ -56,6 +57,7 @@ pathfinder-crypto = { git = "https://github.com/Moonsong-Labs/pathfinder", rev =
 pathfinder-gateway-types = { git = "https://github.com/Moonsong-Labs/pathfinder", rev = "49a2de4ef52726d1fb5ef906ff95f48af8076169", package = "starknet-gateway-types" }
 pathfinder-serde = { git = "https://github.com/Moonsong-Labs/pathfinder", rev = "49a2de4ef52726d1fb5ef906ff95f48af8076169", package = "pathfinder-serde" }
 reqwest = { version = "0.11.18", features = ["blocking", "json"] }
+rpc-client = { path = "crates/rpc-client" }
 rpc-replay = { path = "crates/rpc-replay" }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = { version = "1.0.105", features = ["arbitrary_precision"] }

--- a/crates/bin/prove_block/Cargo.toml
+++ b/crates/bin/prove_block/Cargo.toml
@@ -20,6 +20,7 @@ pathfinder-common = { workspace = true }
 pathfinder-crypto = { workspace = true }
 pathfinder-serde = { workspace = true }
 reqwest = { workspace = true }
+rpc-client = { workspace = true }
 rpc-replay = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bin/prove_block/src/reexecute.rs
+++ b/crates/bin/prove_block/src/reexecute.rs
@@ -9,10 +9,10 @@ use blockifier::transaction::objects::TransactionExecutionInfo;
 use blockifier::transaction::transaction_execution::Transaction;
 use blockifier::transaction::transactions::ExecutableTransaction;
 use cairo_vm::Felt252;
-use reqwest::Url;
+use rpc_client::pathfinder::proofs::{PathfinderProof, TrieNode};
+use rpc_client::RpcClient;
 use starknet::core::types::{BlockId, StarknetError};
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider as _, ProviderError};
+use starknet::providers::{Provider as _, ProviderError};
 use starknet_api::transaction::TransactionHash;
 use starknet_os::config::DEFAULT_STORAGE_TREE_HEIGHT;
 use starknet_os::crypto::pedersen::PedersenHash;
@@ -23,8 +23,6 @@ use starknet_os::starkware_utils::commitment_tree::inner_node_fact::InnerNodeFac
 use starknet_os::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
 use starknet_os::storage::dict_storage::DictStorage;
 use starknet_os::storage::storage::{Fact, HashFunctionType};
-
-use crate::rpc_utils::{PathfinderProof, TrieNode};
 
 /// Retrieves the transaction hash from a Blockifier `Transaction` object.
 fn get_tx_hash(tx: &Transaction) -> TransactionHash {
@@ -77,7 +75,7 @@ pub fn reexecute_transactions_with_blockifier<S: StateReader>(
 }
 
 pub(crate) struct ProverPerContractStorage {
-    provider: JsonRpcClient<HttpTransport>,
+    rpc_client: RpcClient,
     block_id: BlockId,
     contract_address: Felt252,
     previous_tree_root: Felt252,
@@ -88,19 +86,15 @@ pub(crate) struct ProverPerContractStorage {
 
 impl ProverPerContractStorage {
     pub fn new(
+        rpc_client: RpcClient,
         block_id: BlockId,
         contract_address: Felt252,
-        provider_url: String,
         previous_tree_root: Felt252,
         storage_proof: PathfinderProof,
         previous_storage_proof: PathfinderProof,
     ) -> Result<Self, TreeError> {
-        let provider = JsonRpcClient::new(HttpTransport::new(
-            Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
-        ));
-
         Ok(Self {
-            provider,
+            rpc_client,
             block_id,
             contract_address,
             previous_tree_root,
@@ -182,7 +176,12 @@ impl PerContractStorage for ProverPerContractStorage {
         } else {
             let key_felt = Felt252::from(key.clone());
             // TODO: this should be fallible
-            let value = match self.provider.get_storage_at(self.contract_address, key_felt, self.block_id).await {
+            let value = match self
+                .rpc_client
+                .starknet_rpc()
+                .get_storage_at(self.contract_address, key_felt, self.block_id)
+                .await
+            {
                 Ok(value) => Ok(value),
                 Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt252::ZERO),
                 Err(e) => Err(e),

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -2,156 +2,38 @@ use std::collections::HashMap;
 
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
-use serde::de::DeserializeOwned;
-use serde::Deserialize;
-use serde_json::json;
+use rpc_client::pathfinder::proofs::{
+    ContractData, EdgePath, PathfinderClassProof, PathfinderProof, ProofVerificationError, TrieNode,
+};
+use rpc_client::RpcClient;
 use starknet::core::types::BlockWithTxs;
 use starknet_api::core::{ContractAddress, PatriciaKey};
 use starknet_api::state::StorageKey;
 use starknet_api::{contract_address, felt, patricia_key};
 use starknet_os::config::DEFAULT_STORAGE_TREE_HEIGHT;
-use starknet_os::crypto::pedersen::PedersenHash;
-use starknet_os::crypto::poseidon::PoseidonHash;
-use starknet_os::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath};
-use starknet_os::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
-use starknet_os::storage::dict_storage::DictStorage;
-use starknet_os::storage::storage::{Fact, HashFunctionType};
+use starknet_os::starkware_utils::commitment_tree::base_types::Height;
 use starknet_types_core::felt::Felt;
 
 use crate::utils::get_all_accessed_keys;
-
-pub(crate) fn jsonrpc_request(method: &str, params: serde_json::Value) -> serde_json::Value {
-    json!({
-        "jsonrpc": "2.0",
-        "id": "0",
-        "method": method,
-        "params": params,
-    })
-}
-
-async fn post_jsonrpc_request<T: DeserializeOwned>(
-    client: &reqwest::Client,
-    rpc_provider: &str,
-    method: &str,
-    params: serde_json::Value,
-) -> Result<T, reqwest::Error> {
-    let request = jsonrpc_request(method, params);
-    let response = client.post(format!("{}/rpc/pathfinder/v0.1", rpc_provider)).json(&request).send().await?;
-
-    #[derive(Deserialize)]
-    struct TransactionReceiptResponse<T> {
-        result: T,
-    }
-
-    let response_text = response.text().await?;
-    let response: TransactionReceiptResponse<T> =
-        serde_json::from_str(&response_text).unwrap_or_else(|_| panic!("Error: {}", response_text));
-    Ok(response.result)
-}
-
-// Types defined for Deserialize functionality
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct EdgePath {
-    pub len: u64,
-    pub value: Felt252,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) enum TrieNode {
-    #[serde(rename = "binary")]
-    Binary { left: Felt252, right: Felt252 },
-    #[serde(rename = "edge")]
-    Edge { child: Felt252, path: EdgePath },
-}
-
-impl TrieNode {
-    pub(crate) fn hash<H: HashFunctionType>(&self) -> Felt {
-        match self {
-            TrieNode::Binary { left, right } => {
-                let fact = BinaryNodeFact::new((*left).into(), (*right).into())
-                    .expect("storage proof endpoint gave us an invalid binary node");
-
-                // TODO: the hash function should probably be split from the Fact trait.
-                //       we use a placeholder for the Storage trait in the meantime.
-                Felt::from(<BinaryNodeFact as Fact<DictStorage, H>>::hash(&fact))
-            }
-            TrieNode::Edge { child, path } => {
-                let fact = EdgeNodeFact::new((*child).into(), NodePath(path.value.to_biguint()), Length(path.len))
-                    .expect("storage proof endpoint gave us an invalid edge node");
-                // TODO: the hash function should probably be split from the Fact trait.
-                //       we use a placeholder for the Storage trait in the meantime.
-                Felt::from(<EdgeNodeFact as Fact<DictStorage, H>>::hash(&fact))
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct ContractData {
-    /// Root of the Contract state tree
-    pub root: Felt252,
-    /// The proofs associated with the queried storage values
-    pub storage_proofs: Vec<Vec<TrieNode>>,
-}
-
-impl ContractData {
-    /// Verifies that each contract state proof is valid.
-    pub(crate) fn verify(&self, storage_keys: &[Felt252]) -> Result<(), Vec<ProofVerificationError>> {
-        let mut errors = vec![];
-
-        for (index, storage_key) in storage_keys.iter().enumerate() {
-            if let Err(e) = verify_proof::<PedersenHash>(*storage_key, self.root, &self.storage_proofs[index]) {
-                errors.push(e);
-            }
-        }
-
-        if errors.is_empty() { Ok(()) } else { Err(errors) }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct PathfinderProof {
-    pub state_commitment: Felt252,
-    pub class_commitment: Felt252,
-    pub contract_proof: Vec<TrieNode>,
-    pub contract_data: Option<ContractData>,
-}
-
-pub(crate) async fn pathfinder_get_proof(
-    client: &reqwest::Client,
-    rpc_provider: &str,
-    block_number: u64,
-    contract_address: Felt,
-    keys: &[Felt],
-) -> Result<PathfinderProof, reqwest::Error> {
-    post_jsonrpc_request(
-        client,
-        rpc_provider,
-        "pathfinder_getProof",
-        json!({ "block_id": { "block_number": block_number }, "contract_address": contract_address, "keys": keys }),
-    )
-    .await
-}
 
 /// Fetches the state + storage proof for a single contract for all the specified keys.
 /// This function handles the chunking of requests imposed by the RPC API and merges
 /// the proofs returned from multiple calls into one.
 async fn fetch_storage_proof_for_contract(
-    client: &reqwest::Client,
-    rpc_provider: &str,
+    rpc_client: &RpcClient,
     contract_address: Felt,
     keys: &[Felt],
     block_number: u64,
 ) -> Result<PathfinderProof, reqwest::Error> {
     let storage_proof = if keys.is_empty() {
-        pathfinder_get_proof(client, rpc_provider, block_number, contract_address, &[]).await?
+        rpc_client.pathfinder_rpc().get_proof(block_number, contract_address, &[]).await?
     } else {
         // The endpoint is limited to 100 keys at most per call
         const MAX_KEYS: usize = 100;
         let mut chunked_storage_proofs = Vec::new();
         for keys_chunk in keys.chunks(MAX_KEYS) {
             chunked_storage_proofs
-                .push(pathfinder_get_proof(client, rpc_provider, block_number, contract_address, keys_chunk).await?);
+                .push(rpc_client.pathfinder_rpc().get_proof(block_number, contract_address, keys_chunk).await?);
         }
         merge_storage_proofs(chunked_storage_proofs)
     };
@@ -163,8 +45,7 @@ async fn fetch_storage_proof_for_contract(
 /// This function can fetch additional keys if required to fill gaps in the storage trie
 /// that must be filled to get the OS to function. See `get_key_following_edge` for more details.
 async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
-    client: &reqwest::Client,
-    rpc_provider: &str,
+    rpc_client: &RpcClient,
     contract_address: ContractAddress,
     storage_keys: KeyIter,
     block_number: u64,
@@ -173,7 +54,7 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
     let keys: Vec<_> = storage_keys.map(|storage_key| *storage_key.key()).collect();
 
     let mut storage_proof =
-        fetch_storage_proof_for_contract(client, rpc_provider, contract_address_felt, &keys, block_number).await?;
+        fetch_storage_proof_for_contract(rpc_client, contract_address_felt, &keys, block_number).await?;
 
     let contract_data = match &storage_proof.contract_data {
         None => {
@@ -186,14 +67,8 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
     // Fetch additional proofs required to fill gaps in the storage trie that could make
     // the OS crash otherwise.
     if !additional_keys.is_empty() {
-        let additional_proof = fetch_storage_proof_for_contract(
-            client,
-            rpc_provider,
-            contract_address_felt,
-            &additional_keys,
-            block_number,
-        )
-        .await?;
+        let additional_proof =
+            fetch_storage_proof_for_contract(rpc_client, contract_address_felt, &additional_keys, block_number).await?;
 
         storage_proof = merge_storage_proofs(vec![storage_proof, additional_proof]);
     }
@@ -233,8 +108,7 @@ fn verify_storage_proof(contract_data: &ContractData, keys: &[Felt]) -> Vec<Felt
 }
 
 pub(crate) async fn get_storage_proofs(
-    client: &reqwest::Client,
-    rpc_provider: &str,
+    client: &RpcClient,
     block_number: u64,
     tx_execution_infos: &[TransactionExecutionInfo],
     old_block_number: Felt,
@@ -255,14 +129,8 @@ pub(crate) async fn get_storage_proofs(
 
     for (contract_address, storage_keys) in accessed_keys_by_address {
         let contract_address_felt = *contract_address.key();
-        let storage_proof = get_storage_proof_for_contract(
-            client,
-            rpc_provider,
-            contract_address,
-            storage_keys.into_iter(),
-            block_number,
-        )
-        .await?;
+        let storage_proof =
+            get_storage_proof_for_contract(client, contract_address, storage_keys.into_iter(), block_number).await?;
         storage_proofs.insert(contract_address_felt, storage_proof);
     }
 
@@ -308,107 +176,19 @@ fn merge_storage_proofs(proofs: Vec<PathfinderProof>) -> PathfinderProof {
     PathfinderProof { class_commitment, state_commitment, contract_proof, contract_data }
 }
 
-#[allow(dead_code)]
-#[derive(Clone, Deserialize)]
-pub(crate) struct PathfinderClassProof {
-    pub class_commitment: Felt252,
-    pub class_proof: Vec<TrieNode>,
-}
-
-impl PathfinderClassProof {
-    /// Verifies that the class proof is valid.
-    pub(crate) fn verify(&self, class_hash: Felt) -> Result<(), ProofVerificationError> {
-        verify_proof::<PoseidonHash>(class_hash, self.class_commitment, &self.class_proof)
-    }
-}
-
-pub(crate) async fn pathfinder_get_class_proof(
-    client: &reqwest::Client,
-    rpc_provider: &str,
-    block_number: u64,
-    class_hash: &Felt,
-) -> Result<PathfinderClassProof, reqwest::Error> {
-    log::debug!("querying pathfinder_getClassProof for {:x}", class_hash);
-    log::debug!("provider: {}", rpc_provider);
-    post_jsonrpc_request(
-        client,
-        rpc_provider,
-        "pathfinder_getClassProof",
-        json!({ "block_id": { "block_number": block_number }, "class_hash": class_hash }),
-    )
-    .await
-}
-
 pub(crate) async fn get_class_proofs(
-    client: &reqwest::Client,
-    rpc_provider: &str,
+    rpc_client: &RpcClient,
     block_number: u64,
     class_hashes: &[&Felt],
 ) -> Result<HashMap<Felt252, PathfinderClassProof>, reqwest::Error> {
     let mut proofs: HashMap<Felt252, PathfinderClassProof> = HashMap::with_capacity(class_hashes.len());
     for class_hash in class_hashes {
-        let proof = pathfinder_get_class_proof(client, rpc_provider, block_number, class_hash).await?;
+        let proof = rpc_client.pathfinder_rpc().get_class_proof(block_number, class_hash).await?;
         // TODO: need to combine these, similar to merge_chunked_storage_proofs above?
         proofs.insert(**class_hash, proof);
     }
 
     Ok(proofs)
-}
-
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum ProofVerificationError<'a> {
-    #[error("Proof verification failed for key {}. Proof stopped at height {}.", key.to_hex_string(), height.0)]
-    KeyNotInProof { key: Felt, height: Height, proof: &'a [TrieNode] },
-
-    #[error("Proof verification failed, node_hash {node_hash:x} != parent_hash {parent_hash:x}")]
-    InvalidChildNodeHash { node_hash: Felt, parent_hash: Felt },
-}
-
-/// This function goes through the tree from top to bottom and verifies that
-/// the hash of each node is equal to the corresponding hash in the parent node.
-pub(crate) fn verify_proof<H: HashFunctionType>(
-    key: Felt,
-    commitment: Felt,
-    proof: &[TrieNode],
-) -> Result<(), ProofVerificationError> {
-    let bits = key.to_bits_be();
-
-    let mut parent_hash = commitment;
-    let mut trie_node_iter = proof.iter();
-
-    // The tree height is 251, so the first 5 bits are ignored.
-    let start = 5;
-    let mut index = start;
-
-    loop {
-        match trie_node_iter.next() {
-            None => {
-                if index - start != DEFAULT_STORAGE_TREE_HEIGHT {
-                    return Err(ProofVerificationError::KeyNotInProof { key, height: Height(index - start), proof });
-                }
-                break;
-            }
-            Some(node) => {
-                let node_hash = node.hash::<H>();
-                if node_hash != parent_hash {
-                    return Err(ProofVerificationError::InvalidChildNodeHash { node_hash, parent_hash });
-                }
-
-                match node {
-                    TrieNode::Binary { left, right } => {
-                        parent_hash = if bits[index as usize] { *right } else { *left };
-                        index += 1;
-                    }
-                    TrieNode::Edge { child, path } => {
-                        parent_hash = *child;
-                        index += path.len;
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
 }
 
 pub(crate) fn get_starknet_version(block_with_txs: &BlockWithTxs) -> blockifier::versioned_constants::StarknetVersion {

--- a/crates/rpc-client/Cargo.toml
+++ b/crates/rpc-client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rpc-client"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license-file.workspace = true
+
+[dependencies]
+log = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+starknet = { workspace = true }
+starknet-os = { workspace = true }
+starknet-types-core = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use reqwest::Url;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+
+use crate::pathfinder::client::PathfinderRpcClient;
+
+struct RpcClientInner {
+    /// starknet-rs client, used to access data from endpoints defined in the Starknet RPC spec.
+    starknet_client: JsonRpcClient<HttpTransport>,
+    /// A Pathfinder-specific client to access endpoints not covered by starknet-rs.
+    pathfinder_client: PathfinderRpcClient,
+}
+
+impl RpcClientInner {
+    fn new(base_url: &str) -> Self {
+        let starknet_rpc_url = format!("{}/rpc/v0_7", base_url);
+        log::info!("Starknet RPC URL: {}", starknet_rpc_url);
+        let provider = JsonRpcClient::new(HttpTransport::new(
+            Url::parse(starknet_rpc_url.as_str())
+                .unwrap_or_else(|e| panic!("Could not parse provider URL ({}): {}", starknet_rpc_url, e)),
+        ));
+        let pathfinder_client = PathfinderRpcClient::new(base_url);
+
+        Self { starknet_client: provider, pathfinder_client }
+    }
+}
+
+#[derive(Clone)]
+pub struct RpcClient {
+    inner: Arc<RpcClientInner>,
+}
+
+impl RpcClient {
+    pub fn new(base_url: &str) -> Self {
+        Self { inner: Arc::new(RpcClientInner::new(base_url)) }
+    }
+
+    pub fn starknet_rpc(&self) -> &JsonRpcClient<HttpTransport> {
+        &self.inner.starknet_client
+    }
+
+    pub fn pathfinder_rpc(&self) -> &PathfinderRpcClient {
+        &self.inner.pathfinder_client
+    }
+}

--- a/crates/rpc-client/src/lib.rs
+++ b/crates/rpc-client/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod client;
+pub mod pathfinder;
+
+pub use client::RpcClient;

--- a/crates/rpc-client/src/pathfinder/client.rs
+++ b/crates/rpc-client/src/pathfinder/client.rs
@@ -1,0 +1,83 @@
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::json;
+use starknet_types_core::felt::Felt;
+
+use crate::pathfinder::proofs::{PathfinderClassProof, PathfinderProof};
+
+fn jsonrpc_request(method: &str, params: serde_json::Value) -> serde_json::Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": "0",
+        "method": method,
+        "params": params,
+    })
+}
+
+async fn post_jsonrpc_request<T: DeserializeOwned>(
+    client: &reqwest::Client,
+    rpc_provider: &str,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<T, reqwest::Error> {
+    let request = jsonrpc_request(method, params);
+    let response = client.post(format!("{}/rpc/pathfinder/v0.1", rpc_provider)).json(&request).send().await?;
+
+    #[derive(Deserialize)]
+    struct TransactionReceiptResponse<T> {
+        result: T,
+    }
+
+    let response_text = response.text().await?;
+    let response: TransactionReceiptResponse<T> =
+        serde_json::from_str(&response_text).unwrap_or_else(|_| panic!("Error: {}", response_text));
+    Ok(response.result)
+}
+
+pub struct PathfinderRpcClient {
+    /// A raw client to access endpoints not covered by starknet-rs.
+    http_client: reqwest::Client,
+    /// The base URL of the RPC client
+    rpc_base_url: String,
+}
+
+impl PathfinderRpcClient {
+    pub fn new(base_url: &str) -> Self {
+        let starknet_rpc_url = format!("{}/rpc/v0_7", base_url);
+        log::info!("Starknet RPC URL: {}", starknet_rpc_url);
+        let http_client =
+            reqwest::ClientBuilder::new().build().unwrap_or_else(|e| panic!("Could not build reqwest client: {e}"));
+
+        Self { http_client, rpc_base_url: base_url.to_string() }
+    }
+
+    pub async fn get_proof(
+        &self,
+        block_number: u64,
+        contract_address: Felt,
+        keys: &[Felt],
+    ) -> Result<PathfinderProof, reqwest::Error> {
+        post_jsonrpc_request(
+            &self.http_client,
+            &self.rpc_base_url,
+            "pathfinder_getProof",
+            json!({ "block_id": { "block_number": block_number }, "contract_address": contract_address, "keys": keys }),
+        )
+        .await
+    }
+
+    pub async fn get_class_proof(
+        &self,
+        block_number: u64,
+        class_hash: &Felt,
+    ) -> Result<PathfinderClassProof, reqwest::Error> {
+        log::debug!("querying pathfinder_getClassProof for {:x}", class_hash);
+        post_jsonrpc_request(
+            &self.http_client,
+            &self.rpc_base_url,
+            "pathfinder_getClassProof",
+            json!({ "block_id": { "block_number": block_number }, "class_hash": class_hash }),
+        )
+        .await
+    }
+}

--- a/crates/rpc-client/src/pathfinder/mod.rs
+++ b/crates/rpc-client/src/pathfinder/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod proofs;

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -1,0 +1,147 @@
+use serde::Deserialize;
+use starknet_os::config::DEFAULT_STORAGE_TREE_HEIGHT;
+use starknet_os::crypto::pedersen::PedersenHash;
+use starknet_os::crypto::poseidon::PoseidonHash;
+use starknet_os::starkware_utils::commitment_tree::base_types::{Height, Length, NodePath};
+use starknet_os::starkware_utils::commitment_tree::patricia_tree::nodes::{BinaryNodeFact, EdgeNodeFact};
+use starknet_os::storage::dict_storage::DictStorage;
+use starknet_os::storage::storage::{Fact, HashFunctionType};
+use starknet_types_core::felt::Felt;
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum TrieNode {
+    #[serde(rename = "binary")]
+    Binary { left: Felt, right: Felt },
+    #[serde(rename = "edge")]
+    Edge { child: Felt, path: EdgePath },
+}
+
+impl TrieNode {
+    pub fn hash<H: HashFunctionType>(&self) -> Felt {
+        match self {
+            TrieNode::Binary { left, right } => {
+                let fact = BinaryNodeFact::new((*left).into(), (*right).into())
+                    .expect("storage proof endpoint gave us an invalid binary node");
+
+                // TODO: the hash function should probably be split from the Fact trait.
+                //       we use a placeholder for the Storage trait in the meantime.
+                Felt::from(<BinaryNodeFact as Fact<DictStorage, H>>::hash(&fact))
+            }
+            TrieNode::Edge { child, path } => {
+                let fact = EdgeNodeFact::new((*child).into(), NodePath(path.value.to_biguint()), Length(path.len))
+                    .expect("storage proof endpoint gave us an invalid edge node");
+                // TODO: the hash function should probably be split from the Fact trait.
+                //       we use a placeholder for the Storage trait in the meantime.
+                Felt::from(<EdgeNodeFact as Fact<DictStorage, H>>::hash(&fact))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContractData {
+    /// Root of the Contract state tree
+    pub root: Felt,
+    /// The proofs associated with the queried storage values
+    pub storage_proofs: Vec<Vec<TrieNode>>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ProofVerificationError<'a> {
+    #[error("Proof verification failed for key {}. Proof stopped at height {}.", key.to_hex_string(), height.0)]
+    KeyNotInProof { key: Felt, height: Height, proof: &'a [TrieNode] },
+
+    #[error("Proof verification failed, node_hash {node_hash:x} != parent_hash {parent_hash:x}")]
+    InvalidChildNodeHash { node_hash: Felt, parent_hash: Felt },
+}
+
+impl ContractData {
+    /// Verifies that each contract state proof is valid.
+    pub fn verify(&self, storage_keys: &[Felt]) -> Result<(), Vec<ProofVerificationError>> {
+        let mut errors = vec![];
+
+        for (index, storage_key) in storage_keys.iter().enumerate() {
+            if let Err(e) = verify_proof::<PedersenHash>(*storage_key, self.root, &self.storage_proofs[index]) {
+                errors.push(e);
+            }
+        }
+
+        if errors.is_empty() { Ok(()) } else { Err(errors) }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PathfinderProof {
+    pub state_commitment: Felt,
+    pub class_commitment: Felt,
+    pub contract_proof: Vec<TrieNode>,
+    pub contract_data: Option<ContractData>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Deserialize)]
+pub struct PathfinderClassProof {
+    pub class_commitment: Felt,
+    pub class_proof: Vec<TrieNode>,
+}
+
+impl PathfinderClassProof {
+    /// Verifies that the class proof is valid.
+    pub fn verify(&self, class_hash: Felt) -> Result<(), ProofVerificationError> {
+        verify_proof::<PoseidonHash>(class_hash, self.class_commitment, &self.class_proof)
+    }
+}
+
+// Types defined for Deserialize functionality
+#[derive(Debug, Clone, Deserialize)]
+pub struct EdgePath {
+    pub len: u64,
+    pub value: Felt,
+}
+
+/// This function goes through the tree from top to bottom and verifies that
+/// the hash of each node is equal to the corresponding hash in the parent node.
+pub fn verify_proof<H: HashFunctionType>(
+    key: Felt,
+    commitment: Felt,
+    proof: &[TrieNode],
+) -> Result<(), ProofVerificationError> {
+    let bits = key.to_bits_be();
+
+    let mut parent_hash = commitment;
+    let mut trie_node_iter = proof.iter();
+
+    // The tree height is 251, so the first 5 bits are ignored.
+    let start = 5;
+    let mut index = start;
+
+    loop {
+        match trie_node_iter.next() {
+            None => {
+                if index - start != DEFAULT_STORAGE_TREE_HEIGHT {
+                    return Err(ProofVerificationError::KeyNotInProof { key, height: Height(index - start), proof });
+                }
+                break;
+            }
+            Some(node) => {
+                let node_hash = node.hash::<H>();
+                if node_hash != parent_hash {
+                    return Err(ProofVerificationError::InvalidChildNodeHash { node_hash, parent_hash });
+                }
+
+                match node {
+                    TrieNode::Binary { left, right } => {
+                        parent_hash = if bits[index as usize] { *right } else { *left };
+                        index += 1;
+                    }
+                    TrieNode::Edge { child, path } => {
+                        parent_hash = *child;
+                        index += path.len;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rpc-replay/Cargo.toml
+++ b/crates/rpc-replay/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 [dependencies]
 blockifier = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
+rpc-client = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 starknet = { workspace = true }

--- a/crates/rpc-replay/src/rpc_state_reader.rs
+++ b/crates/rpc-replay/src/rpc_state_reader.rs
@@ -1,9 +1,9 @@
 use blockifier::execution::contract_class::ContractClass;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
+use rpc_client::client::RpcClient;
 use starknet::core::types::{BlockId, Felt, StarknetError};
-use starknet::providers::jsonrpc::JsonRpcTransport;
-use starknet::providers::{JsonRpcClient, Provider, ProviderError};
+use starknet::providers::{Provider, ProviderError};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::StorageKey;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
@@ -12,20 +12,14 @@ use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 
 use crate::utils::execute_coroutine;
 
-pub struct AsyncRpcStateReader<T>
-where
-    T: JsonRpcTransport,
-{
-    provider: JsonRpcClient<T>,
+pub struct AsyncRpcStateReader {
+    rpc_client: RpcClient,
     block_id: BlockId,
 }
 
-impl<T> AsyncRpcStateReader<T>
-where
-    T: JsonRpcTransport,
-{
-    pub fn new(provider: JsonRpcClient<T>, block_id: BlockId) -> Self {
-        Self { provider, block_id }
+impl AsyncRpcStateReader {
+    pub fn new(rpc_client: RpcClient, block_id: BlockId) -> Self {
+        Self { rpc_client, block_id }
     }
 }
 
@@ -37,24 +31,26 @@ fn to_state_err<E: ToString>(e: E) -> StateError {
     StateError::StateReadError(e.to_string())
 }
 
-impl<T> AsyncRpcStateReader<T>
-where
-    T: JsonRpcTransport + Sync + Send + 'static,
-{
+impl AsyncRpcStateReader {
     pub async fn get_storage_at_async(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt> {
-        let storage_value =
-            match self.provider.get_storage_at(*contract_address.key(), *key.0.key(), self.block_id).await {
-                Ok(value) => Ok(value),
-                Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
-                Err(e) => Err(provider_error_to_state_error(e)),
-            }?;
+        let storage_value = match self
+            .rpc_client
+            .starknet_rpc()
+            .get_storage_at(*contract_address.key(), *key.0.key(), self.block_id)
+            .await
+        {
+            Ok(value) => Ok(value),
+            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
+            Err(e) => Err(provider_error_to_state_error(e)),
+        }?;
 
         Ok(storage_value)
     }
 
     pub async fn get_nonce_at_async(&self, contract_address: ContractAddress) -> StateResult<Nonce> {
         let nonce = self
-            .provider
+            .rpc_client
+            .starknet_rpc()
             .get_nonce(self.block_id, *contract_address.key())
             .await
             .map_err(provider_error_to_state_error)?;
@@ -63,18 +59,23 @@ where
     }
 
     pub async fn get_class_hash_at_async(&self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        let class_hash = match self.provider.get_class_hash_at(self.block_id, *contract_address.key()).await {
-            Ok(class_hash) => Ok(class_hash),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(ClassHash::default().0),
-            Err(e) => Err(provider_error_to_state_error(e)),
-        }?;
+        let class_hash =
+            match self.rpc_client.starknet_rpc().get_class_hash_at(self.block_id, *contract_address.key()).await {
+                Ok(class_hash) => Ok(class_hash),
+                Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(ClassHash::default().0),
+                Err(e) => Err(provider_error_to_state_error(e)),
+            }?;
 
         Ok(ClassHash(class_hash))
     }
 
     pub async fn get_compiled_contract_class_async(&self, class_hash: ClassHash) -> StateResult<ContractClass> {
-        let contract_class =
-            self.provider.get_class(self.block_id, class_hash.0).await.map_err(provider_error_to_state_error)?;
+        let contract_class = self
+            .rpc_client
+            .starknet_rpc()
+            .get_class(self.block_id, class_hash.0)
+            .await
+            .map_err(provider_error_to_state_error)?;
 
         let contract_class: ContractClass = match contract_class {
             starknet::core::types::ContractClass::Sierra(sierra_class) => {
@@ -92,8 +93,12 @@ where
     }
 
     pub async fn get_compiled_class_hash_async(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
-        let contract_class =
-            self.provider.get_class(self.block_id, class_hash.0).await.map_err(provider_error_to_state_error)?;
+        let contract_class = self
+            .rpc_client
+            .starknet_rpc()
+            .get_class(self.block_id, class_hash.0)
+            .await
+            .map_err(provider_error_to_state_error)?;
 
         let class_hash: GenericClassHash = match contract_class {
             starknet::core::types::ContractClass::Sierra(sierra_class) => {
@@ -111,10 +116,7 @@ where
     }
 }
 
-impl<T> StateReader for AsyncRpcStateReader<T>
-where
-    T: JsonRpcTransport + Sync + Send + 'static,
-{
+impl StateReader for AsyncRpcStateReader {
     fn get_storage_at(&self, contract_address: ContractAddress, key: StorageKey) -> StateResult<Felt> {
         execute_coroutine(self.get_storage_at_async(contract_address, key)).map_err(to_state_err)?
     }

--- a/crates/rpc-replay/tests/test_replay_block.rs
+++ b/crates/rpc-replay/tests/test_replay_block.rs
@@ -2,13 +2,13 @@ use blockifier::blockifier::block::GasPrices;
 use blockifier::state::cached_state::CachedState;
 use blockifier::transaction::transactions::ExecutableTransaction as _;
 use blockifier::versioned_constants::StarknetVersion;
+use rpc_client::RpcClient;
 use rpc_replay::block_context::build_block_context;
 use rpc_replay::rpc_state_reader::AsyncRpcStateReader;
 use rpc_replay::transactions::starknet_rs_to_blockifier;
 use rstest::rstest;
 use starknet::core::types::{BlockId, BlockWithTxs};
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider, Url};
+use starknet::providers::Provider;
 use starknet_api::core::ChainId;
 
 #[rstest]
@@ -22,23 +22,15 @@ async fn test_replay_block() {
     println!("block: {block_with_txs:?}");
 
     let rpc_provider = "http://localhost:9545";
-    let provider_url = format!("{}/rpc/v0_7", rpc_provider);
-    println!("provider url: {}", provider_url);
-    let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
-    ));
+    let rpc_client = RpcClient::new(rpc_provider);
     let block_id = BlockId::Number(block_with_txs.block_number - 1);
-    let state_reader = AsyncRpcStateReader::new(provider, block_id);
+    let state_reader = AsyncRpcStateReader::new(rpc_client.clone(), block_id);
     let mut state = CachedState::from(state_reader);
 
     let block_context = build_block_context(ChainId::Sepolia, &block_with_txs, StarknetVersion::V0_13_1);
 
-    // Workaround for JsonRpcClient not implementing Clone
-    let provider = JsonRpcClient::new(HttpTransport::new(
-        Url::parse(provider_url.as_str()).expect("Could not parse provider url"),
-    ));
-
-    let traces = provider.trace_block_transactions(block_id).await.expect("Failed to get block tx traces");
+    let traces =
+        rpc_client.starknet_rpc().trace_block_transactions(block_id).await.expect("Failed to get block tx traces");
     let gas_prices = GasPrices {
         eth_l1_gas_price: 1u128.try_into().unwrap(),
         strk_l1_gas_price: 1u128.try_into().unwrap(),


### PR DESCRIPTION
Problems:
* We manage two types of clients, one for Starknet RPC endpoints and another for Pathfinder proof endpoints.
* We end up spawning way more clients than necessary because the starknet-rs client type does not implement Clone.

Solution: encapsulate all RPC-related objects in a new struct, `RpcClient`. This struct lives in the new `rpc-client` crate.

* Moved all the code related to proofs in the `rpc-client` crate.
* Updated `rpc-replay` and `prove-block` to use the new RPC client.
* Added a layer to encapsulate the raw `reqwest` client used for Pathfinder proof endpoints in the new `PathfinderRpcClient` struct.

At this stage `RpcClient` still provides direct access to the Starknet and Pathfinder RPC clients, and does not implement anything fancy (read: caching). The goal of this PR is to clean up the code and encapsulate functionalities.

Issue Number: N/A

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
