### PR TITLE
Remove os input from execution helper

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -358,7 +358,6 @@ pub async fn prove_block(
         contract_storages,
         tx_execution_infos,
         &block_context,
-        Some(os_input.clone()),
         (old_block_number, old_block_hash),
     );
 

--- a/crates/starknet-os/src/execution/deprecated_syscall_handler.rs
+++ b/crates/starknet-os/src/execution/deprecated_syscall_handler.rs
@@ -370,7 +370,6 @@ mod test {
             ContractStorageMap::default(),
             execution_infos,
             &block_context,
-            None,
             old_block_number_and_hash,
         );
 

--- a/crates/starknet-os/src/execution/helper.rs
+++ b/crates/starknet-os/src/execution/helper.rs
@@ -15,7 +15,6 @@ use tokio::sync::RwLock;
 
 use super::secp_handler::SecpSyscallProcessor;
 use crate::config::STORED_BLOCK_HASH_BUFFER;
-use crate::io::input::StarknetOsInput;
 use crate::starknet::core::os::kzg_manager::KzgManager;
 use crate::starknet::starknet_storage::{CommitmentInfo, CommitmentInfoError, PerContractStorage};
 use crate::storage::storage::StorageError;
@@ -29,7 +28,6 @@ where
     PCS: PerContractStorage,
 {
     pub _prev_block_context: Option<BlockContext>,
-    pub os_input: Option<Rc<StarknetOsInput>>,
     pub kzg_manager: KzgManager,
     // Pointer tx execution info
     pub tx_execution_info_iter: IntoIter<TransactionExecutionInfo>,
@@ -114,7 +112,6 @@ where
         contract_storage_map: ContractStorageMap<PCS>,
         tx_execution_infos: Vec<TransactionExecutionInfo>,
         block_context: &BlockContext,
-        os_input: Option<Rc<StarknetOsInput>>,
         old_block_number_and_hash: (Felt252, Felt252),
     ) -> Self {
         // Block number and block hash (current_block_number - buffer) block buffer=STORED_BLOCK_HASH_BUFFER
@@ -129,7 +126,6 @@ where
         Self {
             execution_helper: Rc::new(RwLock::new(ExecutionHelper {
                 _prev_block_context: prev_block_context,
-                os_input,
                 kzg_manager: Default::default(),
                 tx_execution_info_iter: tx_execution_infos.into_iter(),
                 tx_execution_info: None,

--- a/crates/starknet-os/src/hints/execution.rs
+++ b/crates/starknet-os/src/hints/execution.rs
@@ -1921,7 +1921,7 @@ mod tests {
 
     #[fixture]
     fn execution_helper(block_context: BlockContext, old_block_number_and_hash: (Felt252, Felt252)) -> EHW {
-        EHW::new(ContractStorageMap::default(), vec![], &block_context, None, old_block_number_and_hash)
+        EHW::new(ContractStorageMap::default(), vec![], &block_context, old_block_number_and_hash)
     }
 
     #[fixture]

--- a/crates/starknet-os/src/hints/syscalls.rs
+++ b/crates/starknet-os/src/hints/syscalls.rs
@@ -862,7 +862,7 @@ mod tests {
     fn exec_scopes(block_context: BlockContext, old_block_number_and_hash: (Felt252, Felt252)) -> ExecutionScopes {
         let execution_infos = vec![];
         let exec_helper =
-            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, None, old_block_number_and_hash);
+            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, old_block_number_and_hash);
         let syscall_handler = OsSyscallHandlerWrapper::new(exec_helper);
 
         let mut exec_scopes = ExecutionScopes::new();

--- a/crates/starknet-os/src/hints/tests.rs
+++ b/crates/starknet-os/src/hints/tests.rs
@@ -98,7 +98,6 @@ pub mod tests {
             ContractStorageMap::default(),
             execution_infos,
             &block_context,
-            None,
             old_block_number_and_hash,
         );
         exec_helper.start_tx(None).await;
@@ -168,7 +167,7 @@ pub mod tests {
         // we need an execution info in order to start a tx
         let execution_infos = vec![transaction_execution_info];
         let exec_helper =
-            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, None, old_block_number_and_hash);
+            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, old_block_number_and_hash);
         let exec_helper_box = Box::new(exec_helper);
         exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 
@@ -203,7 +202,7 @@ pub mod tests {
         // execution info to chew through
         let execution_infos = vec![transaction_execution_info];
         let exec_helper =
-            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, None, old_block_number_and_hash);
+            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, old_block_number_and_hash);
         let exec_helper_box = Box::new(exec_helper);
         exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 
@@ -247,7 +246,7 @@ pub mod tests {
 
         let execution_infos = vec![transaction_execution_info];
         let exec_helper =
-            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, None, old_block_number_and_hash);
+            EHW::new(ContractStorageMap::default(), execution_infos, &block_context, old_block_number_and_hash);
         let exec_helper_box = Box::new(exec_helper);
         exec_scopes.insert_box(vars::scopes::EXECUTION_HELPER, exec_helper_box.clone());
 

--- a/tests/integration/common/block_utils.rs
+++ b/tests/integration/common/block_utils.rs
@@ -220,7 +220,6 @@ where
         contract_storage_map,
         tx_execution_infos,
         block_context,
-        Some(os_input.clone()),
         (Felt252::from(block_context.block_info().block_number.0 - STORED_BLOCK_HASH_BUFFER), Felt252::from(66_u64)),
     );
 


### PR DESCRIPTION
Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description

With https://github.com/keep-starknet-strange/snos/pull/419 and https://github.com/keep-starknet-strange/snos/pull/393 merged, the execution helper no longer needs the os input.

## Breaking changes?

- [ ] yes
- [x] no
