### PR TITLE
Use crate once_cell instead of std::cell

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,4 +84,4 @@ jobs:
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
       - run: cargo install cargo-udeps --locked
-      - run: cargo udeps --all-targets
+      - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "true"
+      - run: rustup install +nightly
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "true"
-      - run: rustup install +nightly
+      - run: rustup install nightly
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,6 +4508,7 @@ dependencies = [
  "flate2",
  "indoc",
  "num-bigint",
+ "once_cell",
  "rstest 0.18.2",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ log = "0.4.19"
 num-bigint = "0.4"
 num-integer = "0.1.45"
 num-traits = "0.2.16"
+once_cell = "1.20.0"
 pathfinder-common = { git = "https://github.com/Moonsong-Labs/pathfinder", rev = "9c19d9a37be8f447ec4548456c440ccbd0e44260", package = "pathfinder-common" }
 pathfinder-crypto = { git = "https://github.com/Moonsong-Labs/pathfinder", rev = "9c19d9a37be8f447ec4548456c440ccbd0e44260", package = "pathfinder-crypto" }
 pathfinder-gateway-types = { git = "https://github.com/Moonsong-Labs/pathfinder", rev = "9c19d9a37be8f447ec4548456c440ccbd0e44260", package = "starknet-gateway-types" }

--- a/crates/rpc-client/src/pathfinder/proofs.rs
+++ b/crates/rpc-client/src/pathfinder/proofs.rs
@@ -69,7 +69,11 @@ impl ContractData {
             }
         }
 
-        if errors.is_empty() { Ok(()) } else { Err(errors) }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }
 

--- a/crates/starknet-os-types/Cargo.toml
+++ b/crates/starknet-os-types/Cargo.toml
@@ -11,6 +11,7 @@ cairo-lang-starknet-classes = { workspace = true }
 cairo-vm = { workspace = true }
 num-bigint = { workspace = true }
 flate2 = { workspace = true }
+once_cell = { workspace = true }
 pathfinder-gateway-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/starknet-os-types/src/casm_contract_class.rs
+++ b/crates/starknet-os-types/src/casm_contract_class.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/starknet-os-types/src/deprecated_compiled_class.rs
+++ b/crates/starknet-os-types/src/deprecated_compiled_class.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
 use pathfinder_gateway_types::class_hash::compute_class_hash;

--- a/crates/starknet-os-types/src/hash.rs
+++ b/crates/starknet-os-types/src/hash.rs
@@ -124,7 +124,7 @@ impl From<GenericClassHash> for CompiledClassHash {
 
 impl From<GenericClassHash> for Felt {
     fn from(class_hash: GenericClassHash) -> Self {
-        Felt::from_bytes_be(&class_hash.0.0)
+        Felt::from_bytes_be(&class_hash.0 .0)
     }
 }
 

--- a/crates/starknet-os-types/src/lib.rs
+++ b/crates/starknet-os-types/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(once_cell_try)]
-
 pub mod casm_contract_class;
 pub mod chain_id;
 pub mod class_hash_utils;

--- a/crates/starknet-os-types/src/sierra_contract_class.rs
+++ b/crates/starknet-os-types/src/sierra_contract_class.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
 use cairo_vm::Felt252;

--- a/crates/starknet-os/src/hints/tests.rs
+++ b/crates/starknet-os/src/hints/tests.rs
@@ -208,17 +208,29 @@ pub mod tests {
 
         // before skipping a tx, tx_execution_info should be none and iter should have a next()
         assert!(exec_helper_box.execution_helper.read().await.tx_execution_info.is_none());
-        assert!(
-            exec_helper_box.execution_helper.read().await.tx_execution_info_iter.clone().peekable().peek().is_some()
-        );
+        assert!(exec_helper_box
+            .execution_helper
+            .read()
+            .await
+            .tx_execution_info_iter
+            .clone()
+            .peekable()
+            .peek()
+            .is_some());
 
         skip_tx::<PCS>(&mut vm, &mut exec_scopes, &ids_data, &ap_tracking, &Default::default()).expect("skip_tx");
 
         // after skipping a tx, tx_execution_info should be some and iter should not have a next()
         assert!(exec_helper_box.execution_helper.read().await.tx_execution_info.is_none());
-        assert!(
-            exec_helper_box.execution_helper.read().await.tx_execution_info_iter.clone().peekable().peek().is_none()
-        );
+        assert!(exec_helper_box
+            .execution_helper
+            .read()
+            .await
+            .tx_execution_info_iter
+            .clone()
+            .peekable()
+            .peek()
+            .is_none());
     }
 
     #[rstest]

--- a/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
+++ b/crates/starknet-os/src/starknet/business_logic/fact_state/state.rs
@@ -484,12 +484,13 @@ where
             let compiled_class_hash = self.get_compiled_class_hash_async(class_hash).await?;
             self.get_compiled_contract_class_async(compiled_class_hash).await
         })
-        .unwrap() // TODO: unwrap
+        .unwrap()
     }
 
     /// Returns the compiled class hash of the given class hash.
     fn get_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         log::debug!("SharedState as StateReader: get_compiled_class_hash {:?}", class_hash);
-        execute_coroutine(self.get_compiled_class_hash_async(class_hash)).unwrap() // TODO: unwrap
+        execute_coroutine(self.get_compiled_class_hash_async(class_hash)).unwrap()
+        // TODO: unwrap
     }
 }

--- a/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
+++ b/crates/starknet-os/src/starkware_utils/commitment_tree/patricia_tree/virtual_patricia_node.rs
@@ -371,7 +371,11 @@ mod tests {
 
         println!("{}", root_hash.to_biguint());
 
-        if root_hash_bytes == expected_root_hash { Ok(()) } else { Err(()) }
+        if root_hash_bytes == expected_root_hash {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     async fn build_empty_patricia_virtual_node(ffc: &mut FFC, height: Height) -> VPN {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,4 @@
 [toolchain]
 channel = "1.84"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,2 @@
 [toolchain]
-channel = "nightly-2024-09-05"
-components = ["rustfmt", "clippy"]
-profile = "minimal" 
+channel = "1.84"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84"
+channel = "1.82"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This PR avoids the need for a `nightly` rust compiler by avoiding the `once_cell_try` feature. This is accomplished by using the `once_cell` crate instead of `std::cell`.

Issue Number: N/A

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testingx

## Breaking changes?

- [ ] yes
- [x] no
