### PR TITLE
Fix inconsistent class hash

### DIFF
--- a/.github/workflows/prove_blocks.yml
+++ b/.github/workflows/prove_blocks.yml
@@ -51,3 +51,9 @@ jobs:
           PATHFINDER_RPC_URL: ${{ secrets.PATHFINDER_RPC_URL }}
         run: |
           cargo test --release --package prove_block --test prove_block -- test_prove_selected_blocks --show-output --ignored
+
+      - name: Class hashes
+        env:
+          PATHFINDER_RPC_URL: ${{ secrets.PATHFINDER_RPC_URL }}
+        run: |
+          cargo test --release --package prove_block --test hash_tests -- test_recompute_class_hash --show-output --ignored

--- a/crates/bin/prove_block/Cargo.toml
+++ b/crates/bin/prove_block/Cargo.toml
@@ -21,6 +21,7 @@ hex = { workspace = true }
 pathfinder-common = { workspace = true }
 pathfinder-crypto = { workspace = true }
 pathfinder-serde = { workspace = true }
+pathfinder-gateway-types = { workspace = true }
 reqwest = { workspace = true }
 rpc-client = { workspace = true }
 rpc-replay = { workspace = true }

--- a/crates/bin/prove_block/Cargo.toml
+++ b/crates/bin/prove_block/Cargo.toml
@@ -15,7 +15,9 @@ cairo-vm = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
+flate2 = { workspace = true }
 futures-core = { workspace = true }
+hex = { workspace = true }
 pathfinder-common = { workspace = true }
 pathfinder-crypto = { workspace = true }
 pathfinder-serde = { workspace = true }
@@ -27,6 +29,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 starknet_api = { workspace = true }
 starknet = { workspace = true }
+starknet-core = { workspace = true }
 starknet-os = { workspace = true }
 starknet-os-types = { workspace = true }
 starknet-types-core = { workspace = true }

--- a/crates/bin/prove_block/Cargo.toml
+++ b/crates/bin/prove_block/Cargo.toml
@@ -15,13 +15,10 @@ cairo-vm = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-flate2 = { workspace = true }
 futures-core = { workspace = true }
-hex = { workspace = true }
 pathfinder-common = { workspace = true }
 pathfinder-crypto = { workspace = true }
 pathfinder-serde = { workspace = true }
-pathfinder-gateway-types = { workspace = true }
 reqwest = { workspace = true }
 rpc-client = { workspace = true }
 rpc-replay = { workspace = true }
@@ -30,7 +27,6 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 starknet_api = { workspace = true }
 starknet = { workspace = true }
-starknet-core = { workspace = true }
 starknet-os = { workspace = true }
 starknet-os-types = { workspace = true }
 starknet-types-core = { workspace = true }

