### PR TITLE
fix(rpc-client): avoid pathfinder idle connection stalls

### DIFF
--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -80,6 +80,7 @@ impl RpcClientInner {
             .map_err(|e| anyhow!("Failed to parse URL ({}): {}", starknet_rpc_url, e))?;
         let http_client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(RPC_CONNECT_TIMEOUT_SECS))
+            .pool_max_idle_per_host(0)
             .timeout(Duration::from_secs(RPC_REQUEST_TIMEOUT_SECS))
             .build()
             .map_err(|e| anyhow!("Failed to create reqwest client for {}: {}", starknet_rpc_url, e))?;


### PR DESCRIPTION
## Summary
- Disable reqwest idle connection reuse for the Starknet RPC client used by SNOS.
- Keep the existing request/connect timeout and retry behavior on feat/0.14.2.

## Context
Local Madara 0.14.2 E2E runs were hanging while SNOS queried Pathfinder. Fresh connections avoid the Pathfinder keepalive stall and let generate-pie complete.

## Validation
- cargo check -p rpc-client