### PR TITLE
fix(generate-pie): handle migrated compiled class hashes

### DIFF
--- a/crates/core/generate-pie/src/block_processor.rs
+++ b/crates/core/generate-pie/src/block_processor.rs
@@ -119,12 +119,7 @@ pub async fn collect_single_block_info(
     let deprecated_compiled_classes = class_result.deprecated_compiled_classes.clone();
 
     // Step 7b: Extract migrated compiled classes (SNIP-34).
-    let mut class_hashes_to_migrate: Vec<(ClassHash, CompiledClassHash)> = tx_result
-        .processed_state_update
-        .migrated_compiled_classes
-        .iter()
-        .map(|(class_hash, compiled_class_hash)| (ClassHash(*class_hash), CompiledClassHash(*compiled_class_hash)))
-        .collect();
+    let mut class_hashes_to_migrate = tx_result.class_hashes_to_migrate.clone();
     class_hashes_to_migrate.sort_by_key(|(class_hash, _)| class_hash.0);
 
     // Step 8: Build final OS block input

--- a/crates/core/generate-pie/src/types/block.rs
+++ b/crates/core/generate-pie/src/types/block.rs
@@ -13,7 +13,6 @@ use blockifier::blockifier::transaction_executor::{TransactionExecutor, Transact
 use blockifier::blockifier_versioned_constants::VersionedConstants;
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses};
-use blockifier::state::state_api::StateReader;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
 use log::{debug, info, warn};

--- a/crates/core/generate-pie/src/types/block.rs
+++ b/crates/core/generate-pie/src/types/block.rs
@@ -629,12 +629,13 @@ fn build_class_hashes_to_migrate(
         .iter()
         .map(|(class_hash, compiled_class_hash_v2)| {
             let class_hash = ClassHash(*class_hash);
-            let compiled_class_hash_v1 = state_reader.get_compiled_class_hash(class_hash).map_err(|source| {
-                BlockProcessingError::StateUpdateProcessing(format!(
-                    "Failed to read pre-migration compiled class hash for {:?}: {}",
-                    class_hash, source
-                ))
-            })?;
+            let compiled_class_hash_v1 =
+                state_reader.get_pre_snip34_compiled_class_hash(class_hash).map_err(|source| {
+                    BlockProcessingError::StateUpdateProcessing(format!(
+                        "Failed to read pre-migration compiled class hash for {:?}: {}",
+                        class_hash, source
+                    ))
+                })?;
             Ok((class_hash, CompiledClassHash(*compiled_class_hash_v2), compiled_class_hash_v1))
         })
         .collect::<Result<Vec<_>, BlockProcessingError>>()?;

--- a/crates/core/generate-pie/src/types/block.rs
+++ b/crates/core/generate-pie/src/types/block.rs
@@ -13,6 +13,7 @@ use blockifier::blockifier::transaction_executor::{TransactionExecutor, Transact
 use blockifier::blockifier_versioned_constants::VersionedConstants;
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses};
+use blockifier::state::state_api::StateReader;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
 use log::{debug, info, warn};
@@ -30,7 +31,7 @@ use starknet_api::block::{
     BlockHash, BlockHashAndNumber, BlockInfo, BlockNumber, BlockTimestamp, GasPrices, StarknetVersion,
 };
 use starknet_api::contract_address;
-use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
 use starknet_api::state::StorageKey;
 use starknet_api::versioned_constants_logic::VersionedConstantsTrait;
 use starknet_os_types::chain_id::chain_id_from_felt;
@@ -332,6 +333,8 @@ impl BlockData {
             BlockProcessingError::StateUpdateProcessing(format!("Failed to get formatted state update: {:?}", e))
         })?;
         info!("Fetched processed state update successfully");
+        let class_hashes_to_migrate = build_class_hashes_to_migrate(&processed_state_update, &blockifier_state_reader)?;
+        apply_pre_migration_compiled_class_hashes(&mut initial_reads, &class_hashes_to_migrate);
 
         let block_hash_commitments = compute_block_hash_commitments(
             &starknet_api_txns,
@@ -376,6 +379,10 @@ impl BlockData {
             central_txn_execution_infos,
             accessed_addresses,
             accessed_classes,
+            class_hashes_to_migrate: class_hashes_to_migrate
+                .iter()
+                .map(|(class_hash, compiled_class_hash_v2, _)| (*class_hash, *compiled_class_hash_v2))
+                .collect(),
             accessed_keys_by_address,
             initial_reads,
             block_hash_commitments,
@@ -581,6 +588,70 @@ fn populate_alias_contract_keys(
     }
 }
 
+fn validate_migrated_compiled_classes(
+    processed_state_update: &crate::state_update::FormattedStateUpdate,
+    class_hashes_to_migrate: &[(ClassHash, CompiledClassHash, CompiledClassHash)],
+) -> Result<(), BlockProcessingError> {
+    if processed_state_update.migrated_compiled_classes.len() != class_hashes_to_migrate.len() {
+        return Err(BlockProcessingError::StateUpdateProcessing(format!(
+            "Migrated compiled classes mismatch: RPC reported {} entries but Blockifier reported {}",
+            processed_state_update.migrated_compiled_classes.len(),
+            class_hashes_to_migrate.len()
+        )));
+    }
+
+    for (class_hash, compiled_class_hash_v2, _) in class_hashes_to_migrate {
+        let rpc_compiled_class_hash_v2 =
+            processed_state_update.migrated_compiled_classes.get(&class_hash.0).copied().ok_or_else(|| {
+                BlockProcessingError::StateUpdateProcessing(format!(
+                    "Missing migrated compiled class in RPC state update for class hash {:?}",
+                    class_hash
+                ))
+            })?;
+
+        if rpc_compiled_class_hash_v2 != compiled_class_hash_v2.0 {
+            return Err(BlockProcessingError::StateUpdateProcessing(format!(
+                "Migrated compiled class hash mismatch for {:?}: RPC reported {:?}, Blockifier reported {:?}",
+                class_hash, rpc_compiled_class_hash_v2, compiled_class_hash_v2
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn build_class_hashes_to_migrate(
+    processed_state_update: &crate::state_update::FormattedStateUpdate,
+    state_reader: &AsyncRpcStateReader,
+) -> Result<Vec<(ClassHash, CompiledClassHash, CompiledClassHash)>, BlockProcessingError> {
+    let class_hashes_to_migrate = processed_state_update
+        .migrated_compiled_classes
+        .iter()
+        .map(|(class_hash, compiled_class_hash_v2)| {
+            let class_hash = ClassHash(*class_hash);
+            let compiled_class_hash_v1 = state_reader.get_compiled_class_hash(class_hash).map_err(|source| {
+                BlockProcessingError::StateUpdateProcessing(format!(
+                    "Failed to read pre-migration compiled class hash for {:?}: {}",
+                    class_hash, source
+                ))
+            })?;
+            Ok((class_hash, CompiledClassHash(*compiled_class_hash_v2), compiled_class_hash_v1))
+        })
+        .collect::<Result<Vec<_>, BlockProcessingError>>()?;
+
+    validate_migrated_compiled_classes(processed_state_update, &class_hashes_to_migrate)?;
+    Ok(class_hashes_to_migrate)
+}
+
+fn apply_pre_migration_compiled_class_hashes(
+    initial_reads: &mut blockifier::state::cached_state::StateMaps,
+    class_hashes_to_migrate: &[(ClassHash, CompiledClassHash, CompiledClassHash)],
+) {
+    for (class_hash, _, compiled_class_hash_v1) in class_hashes_to_migrate {
+        initial_reads.compiled_class_hashes.insert(*class_hash, *compiled_class_hash_v1);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -677,5 +748,39 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(os_error, BlockProcessingError::InvalidOldBlockNumber { .. }));
+    }
+
+    #[test]
+    fn apply_pre_migration_compiled_class_hashes_replaces_v2_with_v1() {
+        let class_hash = ClassHash(Felt::from(11_u8));
+        let compiled_class_hash_v2 = CompiledClassHash(Felt::from(22_u8));
+        let compiled_class_hash_v1 = CompiledClassHash(Felt::from(33_u8));
+        let mut initial_reads = blockifier::state::cached_state::StateMaps::default();
+        initial_reads.compiled_class_hashes.insert(class_hash, compiled_class_hash_v2);
+
+        apply_pre_migration_compiled_class_hashes(
+            &mut initial_reads,
+            &[(class_hash, compiled_class_hash_v2, compiled_class_hash_v1)],
+        );
+
+        assert_eq!(initial_reads.compiled_class_hashes.get(&class_hash), Some(&compiled_class_hash_v1));
+    }
+
+    #[test]
+    fn validate_migrated_compiled_classes_accepts_matching_blockifier_and_rpc_data() {
+        let class_hash = ClassHash(Felt::from(11_u8));
+        let compiled_class_hash_v2 = CompiledClassHash(Felt::from(22_u8));
+        let compiled_class_hash_v1 = CompiledClassHash(Felt::from(33_u8));
+        let processed_state_update = crate::state_update::FormattedStateUpdate {
+            migrated_compiled_classes: HashMap::from([(class_hash.0, compiled_class_hash_v2.0)]),
+            ..Default::default()
+        };
+
+        let result = validate_migrated_compiled_classes(
+            &processed_state_update,
+            &[(class_hash, compiled_class_hash_v2, compiled_class_hash_v1)],
+        );
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/core/generate-pie/src/types/transaction.rs
+++ b/crates/core/generate-pie/src/types/transaction.rs
@@ -10,7 +10,7 @@ use rpc_client::RpcClient;
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
 use starknet::core::types::BlockId;
 use starknet_api::block_hash::block_hash_calculator::BlockHeaderCommitments;
-use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
 use starknet_api::state::StorageKey;
 use std::collections::{HashMap, HashSet};
 
@@ -22,6 +22,7 @@ pub struct TransactionProcessingResult {
     pub central_txn_execution_infos: Vec<CentralTransactionExecutionInfo>,
     pub accessed_addresses: HashSet<ContractAddress>,
     pub accessed_classes: HashSet<ClassHash>,
+    pub class_hashes_to_migrate: Vec<(ClassHash, CompiledClassHash)>,
     pub accessed_keys_by_address: HashMap<ContractAddress, HashSet<StorageKey>>,
     pub initial_reads: StateMaps,
     pub block_hash_commitments: BlockHeaderCommitments,

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use crate::constants::{MAX_CONCURRENT_PROOF_REQUESTS, MAX_STORAGE_KEYS_PER_REQUEST, STARKNET_RPC_VERSION};
 use crate::types::{ClassProof, ContractProof};
 
-const RPC_REQUEST_TIMEOUT_SECS: u64 = 15;
+const RPC_REQUEST_TIMEOUT_SECS: u64 = 60;
 const RPC_CONNECT_TIMEOUT_SECS: u64 = 5;
 
 pub trait ProofClient {

--- a/crates/rpc-client/src/state_reader/mod.rs
+++ b/crates/rpc-client/src/state_reader/mod.rs
@@ -194,6 +194,26 @@ impl AsyncRpcStateReader {
         self.get_compiled_class_hash_with_version_async(class_hash, CompiledClassHashVersion::V1).await
     }
 
+    pub async fn get_pre_snip34_compiled_class_hash_async(
+        &self,
+        class_hash: ClassHash,
+    ) -> StateResult<CompiledClassHash> {
+        if self.has_no_block() {
+            return Err(StateError::UndeclaredClassHash(class_hash));
+        }
+
+        let block_id = self.block_id.unwrap();
+        debug!("get_pre_snip34_compiled_class_hash for class_hash: {:?}", class_hash);
+        let operation_name = format!("get_pre_snip34_compiled_class_hash(class_hash: {:?})", class_hash);
+
+        let contract_class =
+            execute_with_retry(&operation_name, || self.rpc_client.starknet_rpc().get_class(block_id, class_hash.0))
+                .await
+                .map_err(provider_error_to_state_error)?;
+
+        compute_pre_snip34_compiled_class_hash(&contract_class)
+    }
+
     pub async fn get_compiled_class_hash_v2_async(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         self.get_compiled_class_hash_with_version_async(class_hash, CompiledClassHashVersion::V2).await
     }
@@ -222,6 +242,10 @@ impl AsyncRpcStateReader {
 
     pub fn get_compiled_class_hash_v2(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
         execute_coroutine(self.get_compiled_class_hash_v2_async(class_hash))
+    }
+
+    pub fn get_pre_snip34_compiled_class_hash(&self, class_hash: ClassHash) -> StateResult<CompiledClassHash> {
+        execute_coroutine(self.get_pre_snip34_compiled_class_hash_async(class_hash))
     }
 }
 
@@ -299,6 +323,21 @@ fn compute_compiled_class_hash_internal(
             // to skip them during casm hash migration.
             return Ok(CompiledClassHash::default());
         }
+    };
+
+    Ok(class_hash.into())
+}
+
+fn compute_pre_snip34_compiled_class_hash(
+    contract_class: &starknet::core::types::ContractClass,
+) -> Result<CompiledClassHash, StateError> {
+    let class_hash = match contract_class {
+        starknet::core::types::ContractClass::Sierra(sierra_class) => {
+            let generic_sierra = convert_sierra_class_for_generic(sierra_class)?;
+            let compiled_class = generic_sierra.compile().map_err(to_state_err)?;
+            compiled_class.pre_snip34_class_hash().map_err(to_state_err)?
+        }
+        starknet::core::types::ContractClass::Legacy(_) => return Ok(CompiledClassHash::default()),
     };
 
     Ok(class_hash.into())

--- a/crates/rpc-client/src/utils.rs
+++ b/crates/rpc-client/src/utils.rs
@@ -13,7 +13,7 @@ use tokio::time::sleep;
 static GLOBAL_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 /// Maximum number of retry attempts for RPC calls.
-const MAX_RETRY_ATTEMPTS: u32 = 3;
+const MAX_RETRY_ATTEMPTS: u32 = 5;
 
 /// Initial delay for exponential backoff (in milliseconds).
 const INITIAL_BACKOFF_MS: u64 = 100;

--- a/crates/starknet-os-types/src/casm_contract_class.rs
+++ b/crates/starknet-os-types/src/casm_contract_class.rs
@@ -48,9 +48,11 @@ pub struct GenericCasmContractClass {
     cairo_lang_contract_class: OnceCell<Arc<CairoLangCasmClass>>,
     /// Lazy-initialized serialized contract class bytes.
     serialized_class: OnceCell<Arc<Vec<u8>>>,
-    /// Lazy-initialized computed class hash (Poseidon - pre-SNIP-34).
+    /// Lazy-initialized pre-SNIP-34 compiled class hash (Poseidon).
+    class_hash_v1: OnceCell<GenericClassHash>,
+    /// Lazy-initialized canonical compiled class hash.
     class_hash: OnceCell<GenericClassHash>,
-    /// Lazy-initialized computed class hash v2 (BLAKE2s - post-SNIP-34).
+    /// Lazy-initialized compiled class hash v2 (BLAKE2s - post-SNIP-34).
     class_hash_v2: OnceCell<GenericClassHash>,
 }
 
@@ -118,6 +120,7 @@ impl GenericCasmContractClass {
             blockifier_contract_class: OnceCell::new(),
             cairo_lang_contract_class: OnceCell::new(),
             serialized_class: OnceCell::from(Arc::new(serialized_class)),
+            class_hash_v1: OnceCell::new(),
             class_hash: OnceCell::new(),
             class_hash_v2: OnceCell::new(),
         }
@@ -284,7 +287,7 @@ impl GenericCasmContractClass {
         Ok(blockifier_class.clone())
     }
 
-    /// Computes the class hash for this contract class.
+    /// Computes the canonical compiled class hash for this contract class.
     ///
     /// # Returns
     ///
@@ -295,15 +298,26 @@ impl GenericCasmContractClass {
     /// Returns a `ContractClassError` if the class hash computation fails.
     fn compute_class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
         let compiled_class = self.get_cairo_lang_contract_class()?;
-        let class_hash_felt = compiled_class.hash(&HashVersion::V1);
+        let class_hash_felt = compiled_class.compiled_class_hash();
 
-        Ok(GenericClassHash::from_bytes_be(class_hash_felt.0.to_bytes_be()))
+        Ok(GenericClassHash::from_bytes_be(class_hash_felt.to_bytes_be()))
     }
 
-    /// Gets the class hash for this contract class, computing it if necessary.
+    /// Computes the pre-SNIP-34 compiled class hash (Poseidon) for this contract class.
     ///
-    /// This returns the **Poseidon hash** (pre-SNIP-34). For the BLAKE2s hash
-    /// (post-SNIP-34), use [`class_hash_v2`](Self::class_hash_v2).
+    /// This is only needed when reconstructing the pre-migration OS state for chains that still
+    /// transition a class from the old Poseidon hash to the post-SNIP-34 BLAKE2s hash.
+    fn compute_pre_snip34_class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        let compiled_class = self.get_cairo_lang_contract_class()?;
+        let class_hash = compiled_class.hash(&HashVersion::V1);
+        Ok(GenericClassHash::from_bytes_be(class_hash.0.to_bytes_be()))
+    }
+
+    /// Gets the canonical compiled class hash for this contract class, computing it if necessary.
+    ///
+    /// This follows the default Cairo-lang / Starknet representation for the compiled class and
+    /// should be used for normal replay paths. For the pre-SNIP-34 Poseidon hash, use
+    /// [`pre_snip34_class_hash`](Self::pre_snip34_class_hash).
     ///
     /// # Returns
     ///
@@ -323,6 +337,11 @@ impl GenericCasmContractClass {
     /// ```
     pub fn class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
         self.class_hash.get_or_try_init(|| self.compute_class_hash()).copied()
+    }
+
+    /// Gets the pre-SNIP-34 compiled class hash (Poseidon), computing it if necessary.
+    pub fn pre_snip34_class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
+        self.class_hash_v1.get_or_try_init(|| self.compute_pre_snip34_class_hash()).copied()
     }
 
     /// Computes the class hash v2 (BLAKE2s / SNIP-34) for this contract class.
@@ -369,6 +388,7 @@ impl From<CairoLangCasmClass> for GenericCasmContractClass {
             blockifier_contract_class: Default::default(),
             cairo_lang_contract_class: OnceCell::from(Arc::new(cairo_lang_class)),
             serialized_class: Default::default(),
+            class_hash_v1: Default::default(),
             class_hash: Default::default(),
             class_hash_v2: Default::default(),
         }
@@ -381,6 +401,7 @@ impl From<BlockifierCasmClass> for GenericCasmContractClass {
             blockifier_contract_class: OnceCell::from(Arc::new(blockifier_class)),
             cairo_lang_contract_class: Default::default(),
             serialized_class: Default::default(),
+            class_hash_v1: Default::default(),
             class_hash: Default::default(),
             class_hash_v2: Default::default(),
         }
@@ -440,10 +461,11 @@ mod tests {
     }
 
     #[test]
-    fn test_class_hash_versions_diverge_for_cairo1_contract() {
+    fn test_pre_snip34_class_hash_differs_from_default_hash_for_cairo1_contract() {
         let generic_class = GenericCasmContractClass::from_bytes(CONTRACT_BYTES.to_vec());
 
-        assert_ne!(generic_class.class_hash().unwrap(), generic_class.class_hash_v2().unwrap());
+        assert_ne!(generic_class.class_hash().unwrap(), generic_class.pre_snip34_class_hash().unwrap());
+        assert_eq!(generic_class.class_hash().unwrap(), generic_class.class_hash_v2().unwrap());
     }
 
     const TEST_CONTRACT_WITHOUT_SEGMENTATION: &str = indoc! {r#"

--- a/crates/starknet-os-types/src/casm_contract_class.rs
+++ b/crates/starknet-os-types/src/casm_contract_class.rs
@@ -295,9 +295,9 @@ impl GenericCasmContractClass {
     /// Returns a `ContractClassError` if the class hash computation fails.
     fn compute_class_hash(&self) -> Result<GenericClassHash, ContractClassError> {
         let compiled_class = self.get_cairo_lang_contract_class()?;
-        let class_hash_felt = compiled_class.compiled_class_hash();
+        let class_hash_felt = compiled_class.hash(&HashVersion::V1);
 
-        Ok(GenericClassHash::from_bytes_be(class_hash_felt.to_bytes_be()))
+        Ok(GenericClassHash::from_bytes_be(class_hash_felt.0.to_bytes_be()))
     }
 
     /// Gets the class hash for this contract class, computing it if necessary.
@@ -437,6 +437,13 @@ mod tests {
         // improved with more methods on `Hash` / `GenericClassHash`.
         let expected_class_hash = Felt::from_str(EXPECTED_TEST_CONTRACT_CLASS_HASH).unwrap();
         assert_eq!(Felt::from(*class_hash), expected_class_hash);
+    }
+
+    #[test]
+    fn test_class_hash_versions_diverge_for_cairo1_contract() {
+        let generic_class = GenericCasmContractClass::from_bytes(CONTRACT_BYTES.to_vec());
+
+        assert_ne!(generic_class.class_hash().unwrap(), generic_class.class_hash_v2().unwrap());
     }
 
     const TEST_CONTRACT_WITHOUT_SEGMENTATION: &str = indoc! {r#"


### PR DESCRIPTION
## What changed
- preserve the pre-migration compiled class hash in initial state reads while still emitting the migrated v2 hash in the OS block input
- validate migrated compiled class hashes reported by RPC against Blockifier before building the block input
- compute CASM `class_hash()` with hash version V1 and add regression coverage for v1/v2 hash divergence

## Why
Migrated classes under SNIP-34 need both hash versions for correct generate-pie execution. The previous flow reused the migrated hash too early, which could feed the wrong compiled class hash into pre-migration reads.

## Impact
Blocks that include migrated compiled classes now keep the correct pre-migration compiled class hash for execution while still serializing migration metadata for downstream consumers.

## Validation
- `CARGO_HOME=/tmp/cargo-home cargo test -p generate-pie -p starknet-os-types` is running in an isolated cargo home because the default `~/.cargo/git` points to a missing external volume on this machine
