### PR TITLE
Temporary: Improve external usability

### DIFF
--- a/crates/starknet-os-types/src/deprecated_compiled_class.rs
+++ b/crates/starknet-os-types/src/deprecated_compiled_class.rs
@@ -1,5 +1,5 @@
 use std::cell::OnceCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use pathfinder_gateway_types::class_hash::compute_class_hash;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -20,9 +20,9 @@ pub type BlockifierDeprecatedClass = blockifier::execution::contract_class::Cont
 /// Fields are boxed in an RC for cheap cloning.
 #[derive(Debug, Clone)]
 pub struct GenericDeprecatedCompiledClass {
-    blockifier_contract_class: OnceCell<Rc<BlockifierDeprecatedClass>>,
-    starknet_api_contract_class: OnceCell<Rc<StarknetApiDeprecatedClass>>,
-    starknet_core_contract_class: OnceCell<Rc<StarknetCoreDeprecatedClass>>,
+    blockifier_contract_class: OnceCell<Arc<BlockifierDeprecatedClass>>,
+    starknet_api_contract_class: OnceCell<Arc<StarknetApiDeprecatedClass>>,
+    starknet_core_contract_class: OnceCell<Arc<StarknetCoreDeprecatedClass>>,
     serialized_class: OnceCell<Vec<u8>>,
     class_hash: OnceCell<GenericClassHash>,
 }
