### PR TITLE
Add block test to cover missing EvalCircuit hint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cairo-lang-starknet-classes = { version = "=2.7.1" }
 cairo-lang-utils = { version = "=2.7.1" }
 cairo-lang-casm = { version = "=2.7.1" }
 cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
-cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "0a576bb5c4a4e6303d0a7429bc5c82fcbda57d45", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
+cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "79cefb786f407ad0536db253e86017d3c4039f5e", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
 clap = { version = "4.5.4", features = ["derive"] }
 c-kzg = { version = "1.0.3" }
 env_logger = "0.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cairo-lang-starknet-classes = { version = "=2.7.1" }
 cairo-lang-utils = { version = "=2.7.1" }
 cairo-lang-casm = { version = "=2.7.1" }
 cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
-cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "a581ba5aea56489d0ad3127e71bc666615ce2224", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
+cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "679f4124f8bc2120e54f1f3fbe4fed23ae9eb765", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
 clap = { version = "4.5.4", features = ["derive"] }
 c-kzg = { version = "1.0.3" }
 env_logger = "0.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cairo-lang-starknet-classes = { version = "=2.7.1" }
 cairo-lang-utils = { version = "=2.7.1" }
 cairo-lang-casm = { version = "=2.7.1" }
 cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
-cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "679f4124f8bc2120e54f1f3fbe4fed23ae9eb765", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
+cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "0a576bb5c4a4e6303d0a7429bc5c82fcbda57d45", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
 clap = { version = "4.5.4", features = ["derive"] }
 c-kzg = { version = "1.0.3" }
 env_logger = "0.11.3"

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -13,6 +13,7 @@ use rstest::rstest;
 // # * 87041: block with nonce bump inconsistency
 // # * 66645 / 66776: Blob DA blocks
 // # * 97581, 101556, 102076 deploy account txns
+// # * 160023: EvalCircuit hint used
 #[rstest]
 #[case::small_block_with_only_invoke_txs(76793)]
 #[case::additional_basic_blocks_1(76766)]
@@ -33,6 +34,7 @@ use rstest::rstest;
 #[case::deploy_account_v1(97581)]
 #[case::deploy_account_v3(101556)]
 #[case::deploy_account_many_txs(102076)]
+#[case::eval_circuit(160023)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -13,7 +13,7 @@ use rstest::rstest;
 // # * 87041: block with nonce bump inconsistency
 // # * 66645 / 66776: Blob DA blocks
 // # * 97581, 101556, 102076 deploy account txns
-// # * 160023: EvalCircuit hint used
+// # * 160035: EvalCircuit hint used
 #[rstest]
 #[case::small_block_with_only_invoke_txs(76793)]
 #[case::additional_basic_blocks_1(76766)]
@@ -34,7 +34,7 @@ use rstest::rstest;
 #[case::deploy_account_v1(97581)]
 #[case::deploy_account_v3(101556)]
 #[case::deploy_account_many_txs(102076)]
-#[case::eval_circuit(160023)]
+#[case::eval_circuit(160035)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {


### PR DESCRIPTION
Adds test to cover the previously-missing EvalCircuit hint.

~~Points to https://github.com/Moonsong-Labs/cairo-vm/pull/44~~

Currently points to `79cefb786f407ad0536db253e86017d3c4039f5e` which is on branch `notlesh/snos-rc-2024-09-13`. This contains PRs 41, 43, and 44

Issue Number: #366 

## Type

- [ ] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
