### PR TITLE
Dev: Don't wrap comments with cargo fmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -17,4 +17,3 @@ imports_granularity = "Module"
 group_imports = "StdExternalCrate"
 normalize_comments = true
 normalize_doc_attributes = true
-wrap_comments = true


### PR DESCRIPTION
Problem: `cargo fmt` will mangle comments to make them fit on one line. This causes problems especially when code is commented out, but also seems to fight me when I want a multi-line comment to look a specific way.

Solution: remove `wrap_comments = true` from `rustfmt.toml`, allowing the default (true) to kick in.

Documentation: https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#wrap_comments

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