--- a/crates/bin/prove_block/tests/hash_tests.rs
+++ b/crates/bin/prove_block/tests/hash_tests.rs
@@ -7,8 +7,8 @@ use rstest::rstest;
 use starknet::core::types::BlockId;
 use starknet::providers::Provider;
 use starknet_core::types::contract::legacy::{
-    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyEntryPoint, RawLegacyEntryPoints,
-    RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
+    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyConstructor, RawLegacyEntryPoint,
+    RawLegacyEntryPoints, RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
 };
 use starknet_core::types::{
     LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType, LegacyFunctionAbiEntry,
@@ -110,14 +110,17 @@ async fn test_recompute_class_hash2(#[case] class_hash_str: String, #[case] bloc
 
 fn raw_abi_entry_from_legacy_function_abi_entry(entry: LegacyFunctionAbiEntry) -> RawLegacyAbiEntry {
     match entry.r#type {
-        LegacyFunctionAbiType::Function | LegacyFunctionAbiType::Constructor => {
-            RawLegacyAbiEntry::Function(RawLegacyFunction {
-                inputs: entry.inputs,
-                name: entry.name,
-                outputs: entry.outputs,
-                state_mutability: entry.state_mutability,
-            })
-        }
+        LegacyFunctionAbiType::Function => RawLegacyAbiEntry::Function(RawLegacyFunction {
+            inputs: entry.inputs,
+            name: entry.name,
+            outputs: entry.outputs,
+            state_mutability: entry.state_mutability,
+        }),
+        LegacyFunctionAbiType::Constructor => RawLegacyAbiEntry::Constructor(RawLegacyConstructor {
+            inputs: entry.inputs,
+            name: entry.name,
+            outputs: entry.outputs,
+        }),
         LegacyFunctionAbiType::L1Handler => RawLegacyAbiEntry::L1Handler(RawLegacyL1Handler {
             inputs: entry.inputs,
             name: entry.name,

--- a/crates/bin/prove_block/tests/hash_tests.rs
+++ b/crates/bin/prove_block/tests/hash_tests.rs
@@ -153,7 +153,7 @@ fn raw_legacy_abi_entry_from_legacy_contract_abi_entry(
 
 fn raw_legacy_entrypoint_from_legacy_entrypoint(legacy_entry_point: LegacyContractEntryPoint) -> RawLegacyEntryPoint {
     RawLegacyEntryPoint {
-        offset: LegacyEntrypointOffset::U64AsHex(legacy_entry_point.offset),
+        offset: LegacyEntrypointOffset::U64AsInt(legacy_entry_point.offset),
         selector: legacy_entry_point.selector,
     }
 }

--- a/crates/bin/prove_block/tests/hash_tests.rs
+++ b/crates/bin/prove_block/tests/hash_tests.rs
@@ -1,0 +1,39 @@
+use rpc_client::RpcClient;
+use rstest::rstest;
+use starknet::core::types::BlockId;
+use starknet::providers::Provider;
+use starknet_os_types::compiled_class::GenericCompiledClass;
+use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
+use starknet_types_core::felt::Felt;
+
+const PATHFINDER_RPC_URL: &str = "http://81.16.176.130:9545";
+// # These blocks verify the following issues:
+// # * Block number 78720 : Class hash computation works fine
+// # * Block number 30000 : Class hash computation mismatch
+#[rstest]
+// Contract address 0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
+#[case::correct_hash_computation("0x07b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69", 78720)]
+// Contract address 0x7a3c142b1ef242f093642604c2ac2259da0efa3a0517715c34a722ba2ecd048
+#[case::correct_hash_computation("0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6", 30000)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recompute_class_hash(#[case] class_hash_str: String, #[case] block_number: u64) {
+    let class_hash = Felt::from_hex(&class_hash_str).unwrap();
+    let block_id = BlockId::Number(block_number);
+
+    let rpc_client = RpcClient::new(PATHFINDER_RPC_URL);
+    let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash).await.unwrap();
+
+    let compiled_class = if let starknet::core::types::ContractClass::Legacy(legacy_cc) = contract_class {
+        let compiled_class = GenericDeprecatedCompiledClass::try_from(legacy_cc).unwrap();
+        GenericCompiledClass::Cairo0(compiled_class)
+    } else {
+        panic!("Test intended to test Legacy contracts");
+    };
+
+    let recomputed_class_hash = Felt::from(compiled_class.class_hash().unwrap());
+
+    println!("Class hash: {:#x}", class_hash);
+    println!("Recomputed class hash: {:#x}", recomputed_class_hash);
+
+    assert_eq!(class_hash, recomputed_class_hash);
+}

--- a/crates/bin/prove_block/tests/hash_tests.rs
+++ b/crates/bin/prove_block/tests/hash_tests.rs
@@ -1,7 +1,20 @@
+use std::io::Read;
+
+use flate2::read::GzDecoder;
 use rpc_client::RpcClient;
 use rstest::rstest;
+use serde::Serialize;
+// use starknet::core::types::contract::legacy::LegacyContractClass;
 use starknet::core::types::BlockId;
 use starknet::providers::Provider;
+use starknet_core::types::contract::legacy::{
+    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyEntryPoint, RawLegacyEntryPoints,
+    RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
+};
+use starknet_core::types::{
+    CompressedLegacyContractClass, LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType,
+    LegacyFunctionAbiEntry, LegacyFunctionAbiType, LegacyStructMember,
+};
 use starknet_os_types::compiled_class::GenericCompiledClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 use starknet_types_core::felt::Felt;
@@ -36,4 +49,131 @@ async fn test_recompute_class_hash(#[case] class_hash_str: String, #[case] block
     println!("Recomputed class hash: {:#x}", recomputed_class_hash);
 
     assert_eq!(class_hash, recomputed_class_hash);
+}
+
+// Keep only Pathfinder classes
+#[rstest]
+// Contract address 0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
+#[case::correct_hash_computation("0x07b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69", 78720)]
+// Contract address 0x7a3c142b1ef242f093642604c2ac2259da0efa3a0517715c34a722ba2ecd048
+#[case::correct_hash_computation("0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6", 30000)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recompute_class_hash2(#[case] class_hash_str: String, #[case] block_number: u64) {
+    let class_hash = Felt::from_hex(&class_hash_str).unwrap();
+    let block_id = BlockId::Number(block_number);
+
+    let rpc_client = RpcClient::new(PATHFINDER_RPC_URL);
+    let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash).await.unwrap();
+
+    let compressed_legacy_contract_class =
+        if let starknet::core::types::ContractClass::Legacy(legacy_cc) = contract_class {
+            legacy_cc
+        } else {
+            panic!("Test intended to test Legacy contracts");
+        };
+
+    let legacy_contract_class = {
+        let mut program_str = String::new();
+        let mut decoder = GzDecoder::new(compressed_legacy_contract_class.program.as_slice());
+        decoder.read_to_string(&mut program_str).unwrap();
+
+        let program: starknet_core::types::contract::legacy::LegacyProgram =
+            serde_json::from_str(&program_str).unwrap();
+        let abi = compressed_legacy_contract_class
+            .abi
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(raw_legacy_abi_entry_from_legacy_contract_abi_entry)
+            .collect::<Vec<_>>();
+
+        LegacyContractClass {
+            abi,
+            entry_points_by_type: raw_legacy_entrypoints_from_legacy_entrypoints(
+                compressed_legacy_contract_class.entry_points_by_type.clone(),
+            ),
+            program,
+        }
+    };
+
+    let recompressed_legacy_class = legacy_contract_class.compress().unwrap();
+    assert_eq!(compressed_legacy_contract_class, recompressed_legacy_class);
+
+    // let recomputed_class_hash = Felt::from(compiled_class.class_hash().unwrap());
+
+    // println!("Class hash: {:#x}", class_hash);
+    // println!("Recomputed class hash: {:#x}", recomputed_class_hash);
+
+    // assert_eq!(class_hash, recomputed_class_hash);
+}
+
+fn raw_abi_entry_from_legacy_function_abi_entry(entry: LegacyFunctionAbiEntry) -> RawLegacyAbiEntry {
+    match entry.r#type {
+        LegacyFunctionAbiType::Function | LegacyFunctionAbiType::Constructor => {
+            RawLegacyAbiEntry::Function(RawLegacyFunction {
+                inputs: entry.inputs,
+                name: entry.name,
+                outputs: entry.outputs,
+                state_mutability: entry.state_mutability,
+            })
+        }
+        LegacyFunctionAbiType::L1Handler => RawLegacyAbiEntry::L1Handler(RawLegacyL1Handler {
+            inputs: entry.inputs,
+            name: entry.name,
+            outputs: entry.outputs,
+        }),
+    }
+}
+
+fn raw_legacy_member_from_legacy_struct_member(member: LegacyStructMember) -> RawLegacyMember {
+    RawLegacyMember { name: member.name, offset: member.offset, r#type: member.r#type }
+}
+
+/// Implementation of From<LegacyContractAbiEntry> for RawLegacyAbiEntry,
+/// as it is missing from starknet-rs and we need it to interpret compressed legacy contracts.
+fn raw_legacy_abi_entry_from_legacy_contract_abi_entry(
+    legacy_contract_abi_entry: LegacyContractAbiEntry,
+) -> RawLegacyAbiEntry {
+    match legacy_contract_abi_entry {
+        LegacyContractAbiEntry::Function(entry) => raw_abi_entry_from_legacy_function_abi_entry(entry),
+        LegacyContractAbiEntry::Struct(entry) => RawLegacyAbiEntry::Struct(RawLegacyStruct {
+            members: entry.members.into_iter().map(raw_legacy_member_from_legacy_struct_member).collect(),
+            name: entry.name,
+            size: entry.size,
+        }),
+        LegacyContractAbiEntry::Event(entry) => {
+            RawLegacyAbiEntry::Event(RawLegacyEvent { data: entry.data, keys: entry.keys, name: entry.name })
+        }
+    }
+}
+
+fn raw_legacy_entrypoint_from_legacy_entrypoint(legacy_entry_point: LegacyContractEntryPoint) -> RawLegacyEntryPoint {
+    RawLegacyEntryPoint {
+        offset: LegacyEntrypointOffset::U64AsHex(legacy_entry_point.offset),
+        selector: legacy_entry_point.selector,
+    }
+}
+
+/// Implementation of From<LegacyEntryPointsByType> for RawLegacyEntryPoints,
+/// as it is missing from starknet-rs and we need it to interpret compressed legacy contracts.
+fn raw_legacy_entrypoints_from_legacy_entrypoints(
+    legacy_entry_points_by_type: LegacyEntryPointsByType,
+) -> RawLegacyEntryPoints {
+    RawLegacyEntryPoints {
+        constructor: legacy_entry_points_by_type
+            .constructor
+            .into_iter()
+            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
+            .collect(),
+        external: legacy_entry_points_by_type
+            .external
+            .into_iter()
+            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
+            .collect(),
+        l1_handler: legacy_entry_points_by_type
+            .l1_handler
+            .into_iter()
+            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
+            .collect(),
+    }
 }

--- a/crates/bin/prove_block/tests/hash_tests.rs
+++ b/crates/bin/prove_block/tests/hash_tests.rs
@@ -1,38 +1,24 @@
-use std::io::Read;
-
-use flate2::read::GzDecoder;
-use pathfinder_gateway_types::class_hash::compute_class_hash;
 use rpc_client::RpcClient;
 use rstest::rstest;
 use starknet::core::types::BlockId;
 use starknet::providers::Provider;
-use starknet_core::types::contract::legacy::{
-    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyConstructor, RawLegacyEntryPoint,
-    RawLegacyEntryPoints, RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
-};
-use starknet_core::types::{
-    LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType, LegacyFunctionAbiEntry,
-    LegacyFunctionAbiType, LegacyStructMember,
-};
 use starknet_os_types::compiled_class::GenericCompiledClass;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 use starknet_types_core::felt::Felt;
 
-const PATHFINDER_RPC_URL: &str = "http://81.16.176.130:9545";
-// # These blocks verify the following issues:
-// # * Block number 78720 : Class hash computation works fine
-// # * Block number 30000 : Class hash computation mismatch
 #[rstest]
 // Contract address 0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
-#[case::correct_hash_computation("0x07b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69", 78720)]
+#[case::correct_hash_computation_0("0x07b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69", 78720)]
 // Contract address 0x7a3c142b1ef242f093642604c2ac2259da0efa3a0517715c34a722ba2ecd048
-#[case::correct_hash_computation("0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6", 30000)]
+#[case::correct_hash_computation_1("0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6", 30000)]
+#[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recompute_class_hash(#[case] class_hash_str: String, #[case] block_number: u64) {
+    let endpoint = std::env::var("PATHFINDER_RPC_URL").expect("Missing PATHFINDER_RPC_URL in env");
     let class_hash = Felt::from_hex(&class_hash_str).unwrap();
     let block_id = BlockId::Number(block_number);
 
-    let rpc_client = RpcClient::new(PATHFINDER_RPC_URL);
+    let rpc_client = RpcClient::new(&endpoint);
     let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash).await.unwrap();
 
     let compiled_class = if let starknet::core::types::ContractClass::Legacy(legacy_cc) = contract_class {
@@ -48,136 +34,4 @@ async fn test_recompute_class_hash(#[case] class_hash_str: String, #[case] block
     println!("Recomputed class hash: {:#x}", recomputed_class_hash);
 
     assert_eq!(class_hash, recomputed_class_hash);
-}
-
-// Keep only Pathfinder classes
-#[rstest]
-// Contract address 0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
-#[case::correct_hash_computation("0x07b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69", 78720)]
-// Contract address 0x7a3c142b1ef242f093642604c2ac2259da0efa3a0517715c34a722ba2ecd048
-#[case::correct_hash_computation("0x5c478ee27f2112411f86f207605b2e2c58cdb647bac0df27f660ef2252359c6", 30000)]
-#[tokio::test(flavor = "multi_thread")]
-async fn test_recompute_class_hash2(#[case] class_hash_str: String, #[case] block_number: u64) {
-    let class_hash = Felt::from_hex(&class_hash_str).unwrap();
-    let block_id = BlockId::Number(block_number);
-
-    let rpc_client = RpcClient::new(PATHFINDER_RPC_URL);
-    let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash).await.unwrap();
-
-    let compressed_legacy_contract_class =
-        if let starknet::core::types::ContractClass::Legacy(legacy_cc) = contract_class {
-            legacy_cc
-        } else {
-            panic!("Test intended to test Legacy contracts");
-        };
-
-    let legacy_contract_class = {
-        let mut program_str = String::new();
-        let mut decoder = GzDecoder::new(compressed_legacy_contract_class.program.as_slice());
-        decoder.read_to_string(&mut program_str).unwrap();
-
-        let program: starknet_core::types::contract::legacy::LegacyProgram =
-            serde_json::from_str(&program_str).unwrap();
-        let abi = compressed_legacy_contract_class
-            .abi
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .map(raw_legacy_abi_entry_from_legacy_contract_abi_entry)
-            .collect::<Vec<_>>();
-
-        LegacyContractClass {
-            abi,
-            entry_points_by_type: raw_legacy_entrypoints_from_legacy_entrypoints(
-                compressed_legacy_contract_class.entry_points_by_type.clone(),
-            ),
-            program,
-        }
-    };
-
-    let serialized_class = serde_json::to_vec(&legacy_contract_class).unwrap();
-    let recomputed_class_hash =
-        Felt::from_bytes_be(&compute_class_hash(&serialized_class).unwrap().hash().0.to_be_bytes());
-
-    println!("Class hash: {:#x}", class_hash);
-    println!("Recomputed class hash: {:#x}", recomputed_class_hash);
-
-    assert_eq!(class_hash, recomputed_class_hash);
-
-    // let recompressed_legacy_class = legacy_contract_class.compress().unwrap();
-    // assert_eq!(compressed_legacy_contract_class, recompressed_legacy_class);
-}
-
-fn raw_abi_entry_from_legacy_function_abi_entry(entry: LegacyFunctionAbiEntry) -> RawLegacyAbiEntry {
-    match entry.r#type {
-        LegacyFunctionAbiType::Function => RawLegacyAbiEntry::Function(RawLegacyFunction {
-            inputs: entry.inputs,
-            name: entry.name,
-            outputs: entry.outputs,
-            state_mutability: entry.state_mutability,
-        }),
-        LegacyFunctionAbiType::Constructor => RawLegacyAbiEntry::Constructor(RawLegacyConstructor {
-            inputs: entry.inputs,
-            name: entry.name,
-            outputs: entry.outputs,
-        }),
-        LegacyFunctionAbiType::L1Handler => RawLegacyAbiEntry::L1Handler(RawLegacyL1Handler {
-            inputs: entry.inputs,
-            name: entry.name,
-            outputs: entry.outputs,
-        }),
-    }
-}
-
-fn raw_legacy_member_from_legacy_struct_member(member: LegacyStructMember) -> RawLegacyMember {
-    RawLegacyMember { name: member.name, offset: member.offset, r#type: member.r#type }
-}
-
-/// Implementation of From<LegacyContractAbiEntry> for RawLegacyAbiEntry,
-/// as it is missing from starknet-rs and we need it to interpret compressed legacy contracts.
-fn raw_legacy_abi_entry_from_legacy_contract_abi_entry(
-    legacy_contract_abi_entry: LegacyContractAbiEntry,
-) -> RawLegacyAbiEntry {
-    match legacy_contract_abi_entry {
-        LegacyContractAbiEntry::Function(entry) => raw_abi_entry_from_legacy_function_abi_entry(entry),
-        LegacyContractAbiEntry::Struct(entry) => RawLegacyAbiEntry::Struct(RawLegacyStruct {
-            members: entry.members.into_iter().map(raw_legacy_member_from_legacy_struct_member).collect(),
-            name: entry.name,
-            size: entry.size,
-        }),
-        LegacyContractAbiEntry::Event(entry) => {
-            RawLegacyAbiEntry::Event(RawLegacyEvent { data: entry.data, keys: entry.keys, name: entry.name })
-        }
-    }
-}
-
-fn raw_legacy_entrypoint_from_legacy_entrypoint(legacy_entry_point: LegacyContractEntryPoint) -> RawLegacyEntryPoint {
-    RawLegacyEntryPoint {
-        offset: LegacyEntrypointOffset::U64AsInt(legacy_entry_point.offset),
-        selector: legacy_entry_point.selector,
-    }
-}
-
-/// Implementation of From<LegacyEntryPointsByType> for RawLegacyEntryPoints,
-/// as it is missing from starknet-rs and we need it to interpret compressed legacy contracts.
-fn raw_legacy_entrypoints_from_legacy_entrypoints(
-    legacy_entry_points_by_type: LegacyEntryPointsByType,
-) -> RawLegacyEntryPoints {
-    RawLegacyEntryPoints {
-        constructor: legacy_entry_points_by_type
-            .constructor
-            .into_iter()
-            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
-            .collect(),
-        external: legacy_entry_points_by_type
-            .external
-            .into_iter()
-            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
-            .collect(),
-        l1_handler: legacy_entry_points_by_type
-            .l1_handler
-            .into_iter()
-            .map(raw_legacy_entrypoint_from_legacy_entrypoint)
-            .collect(),
-    }
 }

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -43,6 +43,8 @@ use rstest::rstest;
 #[case::declare_and_deploy_in_same_block(169206)]
 #[case::dest_ptr_not_a_relocatable(155140)]
 #[case::dest_ptr_not_a_relocatable_2(155830)]
+#[case::inconsistent_cairo0_class_hash_0(30000)]
+#[case::inconsistent_cairo0_class_hash_1(204936)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {

--- a/crates/starknet-os-types/src/starknet_core_addons.rs
+++ b/crates/starknet-os-types/src/starknet_core_addons.rs
@@ -3,8 +3,8 @@ use std::io::Read;
 
 use flate2::read::GzDecoder;
 use starknet_core::types::contract::legacy::{
-    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyEntryPoint, RawLegacyEntryPoints,
-    RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
+    LegacyContractClass, LegacyEntrypointOffset, RawLegacyAbiEntry, RawLegacyConstructor, RawLegacyEntryPoint,
+    RawLegacyEntryPoints, RawLegacyEvent, RawLegacyFunction, RawLegacyL1Handler, RawLegacyMember, RawLegacyStruct,
 };
 use starknet_core::types::{
     CompressedLegacyContractClass, LegacyContractAbiEntry, LegacyContractEntryPoint, LegacyEntryPointsByType,
@@ -13,14 +13,17 @@ use starknet_core::types::{
 
 fn raw_abi_entry_from_legacy_function_abi_entry(entry: LegacyFunctionAbiEntry) -> RawLegacyAbiEntry {
     match entry.r#type {
-        LegacyFunctionAbiType::Function | LegacyFunctionAbiType::Constructor => {
-            RawLegacyAbiEntry::Function(RawLegacyFunction {
-                inputs: entry.inputs,
-                name: entry.name,
-                outputs: entry.outputs,
-                state_mutability: entry.state_mutability,
-            })
-        }
+        LegacyFunctionAbiType::Function => RawLegacyAbiEntry::Function(RawLegacyFunction {
+            inputs: entry.inputs,
+            name: entry.name,
+            outputs: entry.outputs,
+            state_mutability: entry.state_mutability,
+        }),
+        LegacyFunctionAbiType::Constructor => RawLegacyAbiEntry::Constructor(RawLegacyConstructor {
+            inputs: entry.inputs,
+            name: entry.name,
+            outputs: entry.outputs,
+        }),
         LegacyFunctionAbiType::L1Handler => RawLegacyAbiEntry::L1Handler(RawLegacyL1Handler {
             inputs: entry.inputs,
             name: entry.name,
@@ -53,7 +56,7 @@ fn raw_legacy_abi_entry_from_legacy_contract_abi_entry(
 
 fn raw_legacy_entrypoint_from_legacy_entrypoint(legacy_entry_point: LegacyContractEntryPoint) -> RawLegacyEntryPoint {
     RawLegacyEntryPoint {
-        offset: LegacyEntrypointOffset::U64AsHex(legacy_entry_point.offset),
+        offset: LegacyEntrypointOffset::U64AsInt(legacy_entry_point.offset),
         selector: legacy_entry_point.selector,
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 python = "^3.9"
 ecdsa = "^0.18.0"
 fastecdsa = "^2.3.0"
-sympy = "^1.12"
+sympy = "~1.12"
 cairo-lang = "0.13.1"
 
 [build-system]


### PR DESCRIPTION
Problem: for some Cairo0 contracts, computation from `class_hash` was incorrect. This was preventing from executing some new blocks that use old contracts

Solution: fix the hash computation

Issue Number: #379 

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
