### PR TITLE
Explicitly print inner_exc error

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -326,6 +326,7 @@ pub fn debug_prove_error(err: ProveBlockError) -> ProveBlockError {
             log::error!("died at: {}:{}", inst_location.input_file.filename, inst_location.start_line);
             log::error!("inst_location:\n{:?}", inst_location);
         }
+        log::error!("\ninner_exc error: {}\n", vme.inner_exc);
     }
     err
 }


### PR DESCRIPTION
This prints `inner_exc` clearly on its own line. This is usually the error message that's interesting, and it's otherwise buried and difficult to visually scan for. This also makes it practical to `grep` it.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
