### PR TITLE
Harden proof and class fetch failure handling

### DIFF
--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -446,11 +446,12 @@ async fn process_accessed_addresses(
     info!("Fetched {} contract classes, now compiling in parallel...", class_results.len());
 
     // Phase 3: Compile classes in parallel using rayon (CPU parallelization)
-    let mut successful_class_results = Vec::with_capacity(class_results.len());
-    for (class_hash, contract_class_result) in class_results {
-        let contract_class = contract_class_result.map_err(StateUpdateError::RpcError)?;
-        successful_class_results.push((class_hash, contract_class));
-    }
+    let successful_class_results: Vec<_> = class_results
+        .into_iter()
+        .map(|(class_hash, contract_class_result)| {
+            contract_class_result.map_err(StateUpdateError::RpcError).map(|contract_class| (class_hash, contract_class))
+        })
+        .collect::<Result<_, _>>()?;
 
     let compilation_results: Vec<(Felt, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_results
         .into_par_iter()
@@ -507,11 +508,12 @@ async fn process_accessed_classes(
     info!("Fetched {} contract classes, now compiling in parallel...", class_fetch_results.len());
 
     // Phase 2: Compile classes in parallel using rayon (CPU parallelization)
-    let mut successful_class_fetches = Vec::with_capacity(class_fetch_results.len());
-    for (class_hash, contract_class_result) in class_fetch_results {
-        let contract_class = contract_class_result.map_err(StateUpdateError::RpcError)?;
-        successful_class_fetches.push((class_hash, contract_class));
-    }
+    let successful_class_fetches: Vec<_> = class_fetch_results
+        .into_iter()
+        .map(|(class_hash, contract_class_result)| {
+            contract_class_result.map_err(StateUpdateError::RpcError).map(|contract_class| (class_hash, contract_class))
+        })
+        .collect::<Result<_, _>>()?;
 
     let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_fetches
         .into_par_iter()

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -446,13 +446,15 @@ async fn process_accessed_addresses(
     info!("Fetched {} contract classes, now compiling in parallel...", class_results.len());
 
     // Phase 3: Compile classes in parallel using rayon (CPU parallelization)
-    let compilation_results: Vec<(Felt, Result<GenericCompiledClass, StateUpdateError>)> = class_results
+    let mut successful_class_results = Vec::with_capacity(class_results.len());
+    for (class_hash, contract_class_result) in class_results {
+        let contract_class = contract_class_result.map_err(StateUpdateError::RpcError)?;
+        successful_class_results.push((class_hash, contract_class));
+    }
+
+    let compilation_results: Vec<(Felt, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_results
         .into_par_iter()
-        .filter_map(|(class_hash, contract_class_result)| {
-            let contract_class = contract_class_result.ok()?;
-            let compiled_result = compile_contract_class(contract_class);
-            Some((class_hash, compiled_result))
-        })
+        .map(|(class_hash, contract_class)| (class_hash, compile_contract_class(contract_class)))
         .collect();
 
     // Add compiled classes to result
@@ -488,15 +490,14 @@ async fn process_accessed_classes(
 
     // Phase 1: Fetch all contract classes concurrently (network I/O parallelization)
     let class_hashes: Vec<Felt252> = accessed_classes.iter().copied().collect();
-    let class_fetch_results: Vec<(Felt252, Option<starknet::core::types::ContractClass>)> =
+    let class_fetch_results: Vec<(Felt252, Result<starknet::core::types::ContractClass, ProviderError>)> =
         stream::iter(class_hashes.clone())
             .map(|class_hash| async move {
                 debug!("Fetching class hash: {:?}", class_hash);
                 let operation_name = format!("get_class(block_id: {block_id:?}, class_hash: {class_hash:?})");
                 let contract_class =
                     execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(block_id, class_hash))
-                        .await
-                        .ok();
+                        .await;
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
@@ -506,13 +507,15 @@ async fn process_accessed_classes(
     info!("Fetched {} contract classes, now compiling in parallel...", class_fetch_results.len());
 
     // Phase 2: Compile classes in parallel using rayon (CPU parallelization)
-    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = class_fetch_results
+    let mut successful_class_fetches = Vec::with_capacity(class_fetch_results.len());
+    for (class_hash, contract_class_result) in class_fetch_results {
+        let contract_class = contract_class_result.map_err(StateUpdateError::RpcError)?;
+        successful_class_fetches.push((class_hash, contract_class));
+    }
+
+    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_fetches
         .into_par_iter()
-        .filter_map(|(class_hash, contract_class_opt)| {
-            let contract_class = contract_class_opt?;
-            let compiled_result = compile_contract_class(contract_class);
-            Some((class_hash, compiled_result))
-        })
+        .map(|(class_hash, contract_class)| (class_hash, compile_contract_class(contract_class)))
         .collect();
 
     // Add compiled classes to result

--- a/crates/core/generate-pie/src/utils/rpc.rs
+++ b/crates/core/generate-pie/src/utils/rpc.rs
@@ -8,6 +8,7 @@ use log::info;
 use rpc_client::client::ProofClient;
 use rpc_client::error::ClientError;
 use rpc_client::types::{ClassProof, ContractData, ContractProof};
+use rpc_client::utils::execute_with_retry;
 use rpc_client::RpcClient;
 use starknet_api::contract_address;
 use starknet_api::core::{ClassHash, ContractAddress};
@@ -143,11 +144,16 @@ pub(crate) async fn get_class_proofs(
     info!("Fetching class proofs for {} classes", class_hashes.len());
 
     for class_hash in class_hashes {
-        let proof = rpc_client
-            .starknet_rpc()
-            .get_class_proof(block_number, class_hash)
-            .await
-            .map_err(|e| ClientError::CustomError(format!("{}", e)))?;
+        let operation_name = format!("get_class_proof(block_number: {block_number}, class_hash: {class_hash:#x})");
+        let proof =
+            execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class_proof(block_number, class_hash))
+                .await
+                .map_err(|e| {
+                    ClientError::CustomError(format!(
+                        "class proof request failed for block {} class_hash {:#x}: {}",
+                        block_number, class_hash, e
+                    ))
+                })?;
         // TODO: need to combine these, similar to merge_chunked_storage_proofs above?
         proofs.insert(**class_hash, proof);
     }
@@ -198,8 +204,6 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
         vec![]
     };
 
-    info!("Got {} additional keys for contract {}", additional_keys.len(), contract_address);
-
     // Fetch additional proofs required to fill gaps in the storage trie that could make
     // the OS crash otherwise.
     if !additional_keys.is_empty() {
@@ -209,7 +213,11 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
         // Combine all storage proofs into a single vector
         match &additional_proof.contract_data {
             None => {
-                panic!("Failed to fetch additional proof for contract {}", contract_address)
+                let message = format!(
+                    "Additional storage proof for contract {} at block {} returned no contract_data",
+                    contract_address, block_number
+                );
+                return Err(ClientError::CustomError(message));
             }
             Some(contract_data) => {
                 additional_proof.contract_data = Some(ContractData {
@@ -236,11 +244,22 @@ async fn fetch_storage_proof_for_contract(
 ) -> Result<ContractProof, ClientError> {
     info!("Fetching storage proof for contract {} with {} keys", contract_address, keys.len());
 
-    rpc_client
-        .starknet_rpc()
-        .get_proof(block_number, contract_address, keys)
+    let operation_name = format!(
+        "get_proof(block_number: {block_number}, contract_address: {contract_address:#x}, keys: {})",
+        keys.len()
+    );
+
+    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_proof(block_number, contract_address, keys))
         .await
-        .map_err(|e| ClientError::CustomError(format!("{}", e)))
+        .map_err(|e| {
+            ClientError::CustomError(format!(
+                "storage proof request failed for block {} contract {:#x} keys={}: {}",
+                block_number,
+                contract_address,
+                keys.len(),
+                e
+            ))
+        })
 }
 
 /// Merges the storage proofs of the SAME contract.


### PR DESCRIPTION
## Summary
- retry storage-proof and class-proof fetches before failing
- replace the additional-proof panic with a typed error
- stop silently dropping class fetch failures during state update processing
- include block/address/class context in proof-fetch errors

## Why
`main` already has broader retry coverage and a different pre-state pipeline, so this PR keeps the scope narrow to the remaining proof/class-fetch paths that can still fail opaquely or continue with incomplete data.

## Validation
- cargo fmt --all
- cargo check -p rpc-client