### PR TITLE
Test: add pie validity check to prove block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cairo-lang-starknet-classes = { version = "=2.7.1" }
 cairo-lang-utils = { version = "=2.7.1" }
 cairo-lang-casm = { version = "=2.7.1" }
 cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
-cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", branch = "notlesh/segment-arena-relocation-fix", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
+cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", rev = "56b68b50944ecb3123a168218ea7b8b8e23f9be8", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
 clap = { version = "4.5.4", features = ["derive"] }
 c-kzg = { version = "1.0.3" }
 env_logger = "0.11.3"

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -47,8 +47,10 @@ use rstest::rstest;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {
     let endpoint = std::env::var("PATHFINDER_RPC_URL").expect("Missing PATHFINDER_RPC_URL in env");
-    prove_block(block_number, &endpoint, LayoutName::all_cairo)
+    let (pie, _output) = prove_block(block_number, &endpoint, LayoutName::all_cairo)
         .await
         .map_err(debug_prove_error)
         .expect("Block could not be proven");
+
+    assert!(pie.run_validity_checks().is_ok());
 }

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -50,7 +50,7 @@ async fn test_prove_selected_blocks(#[case] block_number: u64) {
     let (pie, _output) = prove_block(block_number, &endpoint, LayoutName::all_cairo)
         .await
         .map_err(debug_prove_error)
-        .expect("Block could not be proven");
+        .expect("OS failed to generate Cairo Pie");
 
     pie.run_validity_checks().expect("Cairo Pie run validity checks failed");
 }

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -52,5 +52,5 @@ async fn test_prove_selected_blocks(#[case] block_number: u64) {
         .map_err(debug_prove_error)
         .expect("Block could not be proven");
 
-    assert!(pie.run_validity_checks().is_ok());
+    pie.run_validity_checks().expect("Cairo Pie run validity checks failed");
 }

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -920,7 +920,7 @@ where
         Err(_) => {
             println!("exception:\n{:#?}", result);
         }
-        Ok((pie, output)) => {
+        Ok((pie, _output)) => {
             pie.run_validity_checks().expect("Validity check failed");
         }
     }

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -920,7 +920,9 @@ where
         Err(_) => {
             println!("exception:\n{:#?}", result);
         }
-        _ => {}
+        Ok((pie, output)) => {
+            pie.run_validity_checks().expect("Validity check failed");
+        }
     }
 
     result


### PR DESCRIPTION
Problem: We weren't performing validation checks on the PIEs we were generating.
Fix: Adds run_validity_checks() in our prove block tests