### PR TITLE
feat: add support for declare v0 txns

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,5 +84,5 @@ jobs:
         run: |
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
-      - run: cargo +nightly install cargo-udeps --locked
+      - run: cargo install cargo-udeps@0.1.54 --locked
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,5 +84,5 @@ jobs:
         run: |
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
-      - run: cargo install cargo-udeps --locked
+      - run: cargo install cargo-udeps@0.1.54 --locked
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,5 +84,5 @@ jobs:
         run: |
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
-      - run: cargo install cargo-udeps@0.1.54 --locked
+      - run: cargo +nightly install cargo-udeps@0.1.54 --locked
       - run: cargo +nightly udeps --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "true"
-      - run: rustup install nightly-2024-05-02
+      - run: rustup install nightly-2024-09-05
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:
@@ -84,5 +84,5 @@ jobs:
         run: |
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
-      - run: cargo +nightly-2024-05-02 install cargo-udeps@0.1.54 --locked
-      - run: cargo +nightly-2024-05-02 udeps --all-targets
+      - run: cargo +nightly-2024-09-05 install cargo-udeps@0.1.54 --locked
+      - run: cargo +nightly-2024-09-05 udeps --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "true"
-      - run: rustup install nightly
+      - run: rustup install nightly-2024-05-02
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:
@@ -84,5 +84,5 @@ jobs:
         run: |
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
-      - run: cargo +nightly install cargo-udeps@0.1.54 --locked
-      - run: cargo +nightly udeps --all-targets
+      - run: cargo +nightly-2024-05-02 install cargo-udeps@0.1.54 --locked
+      - run: cargo +nightly-2024-05-02 udeps --all-targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,5 +84,5 @@ jobs:
         run: |
           mkdir -p build
           cairo-compile cairo-lang/src/starkware/starknet/core/os/os.cairo --output build/os_latest.json --cairo_path cairo-lang/src
