### PR TITLE
No deploy nullptrs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cairo-lang"]
 	path = cairo-lang
-	url = https://github.com/starkware-libs/cairo-lang.git
+	url = https://github.com/moonsong-labs/cairo-lang.git
 	ignore = all

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cairo-lang"]
 	path = cairo-lang
-	url = https://github.com/moonsong-labs/cairo-lang.git
+	url = https://github.com/notlesh/cairo-lang
 	ignore = all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.1"
-source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04#1fa902bafae507424b5ea83a625830ffe6b0eca5"
+source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization#6036ab9533e1754f1612fbea9c9d2a27063ca5f8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2041,7 +2041,7 @@ name = "hint_tool"
 version = "0.1.0"
 dependencies = [
  "blockifier",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "clap",
  "serde",
  "serde_json",
@@ -2904,7 +2904,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "clap",
  "env_logger",
  "futures-core",
@@ -3245,7 +3245,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "clap",
  "env_logger",
  "futures-core",
@@ -4436,7 +4436,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "cairo-type-derive",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "futures",
  "futures-util",
  "heck 0.4.1",
@@ -4475,7 +4475,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "flate2",
  "indoc",
  "num-bigint",
@@ -4755,7 +4755,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "env_logger",
  "futures",
  "log",

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -6,7 +6,7 @@ use std::vec::IntoIter;
 
 use cairo_vm::hint_processor::builtin_hint_processor::dict_manager::Dictionary;
 use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
-    get_integer_from_var_name, get_maybe_relocatable_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
+    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
     insert_value_into_ap,
 };
 use cairo_vm::hint_processor::hint_processor_definition::HintReference;
