### PR TITLE
fix: `split_commitment` function in KZG data availability implementation

### DIFF
--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::{self, Read};
 use std::num::ParseIntError;
 use std::path::Path;
 
@@ -16,7 +15,7 @@ use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_vm::Felt252;
 use indoc::indoc;
 use num_bigint::{BigInt, ParseBigIntError};
-use num_traits::{FromBytes, Num, One, Zero};
+use num_traits::{Num, One, Zero};
 
 use super::vars;
 use crate::execution::helper::ExecutionHelperWrapper;
@@ -25,8 +24,6 @@ use crate::utils::{execute_coroutine, get_constant};
 
 const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 const COMMITMENT_BYTES_LENGTH: usize = 48;
-const COMMITMENT_LOW_BIT_LENGTH: usize = (COMMITMENT_BYTES_LENGTH * 8) / 2;
-const COMMITMENT_HALF_BIT_LENGTH: usize = COMMITMENT_LOW_BIT_LENGTH / 2;
 const BLOB_SUBGROUP_GENERATOR: &str = "39033254847818212395286706435128746857159659164139250548781411570340225835782";
 const BLS_PRIME: &str = "52435875175126190479447740508185965837690552500527637822603658699938581184513";
 
@@ -44,9 +41,8 @@ pub enum FftError {
     #[error("Encountered a c_kzg error: {0}")]
     CKzgError(#[from] c_kzg::Error),
 
-    #[error("Encountered an internal io error: {0}")]
-    IoError(io::Error),
-
+    // #[error("Encountered an internal io error: {0}")]
+    // IoError(io::Error),
     #[error("Too many coefficients")]
     TooManyCoefficients,
 }
@@ -183,10 +179,6 @@ fn polynomial_coefficients_to_blob(coefficients: Vec<BigInt>) -> Result<Vec<u8>,
 pub fn blob_to_kzg_commitment(blob: &Blob) -> Result<KzgCommitment, c_kzg::Error> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("kzg").join("trusted_setup.txt");
     c_kzg::KzgCommitment::blob_to_kzg_commitment(blob, &c_kzg::KzgSettings::load_trusted_setup_file(&path)?)
-}
-
-fn from_bytes(bytes: &[u8]) -> BigInt {
-    BigInt::from_bytes_le(num_bigint::Sign::Plus, bytes)
 }
 
 fn to_bytes(x: &BigInt, length: usize) -> Vec<u8> {

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -26,6 +26,7 @@ use crate::utils::{execute_coroutine, get_constant};
 const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 const COMMITMENT_BYTES_LENGTH: usize = 48;
 const COMMITMENT_LOW_BIT_LENGTH: usize = (COMMITMENT_BYTES_LENGTH * 8) / 2;
+const COMMITMENT_HALF_BIT_LENGTH: usize = COMMITMENT_LOW_BIT_LENGTH / 2;
 const BLOB_SUBGROUP_GENERATOR: &str = "39033254847818212395286706435128746857159659164139250548781411570340225835782";
 const BLS_PRIME: &str = "52435875175126190479447740508185965837690552500527637822603658699938581184513";
 
@@ -138,9 +139,10 @@ fn fft(coeffs: &[BigInt], generator: &BigInt, prime: &BigInt, bit_reversed: bool
 }
 
 fn split_commitment(num: BigInt) -> (BigInt, BigInt) {
-    let low_part = &num % (BigInt::one() << COMMITMENT_LOW_BIT_LENGTH);
-    let high_part = &num >> COMMITMENT_LOW_BIT_LENGTH;
-    (low_part, high_part)
+    let mask = (BigInt::from(1) << COMMITMENT_HALF_BIT_LENGTH) - 1;
+    let low_part = num.clone() & &mask;
+    let high_part = num >> COMMITMENT_HALF_BIT_LENGTH;
+    (high_part, low_part)
 }
 
 fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Result<(BigInt, BigInt), FftError> {

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -138,11 +138,19 @@ fn fft(coeffs: &[BigInt], generator: &BigInt, prime: &BigInt, bit_reversed: bool
     Ok(values)
 }
 
-fn split_commitment(num: BigInt) -> (BigInt, BigInt) {
-    let mask = (BigInt::from(1) << COMMITMENT_HALF_BIT_LENGTH) - 1;
-    let low_part = num.clone() & &mask;
-    let high_part = num >> COMMITMENT_HALF_BIT_LENGTH;
-    (high_part, low_part)
+fn split_commitment(num: &BigInt) -> (BigInt, BigInt) {
+    // Ensure the input is 384 bits (48 bytes)
+    let num = num & &((BigInt::from(1) << 384) - 1);
+
+    // Calculate midpoint (384 bits / 2 = 192 bits)
+    let mid_point = 192;
+
+    // Split the number
+    let mask = (BigInt::from(1) << mid_point) - 1;
+    let low = &num & &mask;
+    let high = &num >> mid_point;
+
+    (high, low)
 }
 
 fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Result<(BigInt, BigInt), FftError> {

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -256,6 +256,7 @@ where
         .map(|chunk| {
             let coefficients: Vec<BigInt> = chunk.iter().map(|f| f.to_bigint()).collect();
             let res: (BigInt, BigInt) = polynomial_coefficients_to_kzg_commitment(coefficients).unwrap(); // TODO: unwrap
+            println!("res: >>> : {:?}", res);
             (res.0.into(), res.1.into())
         })
         .collect();

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -26,6 +26,8 @@ const FIELD_ELEMENTS_PER_BLOB: usize = 4096;
 const COMMITMENT_BYTES_LENGTH: usize = 48;
 const BLOB_SUBGROUP_GENERATOR: &str = "39033254847818212395286706435128746857159659164139250548781411570340225835782";
 const BLS_PRIME: &str = "52435875175126190479447740508185965837690552500527637822603658699938581184513";
+const COMMITMENT_BITS: usize = 384;
+const COMMITMENT_BITS_MIDPOINT: usize = COMMITMENT_BITS / 2;
 
 #[derive(Debug, thiserror::Error)]
 pub enum FftError {
@@ -134,15 +136,12 @@ fn fft(coeffs: &[BigInt], generator: &BigInt, prime: &BigInt, bit_reversed: bool
 
 fn split_commitment(num: BigInt) -> (BigInt, BigInt) {
     // Ensure the input is 384 bits (48 bytes)
-    let num = num & &((BigInt::from(1) << 384) - 1);
-
-    // Calculate midpoint (384 bits / 2 = 192 bits)
-    let mid_point = 192;
+    let num = num & &((BigInt::from(1) << COMMITMENT_BITS) - 1);
 
     // Split the number
-    let mask = (BigInt::from(1) << mid_point) - 1;
+    let mask = (BigInt::from(1) << COMMITMENT_BITS_MIDPOINT) - 1;
     let low = &num & &mask;
-    let high = &num >> mid_point;
+    let high = &num >> COMMITMENT_BITS_MIDPOINT;
 
     (low, high)
 }

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -41,8 +41,6 @@ pub enum FftError {
     #[error("Encountered a c_kzg error: {0}")]
     CKzgError(#[from] c_kzg::Error),
 
-    // #[error("Encountered an internal io error: {0}")]
-    // IoError(io::Error),
     #[error("Too many coefficients")]
     TooManyCoefficients,
 }
@@ -154,7 +152,8 @@ fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Resul
     let commitment_bytes =
         blob_to_kzg_commitment(&Blob::from_bytes(&blob).map_err(FftError::CKzgError)?).map_err(FftError::CKzgError)?;
     assert_eq!(commitment_bytes.len(), COMMITMENT_BYTES_LENGTH, "Bad commitment bytes length.");
-    let kzg_bigint = BigInt::from_str_radix(&commitment_bytes.as_hex_string(), 16).unwrap();
+    let kzg_bigint =
+        BigInt::from_str_radix(&commitment_bytes.as_hex_string(), 16).map_err(FftError::ParseBigIntError)?;
     Ok(split_commitment(kzg_bigint))
 }
 

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -16,7 +16,7 @@ use cairo_vm::vm::vm_core::VirtualMachine;
 use cairo_vm::Felt252;
 use indoc::indoc;
 use num_bigint::{BigInt, ParseBigIntError};
-use num_traits::{Num, One, Zero};
+use num_traits::{FromBytes, Num, One, Zero};
 
 use super::vars;
 use crate::execution::helper::ExecutionHelperWrapper;
@@ -162,8 +162,10 @@ fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Resul
     println!(">>>> kzg commitment : {:?}", commitment_bytes.as_hex_string());
 
     assert_eq!(commitment_bytes.len(), COMMITMENT_BYTES_LENGTH, "Bad commitment bytes length.");
-    let commitment_by: Result<Vec<_>, _> = commitment_bytes.bytes().collect();
-    Ok(split_commitment(from_bytes(&commitment_by.map_err(FftError::IoError)?)))
+
+    let kzg_bigint = BigInt::from_be_bytes(commitment_bytes.as_slice());
+
+    Ok(split_commitment(kzg_bigint))
 }
 
 fn polynomial_coefficients_to_blob(coefficients: Vec<BigInt>) -> Result<Vec<u8>, FftError> {

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -150,21 +150,15 @@ fn split_commitment(num: BigInt) -> (BigInt, BigInt) {
     let low = &num & &mask;
     let high = &num >> mid_point;
 
-    (high, low)
+    (low, high)
 }
 
 fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Result<(BigInt, BigInt), FftError> {
-    println!(">>>> blob : {:?}", coefficients);
     let blob = polynomial_coefficients_to_blob(coefficients)?;
     let commitment_bytes =
         blob_to_kzg_commitment(&Blob::from_bytes(&blob).map_err(FftError::CKzgError)?).map_err(FftError::CKzgError)?;
-
-    println!(">>>> kzg commitment : {:?}", commitment_bytes.as_hex_string());
-
     assert_eq!(commitment_bytes.len(), COMMITMENT_BYTES_LENGTH, "Bad commitment bytes length.");
-
-    let kzg_bigint = BigInt::from_be_bytes(commitment_bytes.as_slice());
-
+    let kzg_bigint = BigInt::from_str_radix(&commitment_bytes.as_hex_string(), 16).unwrap();
     Ok(split_commitment(kzg_bigint))
 }
 
@@ -268,7 +262,6 @@ where
         .map(|chunk| {
             let coefficients: Vec<BigInt> = chunk.iter().map(|f| f.to_bigint()).collect();
             let res: (BigInt, BigInt) = polynomial_coefficients_to_kzg_commitment(coefficients).unwrap(); // TODO: unwrap
-            println!("res: >>> : {:?}", res);
             (res.0.into(), res.1.into())
         })
         .collect();

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -346,4 +346,26 @@ mod test {
             vec![BigInt::from(121212u64)]
         );
     }
+
+    /// All the expected values are checked using the contract logic given here in
+    /// starknet core contract :
+    /// https://github.com/starkware-libs/cairo-lang/blob/a86e92bfde9c171c0856d7b46580c66e004922f3/src/starkware/starknet/solidity/Starknet.sol#L209
+    #[rstest]
+    #[case(
+        BigInt::from_str_radix("b7a71dc9d8e15ea474a69c0531e720cf5474b189ac9afc81590b91a225b1bf7fa5877ec546d090e0059f019c74675362", 16).unwrap(),
+        (
+            BigInt::from_str_radix("590b91a225b1bf7fa5877ec546d090e0059f019c74675362", 16).unwrap(),
+            BigInt::from_str_radix("b7a71dc9d8e15ea474a69c0531e720cf5474b189ac9afc81", 16).unwrap(),
+        )
+    )]
+    #[case(
+        BigInt::from_str_radix("a797c1973c99961e357246ee81bde0acbdd27e801d186ccb051732ecbaa75842afd3d8860d40b3e8eeea433bce18b5c8", 16).unwrap(),
+        (
+            BigInt::from_str_radix("51732ecbaa75842afd3d8860d40b3e8eeea433bce18b5c8", 16).unwrap(),
+            BigInt::from_str_radix("a797c1973c99961e357246ee81bde0acbdd27e801d186ccb", 16).unwrap(),
+        )
+    )]
+    fn test_split_commitment_function(#[case] commitment: BigInt, #[case] expected_output: (BigInt, BigInt)) {
+        assert_eq!(split_commitment(commitment), expected_output);
+    }
 }

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -149,6 +149,8 @@ fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Resul
     let commitment_bytes =
         blob_to_kzg_commitment(&Blob::from_bytes(&blob).map_err(FftError::CKzgError)?).map_err(FftError::CKzgError)?;
 
