### PR TITLE
fix: remove duplication and check both class proofs

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -71,7 +71,7 @@ fn compute_class_commitment(
         assert!(previous_class_proof.verify(*class_hash).is_ok());
     }
 
-    for (class_hash, class_proof) in previous_class_proofs {
+    for (class_hash, class_proof) in class_proofs {
         assert!(class_proof.verify(*class_hash).is_ok());
     }
 


### PR DESCRIPTION
Problem: Currently the code iterates and checks through the same proofs twice
Solution: Make sure both proofs are checked.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