@@ -1290,12 +1290,12 @@ pub fn add_relocation_rule(
     let dest_ptr = if let Ok(infos) = get_ptr_from_var_name(vars::ids::INFOS, vm, ids_data, ap_tracking) {
         let infos_0_end = vm.get_relocatable((infos + 1)?)?;
         log::warn!("rewriting dest_ptr for segment_arena workaround");
-        (infos_0_end + 1u32)?.into()
+        (infos_0_end + 1u32)?
     } else {
-        get_maybe_relocatable_from_var_name(vars::ids::DEST_PTR, vm, ids_data, ap_tracking)?
+        get_ptr_from_var_name(vars::ids::DEST_PTR, vm, ids_data, ap_tracking)?
     };
 
-    vm.add_relocation_rule_maybe_relocatable(src_ptr, dest_ptr)?;
+    vm.add_relocation_rule(src_ptr, dest_ptr)?;
 
     Ok(())
 }

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -1122,23 +1122,10 @@ pub fn check_new_deploy_response(
 ) -> Result<(), HintError> {
     let response_ptr = get_ptr_from_var_name(vars::ids::RESPONSE, vm, ids_data, ap_tracking)?;
 
-    // Bugfix:
-    // If constructor_retdata_start is a Int(0) instead of a Relocatable, we need to do nothing. This
-    // can happen sometimes when a constructor is called but not defined in the class'es entry
-    // points. Immediately following this, `add_relocation_rule()` will be called with src=0, dest=0
-    // and it will also no-op.
-    //
-    // If "retdata" is an Int instead of a Relocatable, then the vm will error when we try to
-    // request it as such. In this case, there is no retdata anyway, so there is no need to assert
-    // that the contents are equal.
-    let retdata_start_key: Relocatable =
-        (response_ptr + new_syscalls::DeployResponse::constructor_retdata_start_offset())?;
-    let maybe_retdata_start = vm
-        .get_maybe(&retdata_start_key)
-        .ok_or(HintError::VariableNotInScopeError("retdata".to_string().into_boxed_str()))?;
-    let zero = MaybeRelocatable::Int(Felt252::ZERO);
-    if maybe_retdata_start == zero {
-        log::warn!("retdata_start is 0, not a relocatable, ignoring add_relocation_rule()");
+    let retdata_size =
+        felt_to_usize(get_integer_from_var_name(vars::ids::RETDATA_SIZE, vm, ids_data, ap_tracking)?.as_ref())?;
+    if retdata_size == 0 {
+        log::warn!("Ignoring empty retdata");
         return Ok(());
     }
 
@@ -1149,8 +1136,6 @@ pub fn check_new_deploy_response(
     let response_retdata_size = (constructor_retdata_end - constructor_retdata_start)?;
 
     let retdata = get_ptr_from_var_name(vars::ids::RETDATA, vm, ids_data, ap_tracking)?;
-    let retdata_size =
-        felt_to_usize(get_integer_from_var_name(vars::ids::RETDATA_SIZE, vm, ids_data, ap_tracking)?.as_ref())?;
 
     assert_memory_ranges_equal(vm, constructor_retdata_start, response_retdata_size, retdata, retdata_size)?;
 
@@ -1228,8 +1213,8 @@ pub fn check_response_return_value(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    let retdata = get_ptr_from_var_name(vars::ids::RETDATA, vm, ids_data, ap_tracking)?;
     let retdata_size = get_integer_from_var_name(vars::ids::RETDATA_SIZE, vm, ids_data, ap_tracking)?;
+    let retdata = get_ptr_from_var_name(vars::ids::RETDATA, vm, ids_data, ap_tracking)?;
 
     let response = get_ptr_from_var_name(vars::ids::RESPONSE, vm, ids_data, ap_tracking)?;
     let response_retdata_start =
@@ -1289,18 +1274,6 @@ pub fn add_relocation_rule(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-    // Bugfix:
-    // add_relocation_rule() can be called sometimes with Int(0) instead of Relocatables. This is
-    // a result of `cast(0, felt*)` being treated as Int(0). We can work around this here by
-    // ensuring that both src and dest end up being Int(0), and in that case we no-op here.
-    let src_ptr_maybe = get_maybe_relocatable_from_var_name(vars::ids::SRC_PTR, vm, ids_data, ap_tracking)?;
-    let dest_ptr_maybe = get_maybe_relocatable_from_var_name(vars::ids::DEST_PTR, vm, ids_data, ap_tracking)?;
-
-    let zero = MaybeRelocatable::Int(Felt252::ZERO);
-    if src_ptr_maybe == zero && dest_ptr_maybe == zero {
-        log::warn!("add_relocation_rule with Int(0) => Int(0), doing nothing");
-        return Ok(());
-    }
 
     let src_ptr = get_ptr_from_var_name(vars::ids::SRC_PTR, vm, ids_data, ap_tracking)?;
 
@@ -1317,12 +1290,12 @@ pub fn add_relocation_rule(
     let dest_ptr = if let Ok(infos) = get_ptr_from_var_name(vars::ids::INFOS, vm, ids_data, ap_tracking) {
         let infos_0_end = vm.get_relocatable((infos + 1)?)?;
         log::warn!("rewriting dest_ptr for segment_arena workaround");
-        (infos_0_end + 1u32)?
+        (infos_0_end + 1u32)?.into()
     } else {
-        get_ptr_from_var_name(vars::ids::DEST_PTR, vm, ids_data, ap_tracking)?
+        get_maybe_relocatable_from_var_name(vars::ids::DEST_PTR, vm, ids_data, ap_tracking)?
     };
 
-    vm.add_relocation_rule(src_ptr, dest_ptr)?;
+    vm.add_relocation_rule_maybe_relocatable(src_ptr, dest_ptr)?;
 
     Ok(())
 }

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -6,8 +6,7 @@ use std::vec::IntoIter;
 
 use cairo_vm::hint_processor::builtin_hint_processor::dict_manager::Dictionary;
 use cairo_vm::hint_processor::builtin_hint_processor::hint_utils::{
-    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name,
-    insert_value_into_ap,
+    get_integer_from_var_name, get_ptr_from_var_name, insert_value_from_var_name, insert_value_into_ap,
 };
 use cairo_vm::hint_processor::hint_processor_definition::HintReference;
 use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
@@ -1274,7 +1273,6 @@ pub fn add_relocation_rule(
     ap_tracking: &ApTracking,
     _constants: &HashMap<String, Felt252>,
 ) -> Result<(), HintError> {
-
     let src_ptr = get_ptr_from_var_name(vars::ids::SRC_PTR, vm, ids_data, ap_tracking)?;
 
     assert_eq!(src_ptr.offset, 0, "src_ptr offset should be 0");


### PR DESCRIPTION
This PR removes the retdata hacks (as done in #419) but also makes a small change to `cairo-lang` to avoid `cast(0, felt*)` during deploys.

The changes to the OS are effectively:

```diff
diff --git a/src/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo b/src/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo
index d147c23f7b..e329f5855d 100644
--- a/src/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo
+++ b/src/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo
@@ -128,7 +128,7 @@ func deprecated_execute_entry_point{
         // Assert that there is no call data in the case of NOP entry point.
         assert execution_context.calldata_size = 0;
         %{ execution_helper.skip_call() %}
-        return (retdata_size=0, retdata=cast(0, felt*));
+        return (retdata_size=0, retdata=cast(nondet %{ segments.add() %}, felt*));
     }

     local range_check_ptr = range_check_ptr;
diff --git a/src/starkware/starknet/core/os/execution/deprecated_execute_syscalls.cairo b/src/starkware/starknet/core/os/execution/deprecated_execute_syscalls.cairo
index a3d2f922ec..da1c5219ea 100644
--- a/src/starkware/starknet/core/os/execution/deprecated_execute_syscalls.cairo
+++ b/src/starkware/starknet/core/os/execution/deprecated_execute_syscalls.cairo
@@ -248,7 +248,7 @@ func execute_deploy_syscall{
     assert syscall_ptr.response = DeployResponse(
         contract_address=contract_address,
         constructor_retdata_size=0,
-        constructor_retdata=cast(0, felt*),
+        constructor_retdata=cast(nondet %{ segments.add() %}, felt*),
     );

     tempvar constructor_execution_context = new ExecutionContext(
diff --git a/src/starkware/starknet/core/os/execution/execute_entry_point.cairo b/src/starkware/starknet/core/os/execution/execute_entry_point.cairo
index ef2ca40441..7b32e759af 100644
--- a/src/starkware/starknet/core/os/execution/execute_entry_point.cairo
+++ b/src/starkware/starknet/core/os/execution/execute_entry_point.cairo
@@ -171,7 +171,7 @@ func execute_entry_point{
         // Assert that there is no call data in the case of NOP entry point.
         assert execution_context.calldata_size = 0;
         %{ execution_helper.skip_call() %}
-        return (retdata_size=0, retdata=cast(0, felt*));
+        return (retdata_size=0, retdata=cast(nondet %{ segments.add() %}, felt*));
     }

     let entry_point_offset = compiled_class_entry_point.offset;
```

Note that this PR seems to fail because of the second part of this change, as can be seen in CI in both our integration tests and the `Sepolia integration tests`. Specifically, this second change that breaks things is:

```diff

@@ -248,7 +248,7 @@ func execute_deploy_syscall{

-        constructor_retdata=cast(0, felt*),
+        constructor_retdata=cast(nondet %{ segments.add() %}, felt*),
```