### PR TITLE
Fix: invalid type conversions in GenericSierraContractClass

### DIFF
--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -123,14 +123,15 @@ async fn create_class_info(
         client.starknet_rpc().get_class(BlockId::Number(block_number), class_hash).await?;
 
     let (blockifier_contract_class, program_length, abi_length) = match starknet_contract_class {
-        starknet::core::types::ContractClass::Sierra(sierra) => {
-            let generic_sierra = GenericSierraContractClass::from(sierra);
-            let flattened_sierra = generic_sierra.clone().to_starknet_core_contract_class()?;
+        starknet::core::types::ContractClass::Sierra(sierra_class) => {
+            let program_length = sierra_class.sierra_program.len();
+            let abi_length = sierra_class.abi.len();
+            let generic_sierra = GenericSierraContractClass::from(sierra_class);
             let contract_class = blockifier::execution::contract_class::ContractClass::V1(
                 generic_sierra.compile()?.to_blockifier_contract_class()?,
             );
 
-            (contract_class, flattened_sierra.sierra_program.len(), flattened_sierra.abi.len())
+            (contract_class, program_length, abi_length)
         }
 
         starknet::core::types::ContractClass::Legacy(legacy) => {

--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -14,7 +14,6 @@ flate2 = { workspace = true }
 pathfinder-gateway-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { workspace = true }
 starknet_api = { workspace = true }
 starknet-types-core = { workspace = true }
 starknet-core = { workspace = true }


### PR DESCRIPTION
Problem: for a block with a declare tx, we fail when attempting to convert the flattened Sierra class into a `cairo-lang` class before compiling it.

Solution: we now store a `SierraClass` instead of a `FlattenedSierraClass` in the generic struct. This simplifies JSON conversions.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