+    println!(">>>> kzg commitment : {:?}", commitment_bytes.as_hex_string());
+
     assert_eq!(commitment_bytes.len(), COMMITMENT_BYTES_LENGTH, "Bad commitment bytes length.");
     let commitment_by: Result<Vec<_>, _> = commitment_bytes.bytes().collect();
     Ok(split_commitment(from_bytes(&commitment_by.map_err(FftError::IoError)?)))

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -144,6 +144,7 @@ fn split_commitment(num: BigInt) -> (BigInt, BigInt) {
 }
 
 fn polynomial_coefficients_to_kzg_commitment(coefficients: Vec<BigInt>) -> Result<(BigInt, BigInt), FftError> {
+    println!(">>>> blob : {:?}", coefficients);
     let blob = polynomial_coefficients_to_blob(coefficients)?;
     let commitment_bytes =
         blob_to_kzg_commitment(&Blob::from_bytes(&blob).map_err(FftError::CKzgError)?).map_err(FftError::CKzgError)?;

--- a/crates/starknet-os/src/hints/kzg.rs
+++ b/crates/starknet-os/src/hints/kzg.rs
@@ -138,7 +138,7 @@ fn fft(coeffs: &[BigInt], generator: &BigInt, prime: &BigInt, bit_reversed: bool
     Ok(values)
 }
 
-fn split_commitment(num: &BigInt) -> (BigInt, BigInt) {
+fn split_commitment(num: BigInt) -> (BigInt, BigInt) {
     // Ensure the input is 384 bits (48 bytes)
     let num = num & &((BigInt::from(1) << 384) - 1);
 


### PR DESCRIPTION
Problem:
The bug was that the commitment split returned by this function was wrong. I encountered this when I was integrating the snos with madara orchestrator and performing an e2e test. On the final step of the block processing the contract was giving an error saying that "precompile evaluation failed". After debugging we found out that this is the issue the commitment returned by the snos was wrong.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
