### PR TITLE
remove COMPILED_OS const from lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.1"
-source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04#1fa902bafae507424b5ea83a625830ffe6b0eca5"
+source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization#6036ab9533e1754f1612fbea9c9d2a27063ca5f8"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2041,7 +2041,7 @@ name = "hint_tool"
 version = "0.1.0"
 dependencies = [
  "blockifier",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "clap",
  "serde",
  "serde_json",
@@ -2904,7 +2904,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "clap",
  "env_logger",
  "futures-core",
@@ -3245,7 +3245,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "clap",
  "env_logger",
  "futures-core",
@@ -4436,7 +4436,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "cairo-type-derive",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "futures",
  "futures-util",
  "heck 0.4.1",
@@ -4475,7 +4475,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "flate2",
  "indoc",
  "num-bigint",
@@ -4755,7 +4755,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
  "env_logger",
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "1.0.1"
-source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization#6036ab9533e1754f1612fbea9c9d2a27063ca5f8"
+source = "git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04#1fa902bafae507424b5ea83a625830ffe6b0eca5"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2041,7 +2041,7 @@ name = "hint_tool"
 version = "0.1.0"
 dependencies = [
  "blockifier",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "clap",
  "serde",
  "serde_json",
@@ -2904,7 +2904,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "clap",
  "env_logger",
  "futures-core",
@@ -3245,7 +3245,7 @@ dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "clap",
  "env_logger",
  "futures-core",
@@ -4436,7 +4436,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "cairo-type-derive",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "futures",
  "futures-util",
  "heck 0.4.1",
@@ -4475,7 +4475,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "flate2",
  "indoc",
  "num-bigint",
@@ -4755,7 +4755,7 @@ version = "0.1.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
- "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=herman%2Ffix-pie-serialization)",
+ "cairo-vm 1.0.1 (git+https://github.com/Moonsong-Labs/cairo-vm?branch=notlesh%2Fsnos-2024-11-04)",
  "env_logger",
  "futures",
  "log",

--- a/crates/bin/output_segment/src/main.rs
+++ b/crates/bin/output_segment/src/main.rs
@@ -6,7 +6,9 @@ use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::Felt252;
 use clap::Parser;
-use prove_block::{debug_prove_error, get_memory_segment, prove_block, DEFAULT_COMPILED_OS};
+use prove_block::{debug_prove_error, get_memory_segment, prove_block};
+
+const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.json");
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -48,8 +48,6 @@ mod state_utils;
 mod types;
 mod utils;
 
-pub const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.json");
-
 #[derive(Debug, Error)]
 pub enum ProveBlockError {
     #[error("RPC Error: {0}")]

--- a/crates/bin/prove_block/src/main.rs
+++ b/crates/bin/prove_block/src/main.rs
@@ -1,6 +1,8 @@
 use cairo_vm::types::layout_name::LayoutName;
 use clap::Parser;
-use prove_block::{debug_prove_error, DEFAULT_COMPILED_OS};
+use prove_block::debug_prove_error;
+
+const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.json");
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -1,7 +1,7 @@
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use prove_block::{debug_prove_error, get_memory_segment, prove_block};
-use rstest::rstest; 
+use rstest::rstest;
 const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.json");
 
 // # These blocks verify the following issues:

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -1,7 +1,8 @@
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
-use prove_block::{debug_prove_error, get_memory_segment, prove_block, DEFAULT_COMPILED_OS};
-use rstest::rstest;
+use prove_block::{debug_prove_error, get_memory_segment, prove_block};
+use rstest::rstest; 
+const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.json");
 
 // # These blocks verify the following issues:
 // # * 76793: the first block that we managed to prove, only has a few invoke txs


### PR DESCRIPTION
Problem: We had the COMPILED_OS constant in lib.rs, making it impossible for consumers to define the compiled_os while using SNOS as lib. 

Fix: Move it again to main.rs in correspondent binaries

## Breaking changes?

- [ ] yes
- [x] no
