### PR TITLE
Enabled `full_output` and using reference PIE to validate our PIEs are correct

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -102,6 +102,7 @@ pub async fn prove_block(
     block_number: u64,
     rpc_provider: &str,
     layout: LayoutName,
+    full_output: bool,
 ) -> Result<(CairoPie, StarknetOsOutput), ProveBlockError> {
     let block_id = BlockId::Number(block_number);
     let previous_block_id = BlockId::Number(block_number - 1);
@@ -133,8 +134,7 @@ pub async fn prove_block(
     let older_block = match rpc_client
         .starknet_rpc()
         .get_block_with_tx_hashes(BlockId::Number(block_number - STORED_BLOCK_HASH_BUFFER))
-        .await
-        .unwrap()
+        .await?
     {
         MaybePendingBlockWithTxHashes::Block(block_with_txs_hashes) => block_with_txs_hashes,
         MaybePendingBlockWithTxHashes::PendingBlock(_) => {
@@ -315,7 +315,7 @@ pub async fn prove_block(
         declared_class_hash_to_component_hashes: declared_class_hash_component_hashes,
         new_block_hash: block_with_txs.block_hash,
         prev_block_hash: previous_block.block_hash,
-        full_output: false,
+        full_output,
     };
     let execution_helper = ExecutionHelperWrapper::<ProverPerContractStorage>::new(
         contract_storages,

--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use cairo_vm::types::layout_name::LayoutName;
 use clap::Parser;
 use prove_block::debug_prove_error;
@@ -24,7 +22,7 @@ fn init_logging() {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() {
     init_logging();
 
     let args = Args::parse();
@@ -32,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let block_number = args.block_number;
     let layout = LayoutName::all_cairo;
 
-    let result = prove_block::prove_block(block_number, &args.rpc_provider, layout).await;
-    let (_pie, _output) = result.map_err(debug_prove_error).expect("Block could not be proven");
-    Ok(())
+    let result = prove_block::prove_block(block_number, &args.rpc_provider, layout, true).await;
+    let (pie, _snos_output) = result.map_err(debug_prove_error).expect("Block proven");
+    pie.run_validity_checks().expect("Valid PIE");
 }

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -1,4 +1,6 @@
 use cairo_vm::types::layout_name::LayoutName;
+use cairo_vm::types::relocatable::MaybeRelocatable;
+use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use prove_block::{debug_prove_error, prove_block};
 use rstest::rstest;
 
@@ -45,14 +47,44 @@ use rstest::rstest;
 #[case::dest_ptr_not_a_relocatable_2(155830)]
 #[case::inconsistent_cairo0_class_hash_0(30000)]
 #[case::inconsistent_cairo0_class_hash_1(204936)]
+#[case::reference_pie_with_full_output_enabled(173404)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {
     let endpoint = std::env::var("PATHFINDER_RPC_URL").expect("Missing PATHFINDER_RPC_URL in env");
-    let (pie, _output) = prove_block(block_number, &endpoint, LayoutName::all_cairo)
+    let (snos_pie, _snos_output) = prove_block(block_number, &endpoint, LayoutName::all_cairo, true)
         .await
         .map_err(debug_prove_error)
-        .expect("OS failed to generate Cairo Pie");
+        .expect("OS generate Cairo PIE");
+    snos_pie.run_validity_checks().expect("Valid SNOS PIE");
 
-    pie.run_validity_checks().expect("Cairo Pie run validity checks failed");
+    if let Some(reference_pie_bytes) = get_reference_pie_bytes(block_number) {
+        println!("Block {}: Checking against reference PIE", block_number);
+        let reference_pie = CairoPie::from_bytes(&reference_pie_bytes).expect("reference PIE");
+        reference_pie.run_validity_checks().expect("Valid reference PIE");
+
+        let output_segment_index = 2;
+        assert_eq!(
+            get_memory_segment(&reference_pie, output_segment_index),
+            get_memory_segment(&snos_pie, output_segment_index)
+        );
+    }
+}
+
+fn get_reference_pie_bytes(block_number: u64) -> Option<Vec<u8>> {
+    match block_number {
+        173404 => Some(include_bytes!("../reference-pies/173404.zip").to_vec()),
+        _ => None,
+    }
+}
+
+fn get_memory_segment(pie: &CairoPie, index: usize) -> Vec<(usize, &MaybeRelocatable)> {
+    let mut segment = pie
+        .memory
+        .0
+        .iter()
+        .filter_map(|((segment_index, offset), value)| (*segment_index == index).then_some((*offset, value)))
+        .collect::<Vec<_>>();
+    segment.sort_by(|(offset1, _), (offset2, _)| offset1.cmp(offset2));
+    segment
 }

--- a/scripts/prove-blocks.sh
+++ b/scripts/prove-blocks.sh
@@ -29,7 +29,7 @@ fi
 for BLOCK_NUMBER in "${BLOCK_NUMBERS[@]}"; do
   echo "Executing for block number: $BLOCK_NUMBER"
   cargo run -p prove_block --release -- --block-number "$BLOCK_NUMBER" --rpc-provider "$PROVIDER"
-  
+
   # Check if the cargo command failed
   if [ $? -ne 0 ]; then
     echo "Command failed for block number: $BLOCK_NUMBER. Exiting."


### PR DESCRIPTION
The reference PIE was created with `full_output` enabled, so `output.rs` was updated to support that. The code was also refactored to better mirror the Cairo serialization code.

