### PR TITLE
Fix blocks with KeyNotInProof (part 1)

### DIFF
--- a/crates/bin/prove_block/src/state_utils.rs
+++ b/crates/bin/prove_block/src/state_utils.rs
@@ -138,7 +138,12 @@ fn add_compiled_class_to_os_input(
     let compiled_class = compile_contract_class(contract_class)?;
     let compiled_class_hash = compiled_class.class_hash()?;
 
-    class_hash_to_compiled_class_hash.insert(class_hash, compiled_class_hash.into());
+    // Remove deprecated classes from HashMap
+    if matches!(&compiled_class, GenericCompiledClass::Cairo0(_)) {
+        log::warn!("Skipping deprecated class for ch_to_cch: 0x{:x}", class_hash);
+    } else {
+        class_hash_to_compiled_class_hash.insert(class_hash, compiled_class_hash.into());
+    }
 
     match compiled_class {
         GenericCompiledClass::Cairo0(deprecated_cc) => {

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -50,6 +50,9 @@ use rstest::rstest;
 #[case::reference_pie_with_full_output_enabled(173404)]
 #[case::inconsistent_cairo0_class_hash_2(159674)]
 #[case::inconsistent_cairo0_class_hash_3(164180)]
+#[case::key_not_in_proof_0(155087)]
+#[case::key_not_in_proof_1(162388)]
+#[case::key_not_in_proof_2(155172)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {


### PR DESCRIPTION
Problem: while trying to process latest blocks we bumped into KeyNotInProof error. It seems that there are different issues that trigger the same error.

Solution: Remove deprecated classes from `class_hash_compiled_class_hash` map. This will fix part of the failing blocks that present KeyNotInProof error.


Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
