### PR TITLE
fix: handle delegate_call syscalls correctly

### DIFF
--- a/crates/bin/prove_block/src/utils.rs
+++ b/crates/bin/prove_block/src/utils.rs
@@ -162,6 +162,9 @@ fn extract_code_addresses(transaction_info: &[TransactionExecutionInfo]) -> Hash
     addresses
 }
 
+/// Extracts inner code addresses recursively
+///  
+/// *Note* This is an unbounded recursive call
 fn extract_inner_addresses(call_info: &CallInfo, addresses: &mut HashSet<ContractAddress>) {
     if let Some(code_address) = &call_info.call.code_address {
         addresses.insert(*code_address);

--- a/crates/starknet-os/src/execution/deprecated_syscall_handler.rs
+++ b/crates/starknet-os/src/execution/deprecated_syscall_handler.rs
@@ -91,7 +91,7 @@ where
     pub async fn call_contract(&self, syscall_ptr: Relocatable, vm: &mut VirtualMachine) -> Result<(), HintError> {
         self.call_contract_and_write_response(syscall_ptr, CallContract::response_offset(), vm).await
     }
-    #[allow(unused)]
+
     pub async fn delegate_call(&self, syscall_ptr: Relocatable, vm: &mut VirtualMachine) -> Result<(), HintError> {
         self.call_contract_and_write_response(syscall_ptr, CallContract::response_offset(), vm).await
     }

--- a/crates/starknet-os/src/hints/syscalls.rs
+++ b/crates/starknet-os/src/hints/syscalls.rs
@@ -61,7 +61,7 @@ where
     let syscall_handler = exec_scopes.get::<DeprecatedOsSyscallHandlerWrapper<PCS>>(vars::scopes::SYSCALL_HANDLER)?;
     let syscall_ptr = get_ptr_from_var_name(vars::ids::SYSCALL_PTR, vm, ids_data, ap_tracking)?;
 
-    syscall_handler.storage_write(syscall_ptr).await?;
+    syscall_handler.delegate_call(syscall_ptr, vm).await?;
 
     Ok(())
 }

--- a/tests/integration/run_os.rs
+++ b/tests/integration/run_os.rs
@@ -407,6 +407,15 @@ async fn prepare_extensive_os_test_params(
         [test_contract2.class_hash.0],
     ));
 
+    txs.push(build_invoke_tx!(
+        deploy_account_address,
+        nonce_manager,
+        test_contract2_address,
+        "test_delegate_call",
+        // Delegates the test_tx_version to test_contract_run_os, passing on variable and asserting the tx type is 3
+        [**test_contract3_address, selector_from_name("test_tx_version").0, Felt252::ONE, 3.into()],
+    ));
+
     txs
 }
 


### PR DESCRIPTION
Currently the `delegate_syscall` had been silenced with a noop `storage_write`. 
This PR fixes that and adds a test in the run_os tests to ensure that the call is handled correctly

This PR also adds `code_addresses` to the map of `accessed_storage_keys` so that the os can successfully access the storage for contracts that were only invoked in a delegate_call.

Issue Number: N/A

## Type

- [ ] feature
- [x] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [x] testing


## Breaking changes?

- [ ] yes
- [x] no
