### PR TITLE
Moved compiled snos import to allowing using snos as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ serde_json = { version = "1.0.105", features = ["arbitrary_precision"] }
 serde_with = "3.3.0"
 serde_yaml = "0.9.25"
 sha2 = "0.10.8"
-starknet = "0.11.0"
+starknet = "0.12.0"
 starknet_api = { git = "https://github.com/Moonsong-Labs/sequencer", rev = "6624e910c57db9a16f1607c1ed26f7d8f1114e73", features = ["testing"] }
-starknet-core = "0.11.1"
+starknet-core = "0.12.0"
 starknet-crypto = "0.6.2"
 starknet-os = { path = "crates/starknet-os" }
 starknet-os-types = { path = "crates/starknet-os-types" }

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -45,6 +45,8 @@ mod state_utils;
 mod types;
 mod utils;
 
+pub const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.json");
+
 #[derive(Debug, Error)]
 pub enum ProveBlockError {
     #[error("RPC Error: {0}")]
@@ -324,7 +326,7 @@ pub async fn prove_block(
         (old_block_number, old_block_hash),
     );
 
-    Ok(run_os(config::DEFAULT_COMPILED_OS, layout, os_input, block_context, execution_helper)?)
+    Ok(run_os(DEFAULT_COMPILED_OS, layout, os_input, block_context, execution_helper)?)
 }
 
 pub fn debug_prove_error(err: ProveBlockError) -> ProveBlockError {

--- a/crates/bin/prove_block/src/rpc_utils.rs
+++ b/crates/bin/prove_block/src/rpc_utils.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
 use num_bigint::BigInt;
+use rpc_client::pathfinder::client::ClientError;
 use rpc_client::pathfinder::proofs::{
     ContractData, EdgePath, PathfinderClassProof, PathfinderProof, ProofVerificationError, TrieNode,
 };
@@ -25,7 +26,7 @@ async fn fetch_storage_proof_for_contract(
     contract_address: Felt,
     keys: &[Felt],
     block_number: u64,
-) -> Result<PathfinderProof, reqwest::Error> {
+) -> Result<PathfinderProof, ClientError> {
     let storage_proof = if keys.is_empty() {
         rpc_client.pathfinder_rpc().get_proof(block_number, contract_address, &[]).await?
     } else {
@@ -50,7 +51,7 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
     contract_address: ContractAddress,
     storage_keys: KeyIter,
     block_number: u64,
-) -> Result<PathfinderProof, reqwest::Error> {
+) -> Result<PathfinderProof, ClientError> {
     let contract_address_felt = *contract_address.key();
     let keys: Vec<_> = storage_keys.map(|storage_key| *storage_key.key()).collect();
 
@@ -113,7 +114,7 @@ pub(crate) async fn get_storage_proofs(
     block_number: u64,
     tx_execution_infos: &[TransactionExecutionInfo],
     old_block_number: Felt,
-) -> Result<HashMap<Felt, PathfinderProof>, reqwest::Error> {
+) -> Result<HashMap<Felt, PathfinderProof>, ClientError> {
     let accessed_keys_by_address = {
         let mut keys = get_all_accessed_keys(tx_execution_infos);
         // We need to fetch the storage proof for the block hash contract
@@ -124,11 +125,8 @@ pub(crate) async fn get_storage_proofs(
     let mut storage_proofs = HashMap::new();
 
     log::info!("Contracts we're fetching proofs for:");
-    for contract_address in accessed_keys_by_address.keys() {
-        log::info!("    {}", contract_address.to_string());
-    }
-
     for (contract_address, storage_keys) in accessed_keys_by_address {
+        log::info!("    Fetching proof for {}", contract_address.to_string());
         let contract_address_felt = *contract_address.key();
         let storage_proof =
             get_storage_proof_for_contract(client, contract_address, storage_keys.into_iter(), block_number).await?;
@@ -196,7 +194,7 @@ pub(crate) async fn get_class_proofs(
     rpc_client: &RpcClient,
     block_number: u64,
     class_hashes: &[&Felt],
-) -> Result<HashMap<Felt252, PathfinderClassProof>, reqwest::Error> {
+) -> Result<HashMap<Felt252, PathfinderClassProof>, ClientError> {
     let mut proofs: HashMap<Felt252, PathfinderClassProof> = HashMap::with_capacity(class_hashes.len());
     for class_hash in class_hashes {
         let proof = rpc_client.pathfinder_rpc().get_class_proof(block_number, class_hash).await?;

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -47,6 +47,8 @@ use rstest::rstest;
 #[case::dest_ptr_not_a_relocatable_2(155830)]
 #[case::inconsistent_cairo0_class_hash_0(30000)]
 #[case::inconsistent_cairo0_class_hash_1(204936)]
+#[case::no_possible_convertion_1(155007)]
+#[case::no_possible_convertion_2(155029)]
 #[case::reference_pie_with_full_output_enabled(173404)]
 #[case::inconsistent_cairo0_class_hash_2(159674)]
 #[case::inconsistent_cairo0_class_hash_3(164180)]

--- a/crates/rpc-client/src/pathfinder/client.rs
+++ b/crates/rpc-client/src/pathfinder/client.rs
@@ -1,9 +1,18 @@
+use reqwest::{Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::json;
 use starknet_types_core::felt::Felt;
 
 use crate::pathfinder::proofs::{PathfinderClassProof, PathfinderProof};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    #[error("Encountered a request error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Encountered a custom error: {0}")]
+    CustomError(String),
+}
 
 fn jsonrpc_request(method: &str, params: serde_json::Value) -> serde_json::Value {
     json!({
@@ -19,7 +28,7 @@ async fn post_jsonrpc_request<T: DeserializeOwned>(
     rpc_provider: &str,
     method: &str,
     params: serde_json::Value,
-) -> Result<T, reqwest::Error> {
+) -> Result<T, ClientError> {
     let request = jsonrpc_request(method, params);
     let response = client.post(format!("{}/rpc/pathfinder/v0.1", rpc_provider)).json(&request).send().await?;
 
@@ -28,10 +37,19 @@ async fn post_jsonrpc_request<T: DeserializeOwned>(
         result: T,
     }
 
-    let response_text = response.text().await?;
-    let response: TransactionReceiptResponse<T> =
-        serde_json::from_str(&response_text).unwrap_or_else(|_| panic!("Error: {}", response_text));
+    let response: TransactionReceiptResponse<T> = handle_error(response).await?;
+
     Ok(response.result)
+}
+
+async fn handle_error<T: DeserializeOwned>(response: Response) -> Result<T, ClientError> {
+    match response.status() {
+        StatusCode::OK => Ok(response.json().await?),
+        s => {
+            let error = response.text().await?;
+            Err(ClientError::CustomError(format!("Received response: {s:?} Error: {error}")))
+        }
+    }
 }
 
 pub struct PathfinderRpcClient {
@@ -56,7 +74,7 @@ impl PathfinderRpcClient {
         block_number: u64,
         contract_address: Felt,
         keys: &[Felt],
-    ) -> Result<PathfinderProof, reqwest::Error> {
+    ) -> Result<PathfinderProof, ClientError> {
         post_jsonrpc_request(
             &self.http_client,
             &self.rpc_base_url,
@@ -70,7 +88,7 @@ impl PathfinderRpcClient {
         &self,
         block_number: u64,
         class_hash: &Felt,
-    ) -> Result<PathfinderClassProof, reqwest::Error> {
+    ) -> Result<PathfinderClassProof, ClientError> {
         log::debug!("querying pathfinder_getClassProof for {:x}", class_hash);
         post_jsonrpc_request(
             &self.http_client,

--- a/crates/starknet-os-types/src/casm_contract_class.rs
+++ b/crates/starknet-os-types/src/casm_contract_class.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::error::ContractClassError;
+use crate::error::{ContractClassError, ConversionError};
 use crate::hash::GenericClassHash;
 
 pub type CairoLangCasmClass = cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
@@ -26,8 +26,9 @@ pub struct GenericCasmContractClass {
 fn blockifier_contract_class_from_cairo_lang_class(
     cairo_lang_class: CairoLangCasmClass,
 ) -> Result<BlockifierCasmClass, ContractClassError> {
-    let blockifier_class: BlockifierCasmClass =
-        cairo_lang_class.try_into().map_err(|_| ContractClassError::BlockifierConversionError)?;
+    let blockifier_class: BlockifierCasmClass = cairo_lang_class
+        .try_into()
+        .map_err(|e| ContractClassError::ConversionError(ConversionError::BlockifierError(Box::new(e))))?;
     Ok(blockifier_class)
 }
 
@@ -52,7 +53,7 @@ impl GenericCasmContractClass {
             return Ok(contract_class);
         }
 
-        Err(ContractClassError::NoPossibleConversion)
+        Err(ContractClassError::ConversionError(ConversionError::CairoLangClassMissing))
     }
 
     fn build_blockifier_class(&self) -> Result<BlockifierCasmClass, ContractClassError> {
@@ -68,7 +69,7 @@ impl GenericCasmContractClass {
             return blockifier_contract_class_from_cairo_lang_class(cairo_lang_class);
         }
 
-        Err(ContractClassError::NoPossibleConversion)
+        Err(ContractClassError::ConversionError(ConversionError::BlockifierClassMissing))
     }
     pub fn get_cairo_lang_contract_class(&self) -> Result<&CairoLangCasmClass, ContractClassError> {
         self.cairo_lang_contract_class

--- a/crates/starknet-os-types/src/deprecated_compiled_class.rs
+++ b/crates/starknet-os-types/src/deprecated_compiled_class.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use pathfinder_gateway_types::class_hash::compute_class_hash;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::error::ContractClassError;
+use crate::error::{ContractClassError, ConversionError};
 use crate::hash::GenericClassHash;
 use crate::starknet_core_addons::{decompress_starknet_core_contract_class, LegacyContractDecompressionError};
 
@@ -45,7 +45,7 @@ impl GenericDeprecatedCompiledClass {
             return Ok(contract_class);
         }
 
-        Err(ContractClassError::NoPossibleConversion)
+        Err(ContractClassError::ConversionError(ConversionError::StarknetClassMissing))
     }
 
     fn build_blockifier_class(&self) -> Result<BlockifierDeprecatedClass, ContractClassError> {

--- a/crates/starknet-os-types/src/error.rs
+++ b/crates/starknet-os-types/src/error.rs
@@ -1,12 +1,11 @@
+use std::error::Error;
+
 use cairo_lang_starknet_classes::casm_contract_class::StarknetSierraCompilationError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ContractClassError {
-    #[error("Internal error: no type conversion is possible to generate the desired effect.")]
-    NoPossibleConversion,
-
-    #[error("Could not build Blockifier contract class")]
-    BlockifierConversionError,
+    #[error(transparent)]
+    ConversionError(#[from] ConversionError),
 
     #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
@@ -16,4 +15,19 @@ pub enum ContractClassError {
 
     #[error(transparent)]
     CompilationError(#[from] StarknetSierraCompilationError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConversionError {
+    #[error("Could not build Blockifier contract class: {0}")]
+    BlockifierError(Box<dyn Error + 'static>),
+
+    #[error("Missing Starknet serialized class")]
+    StarknetClassMissing,
+
+    #[error("Missing Blockifier serialized class")]
+    BlockifierClassMissing,
+
+    #[error("Missing CairoLang serialized class")]
+    CairoLangClassMissing,
 }

--- a/crates/starknet-os-types/src/sierra_contract_class.rs
+++ b/crates/starknet-os-types/src/sierra_contract_class.rs
@@ -40,12 +40,10 @@ impl GenericSierraContractClass {
     }
 
     fn build_cairo_lang_class(&self) -> Result<CairoLangSierraContractClass, ContractClassError> {
-        if let Ok(serialized_class) = self.get_serialized_contract_class() {
-            let contract_class = serde_json::from_slice(serialized_class)?;
-            return Ok(contract_class);
-        }
-
-        Err(ContractClassError::NoPossibleConversion)
+        self.get_serialized_contract_class().and_then(|res| {
+            let contract_class = serde_json::from_slice(res)?;
+            Ok(contract_class)
+        })
     }
 
     pub fn get_serialized_contract_class(&self) -> Result<&Vec<u8>, ContractClassError> {
@@ -140,7 +138,8 @@ impl TryFrom<&FlattenedSierraClass> for FlattenedSierraClassWithAbi {
     type Error = serde_json::error::Error;
 
     fn try_from(sierra_class: &FlattenedSierraClass) -> Result<Self, Self::Error> {
-        let abi: Option<cairo_lang_starknet_classes::abi::Contract> = serde_json::from_str(&sierra_class.abi)?;
+        let abi: Option<cairo_lang_starknet_classes::abi::Contract> =
+            serde_json::from_str(&sierra_class.abi).unwrap_or_default();
 
         Ok(Self {
             sierra_program: sierra_class.sierra_program.clone(),

--- a/crates/starknet-os/src/config.rs
+++ b/crates/starknet-os/src/config.rs
@@ -23,8 +23,6 @@ pub const fn default_layout() -> LayoutName {
 // https://github.com/starkware-libs/blockifier/blob/8da582b285bfbc7d4c21178609bbd43f80a69240/crates/native_blockifier/src/py_block_executor.rs#L44
 const MAX_STEPS_PER_TX: u32 = 4_000_000;
 
-pub const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../build/os_latest.json");
-
 const DEFAULT_CONFIG_PATH: &str = "../../cairo-lang/src/starkware/starknet/definitions/general_config.yml";
 pub const STORED_BLOCK_HASH_BUFFER: u64 = 10;
 pub const BLOCK_HASH_CONTRACT_ADDRESS: u64 = 1;

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -16,6 +16,8 @@ pub mod state;
 pub mod transaction_utils;
 pub mod utils;
 
+pub const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../build/os_latest.json");
+
 #[fixture]
 pub fn setup_runner() -> CairoRunner {
     let program_content = fs::read("../build/programs/fact.json").unwrap();

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -884,6 +884,7 @@ where
 }
 
 pub async fn execute_txs_and_run_os<S>(
+    compiled_os: &[u8],
     state: CachedState<SharedState<S, PedersenHash>>,
     block_context: BlockContext,
     txs: Vec<Transaction>,
@@ -905,7 +906,7 @@ where
     .await;
 
     let layout = config::default_layout();
-    let result = run_os(config::DEFAULT_COMPILED_OS, layout, os_input, block_context, execution_helper);
+    let result = run_os(compiled_os, layout, os_input, block_context, execution_helper);
 
     match &result {
         Err(Runner(VmException(vme))) => {

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -83,6 +83,7 @@ async fn declare_v3_cairo1_account(
 
     let txs = vec![declare_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,
@@ -149,6 +150,7 @@ async fn declare_cairo1_account(
 
     let txs = vec![declare_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,
@@ -207,6 +209,7 @@ async fn declare_v1_cairo0_account(
 
     let txs = vec![declare_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,

--- a/tests/integration/deploy_txn_tests.rs
+++ b/tests/integration/deploy_txn_tests.rs
@@ -102,6 +102,7 @@ async fn deploy_cairo0_account(
 
     let txs = vec![deploy_account_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,
@@ -194,6 +195,7 @@ async fn deploy_cairo1_account(
 
     let txs = vec![AccountTransaction::DeployAccount(deploy_account_tx)].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,

--- a/tests/integration/deprecated_syscalls_tests.rs
+++ b/tests/integration/deprecated_syscalls_tests.rs
@@ -69,6 +69,7 @@ async fn test_syscall_library_call_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -110,6 +111,7 @@ async fn test_syscall_get_block_number_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -151,6 +153,7 @@ async fn test_syscall_get_block_timestamp_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -212,6 +215,7 @@ async fn test_syscall_get_tx_info_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -270,6 +274,7 @@ async fn test_syscall_get_tx_signature_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -315,6 +320,7 @@ async fn test_syscall_replace_class_cairo0(
 
     // TODO: use a different class hash and check that it is reflected in the OS output.
     let (_pie, _os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -374,6 +380,7 @@ async fn test_syscall_deploy_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -426,6 +433,7 @@ async fn test_syscall_get_sequencer_address_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -482,6 +490,7 @@ async fn test_syscall_get_contract_address_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -534,6 +543,7 @@ async fn test_syscall_emit_event_cairo0(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, _os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -581,6 +591,7 @@ async fn test_syscall_send_message_to_l1_cairo0(
 
     let txs = vec![Transaction::AccountTransaction(tx)];
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,

--- a/tests/integration/kzg_da_tests.rs
+++ b/tests/integration/kzg_da_tests.rs
@@ -32,6 +32,7 @@ async fn test_kzg_da_cairo_1(#[future] initial_state_cairo1: StarknetTestState, 
     };
     let txs = vec![l1_tx].into_iter().map(Into::into).collect();
     let (_, output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         BlockContext::create_for_account_testing_with_kzg(true),
         txs,
@@ -64,6 +65,7 @@ async fn test_kzg_da_cairo_0(#[future] initial_state_cairo0: StarknetTestState, 
     };
     let txs = vec![l1_tx].into_iter().map(Into::into).collect();
     let (_, output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         BlockContext::create_for_account_testing_with_kzg(true),
         txs,

--- a/tests/integration/l1_handler_txn_tests.rs
+++ b/tests/integration/l1_handler_txn_tests.rs
@@ -62,7 +62,7 @@ async fn l1_handler<F>(
         tx_hash: Default::default(),
     };
     let txs = vec![l1_tx].into_iter().map(Into::into).collect();
-    let _result = execute_txs_and_run_os(
+    let _result = execute_txs_and_run_os(crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,

--- a/tests/integration/os.rs
+++ b/tests/integration/os.rs
@@ -45,6 +45,7 @@ async fn return_result_cairo0_account(
 
     let txs = vec![return_result_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,
@@ -86,6 +87,7 @@ async fn return_result_cairo1_account(
 
     let txs = vec![return_result_tx].into_iter().map(Into::into).collect();
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,
@@ -196,6 +198,7 @@ async fn syscalls_cairo1(
     .collect();
 
     let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,

--- a/tests/integration/run_os.rs
+++ b/tests/integration/run_os.rs
@@ -609,6 +609,7 @@ async fn run_os_tests(#[future] initial_state_full_itests: StarknetTestState) {
     let cached_state = CachedState::from(shared_state);
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         cached_state,
         block_context,
         txs,

--- a/tests/integration/segments_tests.rs
+++ b/tests/integration/segments_tests.rs
@@ -43,6 +43,7 @@ async fn test_segment_arena(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, _os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,
         txs,

--- a/tests/integration/syscalls_tests.rs
+++ b/tests/integration/syscalls_tests.rs
@@ -56,6 +56,7 @@ async fn test_syscall_library_call_cairo1(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -99,6 +100,7 @@ async fn test_syscall_replace_class_cairo1(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, _os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -138,6 +140,7 @@ async fn test_syscall_keccak_cairo1(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, _os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,
@@ -180,6 +183,7 @@ async fn test_syscall_test_secp_cairo1(
     let txs = vec![Transaction::AccountTransaction(tx)];
 
     let (_pie, os_output) = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context.clone(),
         txs,


### PR DESCRIPTION
Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [] dev (no functional changes, no API changes)
- [] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description
I moved the `include_bytes!()` with `snos` import to tests and binary, because it is not present when used as a dependency.

## Breaking changes?

- [x] yes
- [ ] no
