### PR TITLE
Missing constant MAX_HIGH

### DIFF
--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -57,6 +57,7 @@ use rstest::rstest;
 #[case::key_not_in_proof_2(155172)]
 #[case::timestamp_rounding_1(162389)]
 #[case::timestamp_rounding_2(167815)]
+#[case::missing_constant_max_high(164684)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {


### PR DESCRIPTION
Problem: some blocks fail with this error: `inner_exc error: Got an exception while executing a hint: Missing constant: MAX_HIGH`

Solution: Since this seems to be a bug in cairo-vm, we've implemented a default value for MAX_HIGH and MAX_LOW if they are not found on the `constants` HashMap.
Related PR: https://github.com/Moonsong-Labs/cairo-vm/pull/47
In order to get the CI in green, the previous PR has to be merged. Current snos project points to the branch, so it's not needed to update Cargo.toml

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
