### PR TITLE
handle underflow while requesting older block

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -131,9 +131,17 @@ pub async fn prove_block(
     };
 
     // We only need to get the older block number and hash. No need to fetch all the txs
+    // This is a workaorund to catch the case where the block number is less than the buffer and still preserve the check
+    // The OS will also handle the case where the block number is less than the buffer.
+    let older_block_number = if block_number <= STORED_BLOCK_HASH_BUFFER {
+        1
+    } else {
+        block_number - STORED_BLOCK_HASH_BUFFER
+    };
+
     let older_block = match rpc_client
         .starknet_rpc()
-        .get_block_with_tx_hashes(BlockId::Number(block_number - STORED_BLOCK_HASH_BUFFER))
+        .get_block_with_tx_hashes(BlockId::Number(older_block_number))
         .await?
     {
         MaybePendingBlockWithTxHashes::Block(block_with_txs_hashes) => block_with_txs_hashes,
@@ -141,11 +149,11 @@ pub async fn prove_block(
             panic!("Block is still pending!");
         }
     };
-
-    let block_context = build_block_context(chain_id.clone(), &block_with_txs, starknet_version);
-
     let old_block_number = Felt252::from(older_block.block_number);
     let old_block_hash = older_block.block_hash;
+    let block_context = build_block_context(chain_id.clone(), &block_with_txs, starknet_version);
+
+
 
     // TODO: nasty clone, the conversion fns don't take references
     let transactions: Vec<_> =


### PR DESCRIPTION
Problem: The OS require the hash and block number of a older block (current - BUFFER) to perform some validations.
If the Block that we want to prove execution is lower that BUFFER, the OS correctly detects this and do nothing, but our prove_block binary was not having this into account.

Fix: Check if current_block < BUFFER and default to 1 in this case.