### PR TITLE
Fix reexecute with blockifier

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -183,7 +183,8 @@ pub async fn prove_block(
                 .await?;
         txs.push(transaction);
     }
-    let tx_execution_infos = reexecute_transactions_with_blockifier(&mut blockifier_state, &block_context, txs)?;
+    let tx_execution_infos =
+        reexecute_transactions_with_blockifier(&mut blockifier_state, &block_context, old_block_hash, txs)?;
 
     let storage_proofs = get_storage_proofs(&rpc_client, block_number, &tx_execution_infos, old_block_number)
         .await

--- a/crates/bin/prove_block/src/reexecute.rs
+++ b/crates/bin/prove_block/src/reexecute.rs
@@ -41,14 +41,14 @@ fn get_tx_hash(tx: &Transaction) -> TransactionHash {
 pub fn reexecute_transactions_with_blockifier<S: StateReader>(
     state: &mut CachedState<S>,
     block_context: &BlockContext,
-    previous_block_hash: Felt252,
+    buffer_block_hash: Felt252,
     txs: Vec<Transaction>,
 ) -> Result<Vec<TransactionExecutionInfo>, Box<dyn Error>> {
     let current_block_number = block_context.block_info().block_number;
-    let previous_block_number_and_hash = if current_block_number.0 >= STORED_BLOCK_HASH_BUFFER {
+    let buffer_block_number_and_hash = if current_block_number.0 >= STORED_BLOCK_HASH_BUFFER {
         Some(BlockNumberHashPair {
             number: starknet_api::block::BlockNumber(current_block_number.0 - STORED_BLOCK_HASH_BUFFER),
-            hash: starknet_api::block::BlockHash(previous_block_hash),
+            hash: starknet_api::block::BlockHash(buffer_block_hash),
         })
     } else {
         None
@@ -57,7 +57,7 @@ pub fn reexecute_transactions_with_blockifier<S: StateReader>(
     // Writes the hash of the (current_block_number - N) block under its block number in the dedicated
     // contract state, where N=STORED_BLOCK_HASH_BUFFER.
     // https://github.com/starkware-libs/sequencer/blob/ee6513d338011067e46c55db4aa6926c8e57650e/crates/blockifier/src/blockifier/block.rs#L110
-    pre_process_block(state, previous_block_number_and_hash, current_block_number)?;
+    pre_process_block(state, buffer_block_number_and_hash, current_block_number)?;
 
     let n_txs = txs.len();
     let tx_execution_infos = txs

--- a/crates/bin/prove_block/src/reexecute.rs
+++ b/crates/bin/prove_block/src/reexecute.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::error::Error;
 
+use blockifier::blockifier::block::{pre_process_block, BlockNumberHashPair};
 use blockifier::context::BlockContext;
 use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::StateReader;
@@ -14,7 +15,7 @@ use rpc_client::RpcClient;
 use starknet::core::types::{BlockId, StarknetError};
 use starknet::providers::{Provider as _, ProviderError};
 use starknet_api::transaction::TransactionHash;
-use starknet_os::config::DEFAULT_STORAGE_TREE_HEIGHT;
+use starknet_os::config::{DEFAULT_STORAGE_TREE_HEIGHT, STORED_BLOCK_HASH_BUFFER};
 use starknet_os::crypto::pedersen::PedersenHash;
 use starknet_os::starknet::starknet_storage::{CommitmentInfo, CommitmentInfoError, PerContractStorage};
 use starknet_os::starkware_utils::commitment_tree::base_types::{Length, NodePath, TreeIndex};
@@ -40,10 +41,25 @@ fn get_tx_hash(tx: &Transaction) -> TransactionHash {
 pub fn reexecute_transactions_with_blockifier<S: StateReader>(
     state: &mut CachedState<S>,
     block_context: &BlockContext,
+    previous_block_hash: Felt252,
     txs: Vec<Transaction>,
 ) -> Result<Vec<TransactionExecutionInfo>, Box<dyn Error>> {
-    let n_txs = txs.len();
+    let current_block_number = block_context.block_info().block_number;
+    let previous_block_number_and_hash = if current_block_number.0 >= STORED_BLOCK_HASH_BUFFER {
+        Some(BlockNumberHashPair {
+            number: starknet_api::block::BlockNumber(current_block_number.0 - STORED_BLOCK_HASH_BUFFER),
+            hash: starknet_api::block::BlockHash(previous_block_hash),
+        })
+    } else {
+        None
+    };
+    // Block pre-processing.
+    // Writes the hash of the (current_block_number - N) block under its block number in the dedicated
+    // contract state, where N=STORED_BLOCK_HASH_BUFFER.
+    // https://github.com/starkware-libs/sequencer/blob/ee6513d338011067e46c55db4aa6926c8e57650e/crates/blockifier/src/blockifier/block.rs#L110
+    pre_process_block(state, previous_block_number_and_hash, current_block_number)?;
 
+    let n_txs = txs.len();
     let tx_execution_infos = txs
         .into_iter()
         .enumerate()

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -62,6 +62,8 @@ const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.j
 #[case::timestamp_rounding_2(167815)]
 #[case::missing_constant_max_high(164684)]
 #[case::retdata_not_a_relocatable(160033)]
+#[case::reexecute_with_blockifier(161599)]
+#[case::reexecute_with_blockifier(174156)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {

--- a/crates/bin/prove_block/tests/prove_block.rs
+++ b/crates/bin/prove_block/tests/prove_block.rs
@@ -62,8 +62,11 @@ const DEFAULT_COMPILED_OS: &[u8] = include_bytes!("../../../../build/os_latest.j
 #[case::timestamp_rounding_2(167815)]
 #[case::missing_constant_max_high(164684)]
 #[case::retdata_not_a_relocatable(160033)]
-#[case::reexecute_with_blockifier(161599)]
-#[case::reexecute_with_blockifier(174156)]
+// The following four tests were added due to errors encountered during reexecution with blockifier
+#[case::dict_error_no_value_found_for_key(161599)]
+#[case::peekable_peek_is_none(174156)]
+#[case::no_more_storage_reads_available(161884)]
+#[case::no_more_storage_reads_available(174027)]
 #[ignore = "Requires a running Pathfinder node"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_prove_selected_blocks(#[case] block_number: u64) {


### PR DESCRIPTION
Problem:
Certain blocks encountered different errors when processed with SNOS. Upon closer inspection, discrepancies were identified between the transaction traces provided by Pathfinder and the internal re-execution using Blockifier. Since both components essentially utilize the same parts of Blockifier, and the traces accurately reflect the network's state, we determined that the traces could serve as a source of truth.

Solution:
Identify the differences in how Pathfinder executes transactions using Blockifier and apply the necessary adjustments. This PR calls `pre_process_block` before executing the transactions that was missing.

Closes https://github.com/keep-starknet-strange/snos/issues/434
Issue Number: N/A

Fix blocks: `161599`, `174156`, `161884` and `174027`

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