@@ -56,13 +56,13 @@ impl GenericDeprecatedCompiledClass {
 
     pub fn get_starknet_api_contract_class(&self) -> Result<&StarknetApiDeprecatedClass, ContractClassError> {
         self.starknet_api_contract_class
-            .get_or_try_init(|| self.build_starknet_api_class().map(Rc::new))
+            .get_or_try_init(|| self.build_starknet_api_class().map(Arc::new))
             .map(|boxed| boxed.as_ref())
     }
 
     pub fn get_blockifier_contract_class(&self) -> Result<&BlockifierDeprecatedClass, ContractClassError> {
         self.blockifier_contract_class
-            .get_or_try_init(|| self.build_blockifier_class().map(Rc::new))
+            .get_or_try_init(|| self.build_blockifier_class().map(Arc::new))
             .map(|boxed| boxed.as_ref())
     }
 
@@ -128,7 +128,7 @@ impl From<StarknetApiDeprecatedClass> for GenericDeprecatedCompiledClass {
     fn from(starknet_api_class: StarknetApiDeprecatedClass) -> Self {
         Self {
             blockifier_contract_class: Default::default(),
-            starknet_api_contract_class: OnceCell::from(Rc::new(starknet_api_class)),
+            starknet_api_contract_class: OnceCell::from(Arc::new(starknet_api_class)),
             starknet_core_contract_class: Default::default(),
             serialized_class: Default::default(),
             class_hash: Default::default(),
@@ -151,7 +151,7 @@ impl TryFrom<CompressedStarknetCoreDeprecatedClass> for GenericDeprecatedCompile
 impl From<BlockifierDeprecatedClass> for GenericDeprecatedCompiledClass {
     fn from(blockifier_class: BlockifierDeprecatedClass) -> Self {
         Self {
-            blockifier_contract_class: OnceCell::from(Rc::new(blockifier_class)),
+            blockifier_contract_class: OnceCell::from(Arc::new(blockifier_class)),
             starknet_api_contract_class: Default::default(),
             starknet_core_contract_class: Default::default(),
             serialized_class: Default::default(),
@@ -165,7 +165,7 @@ impl From<StarknetCoreDeprecatedClass> for GenericDeprecatedCompiledClass {
         Self {
             blockifier_contract_class: Default::default(),
             starknet_api_contract_class: Default::default(),
-            starknet_core_contract_class: OnceCell::from(Rc::new(starknet_core_class)),
+            starknet_core_contract_class: OnceCell::from(Arc::new(starknet_core_class)),
             serialized_class: Default::default(),
             class_hash: Default::default(),
         }

--- a/crates/starknet-os-types/src/sierra_contract_class.rs
+++ b/crates/starknet-os-types/src/sierra_contract_class.rs
@@ -1,5 +1,5 @@
 use std::cell::OnceCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use cairo_vm::Felt252;
 use pathfinder_gateway_types::class_hash::compute_class_hash;
@@ -20,11 +20,11 @@ pub type StarknetCoreSierraContractClass = starknet_core::types::FlattenedSierra
 /// contract class types in Starknet and provides utility methods.
 /// Operations are implemented as lazily as possible, i.e. we only convert
 /// between different types if strictly necessary.
-/// Fields are boxed in an RC for cheap cloning.
+/// Fields are boxed in an Arc for cheap cloning.
 #[derive(Debug, Clone)]
 pub struct GenericSierraContractClass {
-    cairo_lang_contract_class: OnceCell<Rc<CairoLangSierraContractClass>>,
-    starknet_core_contract_class: OnceCell<Rc<StarknetCoreSierraContractClass>>,
+    cairo_lang_contract_class: OnceCell<Arc<CairoLangSierraContractClass>>,
+    starknet_core_contract_class: OnceCell<Arc<StarknetCoreSierraContractClass>>,
     serialized_class: OnceCell<Vec<u8>>,
     class_hash: OnceCell<GenericClassHash>,
 }
@@ -58,13 +58,13 @@ impl GenericSierraContractClass {
     }
     pub fn get_cairo_lang_contract_class(&self) -> Result<&CairoLangSierraContractClass, ContractClassError> {
         self.cairo_lang_contract_class
-            .get_or_try_init(|| self.build_cairo_lang_class().map(Rc::new))
+            .get_or_try_init(|| self.build_cairo_lang_class().map(Arc::new))
             .map(|boxed| boxed.as_ref())
     }
 
     pub fn get_starknet_core_contract_class(&self) -> Result<&StarknetCoreSierraContractClass, ContractClassError> {
         self.starknet_core_contract_class
-            .get_or_try_init(|| self.build_starknet_core_class().map(Rc::new))
+            .get_or_try_init(|| self.build_starknet_core_class().map(Arc::new))
             .map(|boxed| boxed.as_ref())
     }
 
@@ -194,7 +194,7 @@ impl<'de> Deserialize<'de> for GenericSierraContractClass {
 impl From<CairoLangSierraContractClass> for GenericSierraContractClass {
     fn from(cairo_lang_class: CairoLangSierraContractClass) -> Self {
         Self {
-            cairo_lang_contract_class: OnceCell::from(Rc::new(cairo_lang_class)),
+            cairo_lang_contract_class: OnceCell::from(Arc::new(cairo_lang_class)),
             starknet_core_contract_class: Default::default(),
             serialized_class: Default::default(),
             class_hash: Default::default(),
@@ -206,7 +206,7 @@ impl From<StarknetCoreSierraContractClass> for GenericSierraContractClass {
     fn from(starknet_core_class: StarknetCoreSierraContractClass) -> Self {
         Self {
             cairo_lang_contract_class: Default::default(),
-            starknet_core_contract_class: OnceCell::from(Rc::new(starknet_core_class)),
+            starknet_core_contract_class: OnceCell::from(Arc::new(starknet_core_class)),
             serialized_class: Default::default(),
             class_hash: Default::default(),
         }


### PR DESCRIPTION
Issue Number: #364 

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [x] build
- [ ] docs
- [ ] testing

## Description

This PR implements the easiest path to making SNOS and `prove_block` usable externally as needed in #364. It does so by making two easy trade-offs:

### Including OS build artifacts (committing `build/os_latest.json`) - a98e1b0

This prevents `include_bytes!("../../../build/os_latest.json");` from failing without introducing a lot of complexity in build automation, but now we have an artifact to manage which will likely cause confusion, unintended changes, etc.

Alternatives I explored could include [pyO3](https://pyo3.rs/v0.14.2/building_and_distribution.html) or [building with docker](https://github.com/starkware-libs/cairo-lang#building-using-the-dockerfile). Either might work, but would come with a lot of build complexity, maintenance, etc.

### Converting `Rc` to `Arc` - db898dc

This is probably not controversial, although it does come with some overhead. The overhead probably doesn't appear in any hot path, although I don't have a good way to measure this.

## Breaking changes?

- [x] yes
- [ ] no
