### PR TITLE
Fix: pass deprecated compiled classes to the OS input

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -254,6 +254,7 @@ pub async fn prove_block(
     }
 
     let compiled_classes = processed_state_update.compiled_classes;
+    let deprecated_compiled_classes = processed_state_update.deprecated_compiled_classes;
 
     // query storage proofs for each accessed contract
     let class_hashes: Vec<&Felt252> = class_hash_to_compiled_class_hash.keys().collect();
@@ -305,7 +306,7 @@ pub async fn prove_block(
     let os_input = StarknetOsInput {
         contract_state_commitment_info,
         contract_class_commitment_info,
-        deprecated_compiled_classes: Default::default(),
+        deprecated_compiled_classes,
         compiled_classes,
         compiled_class_visited_pcs: visited_pcs,
         contracts: contract_states,

--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -18,6 +18,7 @@ pub struct FormattedStateUpdate {
     // TODO: Use more descriptive types
     pub class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252>,
     pub compiled_classes: HashMap<Felt252, GenericCasmContractClass>,
+    pub deprecated_compiled_classes: HashMap<Felt252, GenericDeprecatedCompiledClass>,
 }
 
 /// Given the `block_id` of the target block to prove, it:
@@ -45,7 +46,7 @@ pub(crate) async fn get_formatted_state_update(
 
     // TODO: Handle deprecated classes
     let mut class_hash_to_compiled_class_hash: HashMap<Felt252, Felt252> = format_declared_classes(&state_diff);
-    let (compiled_contract_classes, _deprecated_compiled_contract_class) =
+    let (compiled_contract_classes, deprecated_compiled_contract_classes) =
         build_compiled_class_and_maybe_update_class_hash_to_compiled_class_hash(
             provider,
             previous_block_id,
@@ -57,7 +58,11 @@ pub(crate) async fn get_formatted_state_update(
         .await?;
 
     Ok((
-        FormattedStateUpdate { class_hash_to_compiled_class_hash, compiled_classes: compiled_contract_classes },
+        FormattedStateUpdate {
+            class_hash_to_compiled_class_hash,
+            compiled_classes: compiled_contract_classes,
+            deprecated_compiled_classes: deprecated_compiled_contract_classes,
+        },
         traces,
     ))
 }


### PR DESCRIPTION
Problem: for some reason, we do not pass Cairo 0 compiled classes in the OS input, despite computing them.

Solution: add them to the formatted state update and pass them to the OS input.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