-      - run: cargo install cargo-udeps@0.1.54 --locked
+      - run: cargo +nightly install cargo-udeps --locked
       - run: cargo +nightly udeps --all-targets

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -157,6 +157,8 @@ async fn declare_v0_to_blockifier(
     let api_tx = starknet_api::transaction::DeclareTransaction::V0(starknet_api::transaction::DeclareTransactionV0V1 {
         max_fee: starknet_api::transaction::Fee(felt_to_u128(&tx.max_fee)?),
         signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+        // Declare v0 does not have a nonce 
+        // So we default to 0
         nonce: starknet_api::core::Nonce(Default::default()),
         class_hash: starknet_api::core::ClassHash(tx.class_hash),
         sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -7,10 +7,10 @@ use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::errors::TransactionExecutionError;
 use rpc_client::RpcClient;
 use starknet::core::types::{
-    BlockId, DeclareTransaction, DeclareTransactionV1, DeclareTransactionV2, DeclareTransactionV3,
-    DeployAccountTransaction, DeployAccountTransactionV1, DeployAccountTransactionV3, Felt, InvokeTransaction,
-    InvokeTransactionV1, InvokeTransactionV3, L1HandlerTransaction, ResourceBoundsMapping, Transaction,
-    TransactionTrace, TransactionTraceWithHash,
+    BlockId, DeclareTransaction, DeclareTransactionV0, DeclareTransactionV1, DeclareTransactionV2,
+    DeclareTransactionV3, DeployAccountTransaction, DeployAccountTransactionV1, DeployAccountTransactionV3, Felt,
+    InvokeTransaction, InvokeTransactionV1, InvokeTransactionV3, L1HandlerTransaction, ResourceBoundsMapping,
+    Transaction, TransactionTrace, TransactionTraceWithHash,
 };
 use starknet::providers::{Provider, ProviderError};
 use starknet_api::core::{calculate_contract_address, ContractAddress, PatriciaKey};
@@ -146,6 +146,27 @@ async fn create_class_info(
     };
 
     Ok(ClassInfo::new(&blockifier_contract_class, program_length, abi_length)?)
+}
+
+async fn declare_v0_to_blockifier(
+    tx: &DeclareTransactionV0,
+    client: &RpcClient,
+    block_number: u64,
+) -> Result<blockifier::transaction::transaction_execution::Transaction, ToBlockifierError> {
+    let tx_hash = TransactionHash(tx.transaction_hash);
+    let api_tx = starknet_api::transaction::DeclareTransaction::V0(starknet_api::transaction::DeclareTransactionV0V1 {
+        max_fee: starknet_api::transaction::Fee(felt_to_u128(&tx.max_fee)?),
+        signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
+        nonce: starknet_api::core::Nonce(Default::default()),
+        class_hash: starknet_api::core::ClassHash(tx.class_hash),
+        sender_address: starknet_api::core::ContractAddress(PatriciaKey::try_from(tx.sender_address)?),
+    });
+    let class_info = create_class_info(tx.class_hash, client, block_number).await?;
+    let declare = blockifier::transaction::transactions::DeclareTransaction::new(api_tx, tx_hash, class_info)?;
+
+    Ok(blockifier::transaction::transaction_execution::Transaction::AccountTransaction(AccountTransaction::Declare(
+        declare,
+    )))
 }
 
 async fn declare_v1_to_blockifier(
@@ -365,7 +386,7 @@ pub async fn starknet_rs_to_blockifier(
             InvokeTransaction::V3(tx) => invoke_v3_to_blockifier(tx)?,
         },
         Transaction::Declare(tx) => match tx {
-            DeclareTransaction::V0(_) => unimplemented!("starknet_rs_to_blockifier with DeclareTransaction::V0"),
+            DeclareTransaction::V0(tx) => declare_v0_to_blockifier(tx, client, block_number).await?,
             DeclareTransaction::V1(tx) => declare_v1_to_blockifier(tx, client, block_number).await?,
             DeclareTransaction::V2(tx) => declare_v2_to_blockifier(tx, client, block_number).await?,
             DeclareTransaction::V3(tx) => declare_v3_to_blockifier(tx, client, block_number).await?,

--- a/crates/rpc-replay/src/transactions.rs
+++ b/crates/rpc-replay/src/transactions.rs
@@ -157,7 +157,7 @@ async fn declare_v0_to_blockifier(
     let api_tx = starknet_api::transaction::DeclareTransaction::V0(starknet_api::transaction::DeclareTransactionV0V1 {
         max_fee: starknet_api::transaction::Fee(felt_to_u128(&tx.max_fee)?),
         signature: starknet_api::transaction::TransactionSignature(tx.signature.clone()),
-        // Declare v0 does not have a nonce 
+        // Declare v0 does not have a nonce
         // So we default to 0
         nonce: starknet_api::core::Nonce(Default::default()),
         class_hash: starknet_api::core::ClassHash(tx.class_hash),

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.82"
+channel = "1.83"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.82"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -446,7 +446,7 @@ fn to_internal_l1_handler_tx(l1_tx: &L1HandlerTransaction, chain_id: &ChainId) -
     }
 }
 
-/// Convert a DeclareTransactionV1 to a SNOS InternalTransaction
+/// Convert a DeclareTransactionV0V1 to a SNOS InternalTransaction
 pub fn to_internal_declare_v0_v1_tx(
     account_tx: &AccountTransaction,
     tx: &DeclareTransactionV0V1,

--- a/tests/integration/common/transaction_utils.rs
+++ b/tests/integration/common/transaction_utils.rs
@@ -389,21 +389,18 @@ pub fn to_internal_tx(tx: &Transaction, chain_id: &ChainId) -> InternalTransacti
 }
 fn account_tx_to_internal_tx(account_tx: &AccountTransaction, chain_id: &ChainId) -> InternalTransaction {
     match account_tx {
-        Declare(declare_tx) => {
-            match &declare_tx.tx() {
-                starknet_api::transaction::DeclareTransaction::V0(_) => {
-                    // explicitly not supported
-                    panic!("Declare V0 is not supported");
-                }
-                starknet_api::transaction::DeclareTransaction::V1(tx) => {
-                    to_internal_declare_v1_tx(account_tx, tx, chain_id)
-                }
-                starknet_api::transaction::DeclareTransaction::V2(tx) => {
-                    to_internal_declare_v2_tx(account_tx, tx, chain_id)
-                }
-                starknet_api::transaction::DeclareTransaction::V3(tx) => to_internal_declare_v3_tx(tx, chain_id),
+        Declare(declare_tx) => match &declare_tx.tx() {
+            starknet_api::transaction::DeclareTransaction::V0(tx) => {
+                to_internal_declare_v0_v1_tx(account_tx, tx, chain_id, Felt252::ZERO)
             }
-        }
+            starknet_api::transaction::DeclareTransaction::V1(tx) => {
+                to_internal_declare_v0_v1_tx(account_tx, tx, chain_id, Felt252::ONE)
+            }
+            starknet_api::transaction::DeclareTransaction::V2(tx) => {
+                to_internal_declare_v2_tx(account_tx, tx, chain_id)
+            }
+            starknet_api::transaction::DeclareTransaction::V3(tx) => to_internal_declare_v3_tx(tx, chain_id),
+        },
         DeployAccount(deploy_tx) => match deploy_tx.tx() {
             starknet_api::transaction::DeployAccountTransaction::V1(tx) => {
                 to_internal_deploy_v1_tx(account_tx, tx, chain_id)
@@ -450,10 +447,11 @@ fn to_internal_l1_handler_tx(l1_tx: &L1HandlerTransaction, chain_id: &ChainId) -
 }
 
 /// Convert a DeclareTransactionV1 to a SNOS InternalTransaction
-pub fn to_internal_declare_v1_tx(
+pub fn to_internal_declare_v0_v1_tx(
     account_tx: &AccountTransaction,
     tx: &DeclareTransactionV0V1,
     chain_id: &ChainId,
+    version: Felt252,
 ) -> InternalTransaction {
     let hash_value;
     let sender_address;
@@ -475,7 +473,7 @@ pub fn to_internal_declare_v1_tx(
 
     InternalTransaction {
         hash_value,
-        version: Some(Felt252::ONE),
+        version: Some(version),
         nonce: Some(nonce),
         sender_address: Some(sender_address),
         entry_point_type: Some("EXTERNAL".to_string()),

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -294,7 +294,7 @@ async fn declare_cairo0_with_tx_info(
     .expect("OS run failed");
 }
 
-#[rstest] 
+#[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn declare_v0_cairo0_account(block_context: BlockContext) {
     use starknet_api::core::{ContractAddress, PatriciaKey};

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -5,12 +5,17 @@ use blockifier::declare_tx_args;
 use blockifier::execution::contract_class::ClassInfo;
 use blockifier::test_utils::{NonceManager, BALANCE};
 use blockifier::transaction::test_utils::{calculate_class_info_for_testing, max_fee};
+use cairo_vm::Felt252;
 use rstest::{fixture, rstest};
-use starknet_api::core::CompiledClassHash;
-use starknet_api::transaction::{Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionVersion};
+use starknet_api::contract_address;
+use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::transaction::{
+    Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionSignature, TransactionVersion,
+};
 use starknet_os::crypto::poseidon::PoseidonHash;
 use starknet_os::starknet::business_logic::utils::write_class_facts;
 use starknet_os_types::class_hash_utils::ContractClassComponentHashes;
+use starknet_os_types::deprecated_compiled_class::{BlockifierDeprecatedClass, GenericDeprecatedCompiledClass};
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 
 use crate::common::block_context;
@@ -284,6 +289,47 @@ async fn declare_cairo0_with_tx_info(
         initial_state.cairo0_compiled_classes,
         initial_state.cairo1_compiled_classes,
         class_hash_component_hashes,
+    )
+    .await
+    .expect("OS run failed");
+}
+
+#[rstest] 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn declare_v0_cairo0_account(block_context: BlockContext) {
+    use starknet_api::core::{ContractAddress, PatriciaKey};
+    use starknet_api::{felt, patricia_key};
+
+    let initial_state = StarknetStateBuilder::new(&block_context).build().await;
+
+    let tx_version = TransactionVersion::ZERO;
+
+    let (_, account_with_dummy_validate) = load_cairo0_feature_contract("account_with_dummy_validate");
+    let class_hash = account_with_dummy_validate.class_hash().unwrap();
+
+    let blockifier_class = account_with_dummy_validate.to_blockifier_contract_class().unwrap();
+    let class_info = calculate_class_info_for_testing(blockifier_class.into());
+
+    let sender_address = contract_address!("0x1");
+    let declare_tx = blockifier::test_utils::declare::declare_tx(
+        declare_tx_args! {
+            max_fee: Fee(0),
+            sender_address,
+            version: tx_version,
+            class_hash: class_hash.into(),
+        },
+        class_info,
+    );
+
+    let txs = vec![declare_tx].into_iter().map(Into::into).collect();
+    let _result = execute_txs_and_run_os(
+        crate::common::DEFAULT_COMPILED_OS,
+        initial_state.cached_state,
+        block_context,
+        txs,
+        initial_state.cairo0_compiled_classes,
+        initial_state.cairo1_compiled_classes,
+        HashMap::default(),
     )
     .await
     .expect("OS run failed");

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -318,7 +318,7 @@ async fn declare_v0_cairo0_account(block_context: BlockContext) {
     );
 
     let txs = vec![declare_tx].into_iter().map(Into::into).collect();
-    let _result = execute_txs_and_run_os(
+    let _ = execute_txs_and_run_os(
         crate::common::DEFAULT_COMPILED_OS,
         initial_state.cached_state,
         block_context,

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -8,9 +8,7 @@ use blockifier::transaction::test_utils::{calculate_class_info_for_testing, max_
 use rstest::{fixture, rstest};
 use starknet_api::contract_address;
 use starknet_api::core::CompiledClassHash;
-use starknet_api::transaction::{
-    Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionVersion,
-};
+use starknet_api::transaction::{Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionVersion};
 use starknet_os::crypto::poseidon::PoseidonHash;
 use starknet_os::starknet::business_logic::utils::write_class_facts;
 use starknet_os_types::class_hash_utils::ContractClassComponentHashes;

--- a/tests/integration/declare_txn_tests.rs
+++ b/tests/integration/declare_txn_tests.rs
@@ -5,17 +5,15 @@ use blockifier::declare_tx_args;
 use blockifier::execution::contract_class::ClassInfo;
 use blockifier::test_utils::{NonceManager, BALANCE};
 use blockifier::transaction::test_utils::{calculate_class_info_for_testing, max_fee};
-use cairo_vm::Felt252;
 use rstest::{fixture, rstest};
 use starknet_api::contract_address;
-use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::core::CompiledClassHash;
 use starknet_api::transaction::{
-    Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionSignature, TransactionVersion,
+    Fee, Resource, ResourceBounds, ResourceBoundsMapping, TransactionVersion,
 };
 use starknet_os::crypto::poseidon::PoseidonHash;
 use starknet_os::starknet::business_logic::utils::write_class_facts;
 use starknet_os_types::class_hash_utils::ContractClassComponentHashes;
-use starknet_os_types::deprecated_compiled_class::{BlockifierDeprecatedClass, GenericDeprecatedCompiledClass};
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 
 use crate::common::block_context;


### PR DESCRIPTION
Currently we don't support v0 declare txns. 
We need to:
- [x] Support `DECLARE` V0 on snos
- [x] Support and re-execute tx with blockifier
- [x] Include an integration test for `snos`
- [ ]  Include an integration test for `prove_block` 

**Related Code**

```
thread 'main' panicked at ~/snos/crates/rpc-replay/src/transactions.rs:368:42:
not implemented: starknet_rs_to_blockifier with DeclareTransaction::V0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Issue Number: #470 

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [x] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
