### PR TITLE
Fix: Serialize pie function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cairo-lang-starknet-classes = { version = "=2.8.2" }
 cairo-lang-utils = { version = "=2.8.2" }
 cairo-lang-casm = { version = "=2.8.2" }
 cairo-type-derive = { version = "0.1.0", path = "crates/cairo-type-derive" }
-cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", branch = "notlesh/segment-arena-relocation-fix", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
+cairo-vm = { git = "https://github.com/Moonsong-Labs/cairo-vm", branch = "herman/fix-pie-serialization", features = ["cairo-1-hints", "extensive_hints", "mod_builtin"] }
 clap = { version = "4.5.4", features = ["derive"] }
 c-kzg = { version = "1.0.3" }
 env_logger = "0.11.3"

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -8,6 +8,7 @@ use cairo_vm::vm::runners::cairo_pie::{
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use rstest::rstest;
 use serde_json::json;
+use starknet_os::hints::vars::ids::PATH;
 use starknet_os::sharp::pie::{decode_base64_to_unzipped, PIE_FILES};
 
 use crate::common::{os_pie_string, setup_pie};
@@ -89,4 +90,25 @@ fn convert_b64_to_raw(os_pie_string: String) {
         let file_path = dst.join(format!("{file:}.{:}", if file != "memory" { "json" } else { "bin" }));
         assert!(file_path.exists(), "Missing file {:}", file_path.to_string_lossy());
     }
+}
+
+#[rstest]
+fn deserialize_serialize_pie() {
+    let path_read = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("build").join("pie").join("173404.zip");
+    println!("HOLAAA {}", path_read.to_string_lossy());
+    let pie_read = CairoPie::read_zip_file(&path_read).unwrap();
+    pie_read.run_validity_checks().expect("Valid reference PIE");
+    log::info!("SNOS output is valid");
+
+    let path_write = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("build").join("pie").join("test_173404.zip");
+    pie_read.write_zip_file(&path_write).expect("Could not write pie");
+    let pie_write = CairoPie::read_zip_file(&path_write).unwrap();
+
+    pie_write.check_pie_compatibility(&pie_read).expect("Compatible pies");
+
+    // This also fail (pies are not compatible)
+    // pie_write.run_validity_checks().expect("Valid reference PIE");
+
+    // Remove zip file created by the test
+    // std::fs::remove_file(path_write).unwrap();
 }

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -103,8 +103,7 @@ fn deserialize_serialize_pie() {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404_test.zip");
     pie_read.write_zip_file(&path_write).expect("Could not write pie");
     let pie_write = CairoPie::read_zip_file(&path_write).unwrap();
-
-    // This currently fails
+    
     pie_write.check_pie_compatibility(&pie_read).expect("Compatible pies");
 
     println!("Pies are compatibles");

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -94,21 +94,23 @@ fn convert_b64_to_raw(os_pie_string: String) {
 
 #[rstest]
 fn deserialize_serialize_pie() {
-    let path_read = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("build").join("pie").join("173404.zip");
+    let path_read = Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404.zip");
     let pie_read = CairoPie::read_zip_file(&path_read).unwrap();
     pie_read.run_validity_checks().expect("Valid reference PIE");
-    log::info!("SNOS output is valid");
+    println!("SNOS output is valid");
 
-    let path_write = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("build").join("pie").join("test_173404.zip");
+    let path_write = Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404_test.zip");
     pie_read.write_zip_file(&path_write).expect("Could not write pie");
     let pie_write = CairoPie::read_zip_file(&path_write).unwrap();
 
     // This currently fails
     pie_write.check_pie_compatibility(&pie_read).expect("Compatible pies");
 
-    // This also fail (pies are not compatible)
-    // pie_write.run_validity_checks().expect("Valid reference PIE");
+    println!("Pies are compatibles");
 
+    pie_write.run_validity_checks().expect("Valid reference PIE");
+
+    println!("Written file is valid");
     // Remove zip file created by the test
-    // std::fs::remove_file(path_write).unwrap();
+    std::fs::remove_file(path_write).unwrap();
 }

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -8,7 +8,6 @@ use cairo_vm::vm::runners::cairo_pie::{
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use rstest::rstest;
 use serde_json::json;
-use starknet_os::hints::vars::ids::PATH;
 use starknet_os::sharp::pie::{decode_base64_to_unzipped, PIE_FILES};
 
 use crate::common::{os_pie_string, setup_pie};

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -94,12 +94,14 @@ fn convert_b64_to_raw(os_pie_string: String) {
 
 #[rstest]
 fn deserialize_serialize_pie() {
-    let path_read = Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404.zip");
+    let path_read =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404.zip");
     let pie_read = CairoPie::read_zip_file(&path_read).unwrap();
     pie_read.run_validity_checks().expect("Valid reference PIE");
     println!("SNOS output is valid");
 
-    let path_write = Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404_test.zip");
+    let path_write =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404_test.zip");
     pie_read.write_zip_file(&path_write).expect("Could not write pie");
     let pie_write = CairoPie::read_zip_file(&path_write).unwrap();
 

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -103,6 +103,7 @@ fn deserialize_serialize_pie() {
     pie_read.write_zip_file(&path_write).expect("Could not write pie");
     let pie_write = CairoPie::read_zip_file(&path_write).unwrap();
 
+    // This currently fails
     pie_write.check_pie_compatibility(&pie_read).expect("Compatible pies");
 
     // This also fail (pies are not compatible)

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -95,7 +95,6 @@ fn convert_b64_to_raw(os_pie_string: String) {
 #[rstest]
 fn deserialize_serialize_pie() {
     let path_read = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("build").join("pie").join("173404.zip");
-    println!("HOLAAA {}", path_read.to_string_lossy());
     let pie_read = CairoPie::read_zip_file(&path_read).unwrap();
     pie_read.run_validity_checks().expect("Valid reference PIE");
     log::info!("SNOS output is valid");

--- a/tests/integration/pie.rs
+++ b/tests/integration/pie.rs
@@ -103,7 +103,7 @@ fn deserialize_serialize_pie() {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("integration").join("common").join("data").join("173404_test.zip");
     pie_read.write_zip_file(&path_write).expect("Could not write pie");
     let pie_write = CairoPie::read_zip_file(&path_write).unwrap();
-    
+
     pie_write.check_pie_compatibility(&pie_read).expect("Compatible pies");
 
     println!("Pies are compatibles");


### PR DESCRIPTION
Problem: serialize/deserialize is not properly working

Fix: cairo-vm serialize function was not expecting new builtins (fixed [here](https://github.com/Moonsong-Labs/cairo-vm/pull/48/files))
