### PR TITLE
Calculate class_commitment from proof

### DIFF
--- a/crates/bin/prove_block/src/lib.rs
+++ b/crates/bin/prove_block/src/lib.rs
@@ -79,7 +79,7 @@ fn compute_class_commitment(
     for (class_hash, previous_class_proof) in previous_class_proofs {
         if let Err(e) = previous_class_proof.verify(*class_hash) {
             match e {
-                ProofVerificationError::NonExistenceProof { .. } => {}
+                ProofVerificationError::NonExistenceProof { .. } | ProofVerificationError::EmptyProof => {}
                 _ => panic!("Previous class proof verification failed"),
             }
         }

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -106,6 +106,9 @@ impl PathfinderClassProof {
     ///
     /// However, the proof should always start with the root node, which means all we have
     /// to do is hash the first node in the proof to get the same thing.
+    ///
+    /// NOTE: the v0.8 RPC spec does NOT require the proof to be in order, in which case it is
+    ///       much trickier to guess what the root node is.
     pub fn class_commitment(&self) -> Result<Felt, ProofVerificationError> {
         if !self.class_proof.is_empty() {
             Ok(self.class_proof[0].hash::<PoseidonHash>())

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -54,6 +54,9 @@ pub enum ProofVerificationError<'a> {
     #[error("Proof verification failed, node_hash {node_hash:x} != parent_hash {parent_hash:x}")]
     InvalidChildNodeHash { node_hash: Felt, parent_hash: Felt },
 
+    #[error("Proof is empty")]
+    EmptyProof,
+
     #[error("Conversion error")]
     ConversionError,
 }
@@ -84,14 +87,28 @@ pub struct PathfinderProof {
 #[allow(dead_code)]
 #[derive(Clone, Deserialize)]
 pub struct PathfinderClassProof {
-    pub class_commitment: Felt,
     pub class_proof: Vec<TrieNode>,
 }
 
 impl PathfinderClassProof {
-    /// Verifies that the class proof is valid.
+
     pub fn verify(&self, class_hash: Felt) -> Result<(), ProofVerificationError> {
-        verify_proof::<PoseidonHash>(class_hash, self.class_commitment, &self.class_proof)
+        verify_proof::<PoseidonHash>(class_hash, self.class_commitment()?, &self.class_proof)
+    }
+
+    /// Gets the "class_commitment" which is aka the root node of the class Merkle tree.
+    /// Pathfinder used to provide this explicitly, but stopped doing so in #2452:
+    ///
+    /// https://github.com/eqlabs/pathfinder/pull/2452
+    ///
+    /// However, the proof should always start with the root node, which means all we have
+    /// to do is hash the first node in the proof to get the same thing.
+    pub fn class_commitment(&self) -> Result<Felt, ProofVerificationError> {
+        return if self.class_proof.len() > 0 {
+            Ok(self.class_proof[0].hash::<PoseidonHash>())
+        } else {
+            Err(ProofVerificationError::EmptyProof) // TODO: give an error type or change fn return type
+        };
     }
 }
 

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -108,11 +108,11 @@ impl PathfinderClassProof {
     /// However, the proof should always start with the root node, which means all we have
     /// to do is hash the first node in the proof to get the same thing.
     pub fn class_commitment(&self) -> Result<Felt, ProofVerificationError> {
-        return if self.class_proof.len() > 0 {
+        if !self.class_proof.is_empty() {
             Ok(self.class_proof[0].hash::<PoseidonHash>())
         } else {
             Err(ProofVerificationError::EmptyProof) // TODO: give an error type or change fn return type
-        };
+        }
     }
 }
 

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -95,7 +95,6 @@ pub struct PathfinderClassProof {
 }
 
 impl PathfinderClassProof {
-
     pub fn verify(&self, class_hash: Felt) -> Result<(), ProofVerificationError> {
         verify_proof::<PoseidonHash>(class_hash, self.class_commitment()?, &self.class_proof)
     }


### PR DESCRIPTION
This works around an issue introduced when Pathfinder [removed `class_commitment` from its class proof](https://github.com/eqlabs/pathfinder/pull/2452).

The proofs we get back from `Pathfinder` (prior to v0.8 RPC) are in order. What that means is that the proof is a list of MPT nodes, ordered such that you can walk through the proof from top-to-bottom. This implies that the first node is always the root node, which is the same thing as the `commitment`. In other words, we can get the root/commitment by simply looking at the first node, and that's what this PR does.

Note, however, that this is redundant -- `verify_proof()` ultimately hashes the root node and compares that to `class_commitment`, which is exactly what this PR does. It would be just as good to make `class_commitment` an `Option` an only verify it then; but this PR at least makes the problem clear.

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [ ] no
