### PR TITLE
Retry and fail fast on RPC-backed pre-state reads

### DIFF
--- a/crates/core/generate-pie/src/cached_state.rs
+++ b/crates/core/generate-pie/src/cached_state.rs
@@ -1,8 +1,8 @@
 use futures::stream::{self, StreamExt};
 use log::info;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use starknet::core::types::BlockId;
-use starknet::providers::Provider;
+use starknet::core::types::{BlockId, StarknetError};
+use starknet::providers::ProviderError;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::state::StorageKey;
 use starknet_os::io::os_input::CachedStateInput;
@@ -11,11 +11,16 @@ use std::collections::{HashMap, HashSet};
 
 use crate::constants::{MAX_CONCURRENT_GET_CLASS_REQUESTS, MAX_CONCURRENT_GET_STORAGE_AT_REQUESTS};
 use rpc_client::state_reader::{compute_compiled_class_hash, compute_compiled_class_hash_v2};
+use rpc_client::utils::execute_with_retry;
 use rpc_client::RpcClient;
 
 // Constants for special contract addresses
 const BLOCK_HASH_CONTRACT_ADDRESS: Felt = Felt::ONE;
 const ALIAS_CONTRACT_ADDRESS: Felt = Felt::TWO;
+
+fn is_expected_missing_state_error(error: &ProviderError) -> bool {
+    matches!(error, ProviderError::StarknetError(StarknetError::ContractNotFound | StarknetError::ClassHashNotFound))
+}
 
 /// Creates an empty cached state for block 0 (genesis block).
 ///
@@ -83,22 +88,35 @@ pub async fn generate_cached_state_input(
     );
 
     // Fetch all storage values concurrently
-    let storage_results: Vec<(ContractAddress, StorageKey, Felt)> = stream::iter(storage_requests)
-        .map(|(contract_address, storage_key)| async move {
-            let storage_value = rpc_client
-                .starknet_rpc()
-                .get_storage_at(*contract_address.key(), *storage_key.0.key(), block_id)
+    let storage_results: Vec<Result<(ContractAddress, StorageKey, Felt), ProviderError>> =
+        stream::iter(storage_requests)
+            .map(|(contract_address, storage_key)| async move {
+                let operation_name = format!(
+                    "get_storage_at(contract_address: {:#x}, storage_key: {:#x}, block_id: {:?})",
+                    contract_address.key(),
+                    storage_key.0.key(),
+                    block_id
+                );
+                let storage_value = match execute_with_retry(&operation_name, || {
+                    rpc_client.starknet_rpc().get_storage_at(*contract_address.key(), *storage_key.0.key(), block_id)
+                })
                 .await
-                .unwrap_or(Felt::ZERO); // Default to zero if not found
+                {
+                    Ok(storage_value) => Ok(storage_value),
+                    Err(err) if is_expected_missing_state_error(&err) => Ok(Felt::ZERO),
+                    Err(err) => Err(err),
+                }?;
 
-            (contract_address, storage_key, storage_value)
-        })
-        .buffer_unordered(MAX_CONCURRENT_GET_STORAGE_AT_REQUESTS)
-        .collect()
-        .await;
+                Ok((contract_address, storage_key, storage_value))
+            })
+            .buffer_unordered(MAX_CONCURRENT_GET_STORAGE_AT_REQUESTS)
+            .collect()
+            .await;
 
     // Reconstruct the nested HashMap structure from results
-    for (contract_address, storage_key, storage_value) in storage_results {
+    for result in storage_results {
+        let (contract_address, storage_key, storage_value) =
+            result.map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
         storage.entry(contract_address).or_insert_with(HashMap::new).insert(storage_key, storage_value);
     }
 
@@ -106,7 +124,18 @@ pub async fn generate_cached_state_input(
 
     // 2. Get nonces for all addresses
     for contract_address in &all_addresses {
-        let nonce = rpc_client.starknet_rpc().get_nonce(block_id, *contract_address.key()).await.unwrap_or(Felt::ZERO); // Default to zero if not found
+        let operation_name =
+            format!("get_nonce(contract_address: {:#x}, block_id: {:?})", contract_address.key(), block_id);
+        let nonce = match execute_with_retry(&operation_name, || {
+            rpc_client.starknet_rpc().get_nonce(block_id, *contract_address.key())
+        })
+        .await
+        {
+            Ok(nonce) => Ok(nonce),
+            Err(err) if is_expected_missing_state_error(&err) => Ok(Felt::ZERO),
+            Err(err) => Err(err),
+        }
+        .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
 
         address_to_nonce.insert(*contract_address, Nonce(nonce));
     }
@@ -123,11 +152,18 @@ pub async fn generate_cached_state_input(
             // Special case for system contracts (block hash and alias contract)
             ClassHash(Felt::ZERO)
         } else {
-            let class_hash_felt = rpc_client
-                .starknet_rpc()
-                .get_class_hash_at(block_id, *contract_address.key())
-                .await
-                .unwrap_or(Felt::ZERO); // Default to zero if not found
+            let operation_name =
+                format!("get_class_hash_at(contract_address: {:#x}, block_id: {:?})", contract_address.key(), block_id);
+            let class_hash_felt = match execute_with_retry(&operation_name, || {
+                rpc_client.starknet_rpc().get_class_hash_at(block_id, *contract_address.key())
+            })
+            .await
+            {
+                Ok(class_hash_felt) => Ok(class_hash_felt),
+                Err(err) if is_expected_missing_state_error(&err) => Ok(Felt::ZERO),
+                Err(err) => Err(err),
+            }
+            .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
             ClassHash(class_hash_felt)
         };
 
@@ -149,25 +185,34 @@ pub async fn generate_cached_state_input(
     );
 
     // Phase 1: Fetch all contract classes concurrently (network I/O parallelization)
-    let class_fetch_results: Vec<(ClassHash, Option<starknet::core::types::ContractClass>)> =
+    let class_fetch_results: Vec<(ClassHash, Result<starknet::core::types::ContractClass, ProviderError>)> =
         stream::iter(non_zero_class_hashes.clone())
             .map(|class_hash| async move {
-                let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash.0).await.ok();
+                let operation_name = format!("get_class(class_hash: {:#x}, block_id: {:?})", class_hash.0, block_id);
+                let contract_class =
+                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(block_id, class_hash.0))
+                        .await;
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
             .collect()
             .await;
 
-    info!("Fetched {} contract classes, now computing hashes in parallel...", class_fetch_results.len());
+    let mut successful_class_fetches = Vec::with_capacity(class_fetch_results.len());
+    for (class_hash, contract_class_result) in class_fetch_results {
+        match contract_class_result {
+            Ok(contract_class) => successful_class_fetches.push((class_hash, contract_class)),
+            Err(ProviderError::StarknetError(StarknetError::ClassHashNotFound)) => {}
+            Err(err) => return Err(Box::new(err)),
+        }
+    }
 
     // Phase 2: Process contract classes in parallel using rayon (CPU parallelization)
     // For migrated classes, use v1 (Poseidon) hash since cached state represents previous block
     // For other classes, use v2 (BLAKE) hash
-    let compiled_class_hash_results: Vec<(ClassHash, CompiledClassHash)> = class_fetch_results
+    let compiled_class_hash_results: Vec<(ClassHash, CompiledClassHash)> = successful_class_fetches
         .par_iter()
-        .filter_map(|(class_hash, contract_class_opt)| {
-            let contract_class = contract_class_opt.as_ref()?;
+        .filter_map(|(class_hash, contract_class)| {
             let compiled_hash = if migrated_class_hashes.contains(class_hash) {
                 // Use old Poseidon hash (v1) for migrated classes in cached state
                 compute_compiled_class_hash(contract_class).ok()?

--- a/crates/core/generate-pie/src/conversions.rs
+++ b/crates/core/generate-pie/src/conversions.rs
@@ -37,6 +37,7 @@ use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 use thiserror::Error;
 
 use crate::error::ToBlockifierError;
+use rpc_client::utils::execute_with_retry;
 use rpc_client::RpcClient;
 
 // ================================================================================================
@@ -154,7 +155,11 @@ async fn fetch_class_info(
 ) -> Result<ClassInfo, ConversionError> {
     debug!("Fetching class info for hash: {:?} at block: {}", class_hash, block_number);
 
-    let contract_class = rpc_client.starknet_rpc().get_class(BlockId::Number(block_number), class_hash).await?;
+    let operation_name = format!("get_class(block_number: {block_number}, class_hash: {class_hash:#x})");
+    let contract_class = execute_with_retry(&operation_name, || {
+        rpc_client.starknet_rpc().get_class(BlockId::Number(block_number), class_hash)
+    })
+    .await?;
 
     let (blockifier_contract_class, program_length, abi_length, version) = match contract_class {
         starknet::core::types::ContractClass::Sierra(sierra) => {

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -13,12 +13,12 @@ use cairo_vm::Felt252;
 use futures::stream::{self, StreamExt};
 use log::{debug, info, warn};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rpc_client::utils::execute_with_retry;
 use rpc_client::RpcClient;
 use starknet::core::types::{
     BlockId, ExecuteInvocation, FunctionInvocation, MaybePreConfirmedStateUpdate, StarknetError, StateDiff,
     TransactionTrace, TransactionTraceWithHash,
 };
-use starknet::providers::Provider;
 use starknet::providers::ProviderError;
 use starknet_os_types::casm_contract_class::GenericCasmContractClass;
 use starknet_os_types::class_hash_utils::ContractClassComponentHashes;
@@ -317,8 +317,11 @@ async fn fetch_state_update(
 ) -> Result<starknet::core::types::StateUpdate, StateUpdateError> {
     debug!("Fetching state update for block {:?}", block_id);
 
-    let state_update =
-        rpc_client.starknet_rpc().get_state_update(block_id).await.map_err(StateUpdateError::RpcError)?;
+    let state_update = execute_with_retry(&format!("get_state_update(block_id: {block_id:?})"), || {
+        rpc_client.starknet_rpc().get_state_update(block_id)
+    })
+    .await
+    .map_err(StateUpdateError::RpcError)?;
 
     match state_update {
         MaybePreConfirmedStateUpdate::Update(update) => {
@@ -424,7 +427,10 @@ async fn process_accessed_addresses(
     let class_hash_results: Vec<(Felt252, BlockId, bool, Result<Felt, ProviderError>)> =
         stream::iter(address_block_pairs)
             .map(|(address, bid, is_prev)| async move {
-                let class_hash = rpc_client.starknet_rpc().get_class_hash_at(bid, address).await;
+                let operation_name = format!("get_class_hash_at(block_id: {bid:?}, contract_address: {address:#x})");
+                let class_hash =
+                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class_hash_at(bid, address))
+                        .await;
                 (address, bid, is_prev, class_hash)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
@@ -450,7 +456,9 @@ async fn process_accessed_addresses(
     let class_results: Vec<(Felt, Result<starknet::core::types::ContractClass, ProviderError>)> =
         stream::iter(class_fetch_pairs)
             .map(|(_, bid, _, class_hash)| async move {
-                let contract_class = rpc_client.starknet_rpc().get_class(bid, class_hash).await;
+                let operation_name = format!("get_class(block_id: {bid:?}, class_hash: {class_hash:#x})");
+                let contract_class =
+                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(bid, class_hash)).await;
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
@@ -460,13 +468,15 @@ async fn process_accessed_addresses(
     info!("Fetched {} contract classes, now compiling in parallel...", class_results.len());
 
     // Phase 3: Compile classes in parallel using rayon (CPU parallelization)
-    let compilation_results: Vec<(Felt, Result<GenericCompiledClass, StateUpdateError>)> = class_results
+    let mut successful_class_results = Vec::with_capacity(class_results.len());
+    for (class_hash, contract_class_result) in class_results {
+        let contract_class = contract_class_result.map_err(StateUpdateError::RpcError)?;
+        successful_class_results.push((class_hash, contract_class));
+    }
+
+    let compilation_results: Vec<(Felt, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_results
         .into_par_iter()
-        .filter_map(|(class_hash, contract_class_result)| {
-            let contract_class = contract_class_result.ok()?;
-            let compiled_result = compile_contract_class(contract_class);
-            Some((class_hash, compiled_result))
-        })
+        .map(|(class_hash, contract_class)| (class_hash, compile_contract_class(contract_class)))
         .collect();
 
     // Add compiled classes to result
@@ -502,11 +512,14 @@ async fn process_accessed_classes(
 
     // Phase 1: Fetch all contract classes concurrently (network I/O parallelization)
     let class_hashes: Vec<Felt252> = accessed_classes.iter().copied().collect();
-    let class_fetch_results: Vec<(Felt252, Option<starknet::core::types::ContractClass>)> =
+    let class_fetch_results: Vec<(Felt252, Result<starknet::core::types::ContractClass, ProviderError>)> =
         stream::iter(class_hashes.clone())
             .map(|class_hash| async move {
                 debug!("Fetching class hash: {:?}", class_hash);
-                let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash).await.ok();
+                let operation_name = format!("get_class(block_id: {block_id:?}, class_hash: {class_hash:#x})");
+                let contract_class =
+                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(block_id, class_hash))
+                        .await;
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
@@ -516,13 +529,15 @@ async fn process_accessed_classes(
     info!("Fetched {} contract classes, now compiling in parallel...", class_fetch_results.len());
 
     // Phase 2: Compile classes in parallel using rayon (CPU parallelization)
-    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = class_fetch_results
+    let mut successful_class_fetches = Vec::with_capacity(class_fetch_results.len());
+    for (class_hash, contract_class_result) in class_fetch_results {
+        let contract_class = contract_class_result.map_err(StateUpdateError::RpcError)?;
+        successful_class_fetches.push((class_hash, contract_class));
+    }
+
+    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_fetches
         .into_par_iter()
-        .filter_map(|(class_hash, contract_class_opt)| {
-            let contract_class = contract_class_opt?;
-            let compiled_result = compile_contract_class(contract_class);
-            Some((class_hash, compiled_result))
-        })
+        .map(|(class_hash, contract_class)| (class_hash, compile_contract_class(contract_class)))
         .collect();
 
     // Add compiled classes to result
@@ -561,7 +576,10 @@ async fn process_declared_classes(
         stream::iter(class_hashes)
             .map(|class_hash| async move {
                 debug!("Fetching declared class: {:?}", class_hash);
-                let contract_class = rpc_client.starknet_rpc().get_class(block_id, class_hash).await;
+                let operation_name = format!("get_class(block_id: {block_id:?}, class_hash: {class_hash:#x})");
+                let contract_class =
+                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(block_id, class_hash))
+                        .await;
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)

--- a/crates/core/generate-pie/src/types/block.rs
+++ b/crates/core/generate-pie/src/types/block.rs
@@ -13,6 +13,7 @@ use blockifier::state::cached_state::CachedState;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use log::{debug, info, warn};
 use rpc_client::state_reader::AsyncRpcStateReader;
+use rpc_client::utils::execute_with_retry;
 use rpc_client::RpcClient;
 use shared_execution_objects::central_objects::CentralTransactionExecutionInfo;
 use starknet::core::types::{
@@ -65,17 +66,18 @@ impl BlockData {
         let previous_block_id = if block_number == 0 { None } else { Some(BlockId::Number(block_number - 1)) };
 
         // Fetch chain ID from RPC
-        let chain_id_result =
-            rpc_client.starknet_rpc().chain_id().await.map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?;
+        let chain_id_result = execute_with_retry("chain_id", || rpc_client.starknet_rpc().chain_id())
+            .await
+            .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?;
         let chain_id = chain_id_from_felt(chain_id_result);
         info!("Provider's chain_id: {}", chain_id);
 
         // Fetch the current block with transactions
-        let current_block = match rpc_client
-            .starknet_rpc()
-            .get_block_with_txs(block_id)
-            .await
-            .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?
+        let current_block = match execute_with_retry("get_block_with_txs(current_block)", || {
+            rpc_client.starknet_rpc().get_block_with_txs(block_id)
+        })
+        .await
+        .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?
         {
             MaybePreConfirmedBlockWithTxs::Block(block_with_txs) => block_with_txs,
             MaybePreConfirmedBlockWithTxs::PreConfirmedBlock(_) => {
@@ -91,11 +93,11 @@ impl BlockData {
 
         // Fetch the previous block if it exists
         let previous_block = match previous_block_id {
-            Some(previous_block_id) => match rpc_client
-                .starknet_rpc()
-                .get_block_with_tx_hashes(previous_block_id)
-                .await
-                .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?
+            Some(previous_block_id) => match execute_with_retry("get_block_with_tx_hashes(previous_block)", || {
+                rpc_client.starknet_rpc().get_block_with_tx_hashes(previous_block_id)
+            })
+            .await
+            .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?
             {
                 MaybePreConfirmedBlockWithTxHashes::Block(block_with_txs) => Some(block_with_txs),
                 MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_) => {
@@ -107,11 +109,11 @@ impl BlockData {
 
         // Fetch older block for hash buffer
         let old_block_number_u64 = block_number.saturating_sub(STORED_BLOCK_HASH_BUFFER);
-        let old_block = match rpc_client
-            .starknet_rpc()
-            .get_block_with_tx_hashes(BlockId::Number(old_block_number_u64))
-            .await
-            .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?
+        let old_block = match execute_with_retry("get_block_with_tx_hashes(old_block)", || {
+            rpc_client.starknet_rpc().get_block_with_tx_hashes(BlockId::Number(old_block_number_u64))
+        })
+        .await
+        .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?
         {
             MaybePreConfirmedBlockWithTxHashes::Block(block_with_txs_hashes) => block_with_txs_hashes,
             MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_) => {
@@ -156,9 +158,10 @@ impl BlockData {
             self.previous_block.as_ref().map(|previous_block| BlockId::Number(previous_block.block_number));
 
         // Fetch transaction traces
-        let transaction_traces = rpc_client
-            .starknet_rpc()
-            .trace_block_transactions(confirmed_block_id)
+        let transaction_traces =
+            execute_with_retry(&format!("trace_block_transactions(block_id: {confirmed_block_id:?})"), || {
+                rpc_client.starknet_rpc().trace_block_transactions(confirmed_block_id)
+            })
             .await
             .map_err(|e| BlockProcessingError::RpcClient(Box::new(e)))?;
         info!("Successfully fetched {} transaction traces for block {}", transaction_traces.len(), block_number);

--- a/crates/core/generate-pie/src/utils/rpc.rs
+++ b/crates/core/generate-pie/src/utils/rpc.rs
@@ -2,9 +2,9 @@ use blockifier::execution::call_info::CallInfo;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
 use log::info;
-use rpc_client::client::ProofClient;
 use rpc_client::error::ClientError;
 use rpc_client::types::{ClassProof, ContractData, ContractProof};
+use rpc_client::utils::execute_with_retry;
 use rpc_client::RpcClient;
 use starknet_api::contract_address;
 use starknet_api::core::ContractAddress;
@@ -131,11 +131,16 @@ pub(crate) async fn get_class_proofs(
     info!("Fetching class proofs for {} classes", class_hashes.len());
 
     for class_hash in class_hashes {
-        let proof = rpc_client
-            .starknet_rpc()
-            .get_class_proof(block_number, class_hash)
-            .await
-            .map_err(|e| ClientError::CustomError(format!("{}", e)))?;
+        let operation_name = format!("get_class_proof(block_number: {block_number}, class_hash: {class_hash:#x})");
+        let proof =
+            execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class_proof(block_number, class_hash))
+                .await
+                .map_err(|e| {
+                    ClientError::CustomError(format!(
+                        "class proof request failed for block {} class_hash {:#x}: {}",
+                        block_number, class_hash, e
+                    ))
+                })?;
         // TODO: need to combine these, similar to merge_chunked_storage_proofs above?
         proofs.insert(**class_hash, proof);
     }
@@ -186,8 +191,6 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
         vec![]
     };
 
-    info!("Got {} additional keys for contract {}", additional_keys.len(), contract_address);
-
     // Fetch additional proofs required to fill gaps in the storage trie that could make
     // the OS crash otherwise.
     if !additional_keys.is_empty() {
@@ -197,7 +200,11 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
         // Combine all storage proofs into a single vector
         match &additional_proof.contract_data {
             None => {
-                panic!("Failed to fetch additional proof for contract {}", contract_address)
+                let message = format!(
+                    "Additional storage proof for contract {} at block {} returned no contract_data",
+                    contract_address, block_number
+                );
+                return Err(ClientError::CustomError(message));
             }
             Some(contract_data) => {
                 additional_proof.contract_data = Some(ContractData {
@@ -224,11 +231,22 @@ async fn fetch_storage_proof_for_contract(
 ) -> Result<ContractProof, ClientError> {
     info!("Fetching storage proof for contract {} with {} keys", contract_address, keys.len());
 
-    rpc_client
-        .starknet_rpc()
-        .get_proof(block_number, contract_address, keys)
+    let operation_name = format!(
+        "get_proof(block_number: {block_number}, contract_address: {contract_address:#x}, keys: {})",
+        keys.len()
+    );
+
+    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_proof(block_number, contract_address, keys))
         .await
-        .map_err(|e| ClientError::CustomError(format!("{}", e)))
+        .map_err(|e| {
+            ClientError::CustomError(format!(
+                "storage proof request failed for block {} contract {:#x} keys={}: {}",
+                block_number,
+                contract_address,
+                keys.len(),
+                e
+            ))
+        })
 }
 
 /// Merges the storage proofs of the SAME contract.

--- a/crates/rpc-client/src/state_reader/mod.rs
+++ b/crates/rpc-client/src/state_reader/mod.rs
@@ -12,12 +12,9 @@ use starknet_api::state::StorageKey;
 use starknet_os_types::deprecated_compiled_class::GenericDeprecatedCompiledClass;
 use starknet_os_types::sierra_contract_class::GenericSierraContractClass;
 use starknet_os_types::starknet_core_addons::decompress_starknet_legacy_contract_class;
-use std::future::Future;
-use std::time::Duration;
-use tokio::time::sleep;
 
 use crate::client::RpcClient;
-use crate::utils::execute_coroutine;
+use crate::utils::{execute_coroutine, execute_with_retry};
 
 #[cfg(test)]
 pub mod tests;
@@ -41,15 +38,6 @@ impl CompiledClassHashVersion {
     }
 }
 
-/// Maximum number of retry attempts for RPC calls
-const MAX_RETRY_ATTEMPTS: u32 = 3;
-
-/// Initial delay for exponential backoff (in milliseconds)
-const INITIAL_BACKOFF_MS: u64 = 100;
-
-/// Maximum delay for exponential backoff (in milliseconds)
-const MAX_BACKOFF_MS: u64 = 5000;
-
 #[derive(Clone)]
 pub struct AsyncRpcStateReader {
     rpc_client: RpcClient,
@@ -59,64 +47,6 @@ pub struct AsyncRpcStateReader {
 impl AsyncRpcStateReader {
     pub fn new(rpc_client: RpcClient, block_id: Option<BlockId>) -> Self {
         Self { rpc_client, block_id }
-    }
-
-    /// Execute an RPC call with exponential backoff retry logic
-    ///
-    /// # Arguments
-    /// * `operation_name` - Name of the operation for logging purposes
-    /// * `f` - The async function to execute with retry logic
-    ///
-    /// # Returns
-    /// The result of the RPC call or an error after all retries are exhausted
-    async fn execute_with_retry<T, F, Fut>(&self, operation_name: &str, f: F) -> Result<T, ProviderError>
-    where
-        F: Fn() -> Fut,
-        Fut: Future<Output = Result<T, ProviderError>>,
-    {
-        let mut attempts = 0;
-        let mut backoff_ms = INITIAL_BACKOFF_MS;
-
-        loop {
-            attempts += 1;
-
-            match f().await {
-                Ok(result) => {
-                    if attempts > 1 {
-                        debug!("{}: succeeded after {} attempts", operation_name, attempts);
-                    }
-                    return Ok(result);
-                }
-                Err(e) => {
-                    // Check if the error is retryable
-                    let is_retryable = match &e {
-                        // Don't retry on semantic errors (contract not found, class not found, etc.)
-                        ProviderError::StarknetError(StarknetError::ContractNotFound)
-                        | ProviderError::StarknetError(StarknetError::ClassHashNotFound) => false,
-                        // Retry on network/transport errors
-                        _ => true,
-                    };
-
-                    if !is_retryable || attempts >= MAX_RETRY_ATTEMPTS {
-                        if attempts > 1 {
-                            warn!("{}: failed after {} attempts with error: {:?}", operation_name, attempts, e);
-                        }
-                        return Err(e);
-                    }
-
-                    warn!(
-                        "{}: attempt {} failed with error: {:?}, retrying in {}ms...",
-                        operation_name, attempts, e, backoff_ms
-                    );
-
-                    // Wait with exponential backoff
-                    sleep(Duration::from_millis(backoff_ms)).await;
-
-                    // Increase backoff for next attempt (exponential backoff with cap)
-                    backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
-                }
-            }
-        }
     }
 }
 
@@ -144,11 +74,10 @@ impl AsyncRpcStateReader {
         let block_id = self.block_id.unwrap();
         let operation_name = format!("get_storage_at(contract: {:?}, key: {:?})", contract_address, key);
 
-        let storage_value = match self
-            .execute_with_retry(&operation_name, || {
-                self.rpc_client.starknet_rpc().get_storage_at(*contract_address.key(), *key.0.key(), block_id)
-            })
-            .await
+        let storage_value = match execute_with_retry(&operation_name, || {
+            self.rpc_client.starknet_rpc().get_storage_at(*contract_address.key(), *key.0.key(), block_id)
+        })
+        .await
         {
             Ok(value) => Ok(value),
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
@@ -168,11 +97,10 @@ impl AsyncRpcStateReader {
         debug!("got a request of get_nonce_at with parameters the contract address: {:?}", contract_address);
         let operation_name = format!("get_nonce_at(contract: {:?})", contract_address);
 
-        let nonce = match self
-            .execute_with_retry(&operation_name, || {
-                self.rpc_client.starknet_rpc().get_nonce(block_id, *contract_address.key())
-            })
-            .await
+        let nonce = match execute_with_retry(&operation_name, || {
+            self.rpc_client.starknet_rpc().get_nonce(block_id, *contract_address.key())
+        })
+        .await
         {
             Ok(value) => Ok(value),
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
@@ -191,11 +119,10 @@ impl AsyncRpcStateReader {
         debug!("got a request of get_class_hash_at with parameters the contract address: {:?}", contract_address);
         let operation_name = format!("get_class_hash_at(contract: {:?})", contract_address);
 
-        let class_hash = match self
-            .execute_with_retry(&operation_name, || {
-                self.rpc_client.starknet_rpc().get_class_hash_at(block_id, *contract_address.key())
-            })
-            .await
+        let class_hash = match execute_with_retry(&operation_name, || {
+            self.rpc_client.starknet_rpc().get_class_hash_at(block_id, *contract_address.key())
+        })
+        .await
         {
             Ok(class_hash) => Ok(class_hash),
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(ClassHash::default().0),
@@ -215,9 +142,10 @@ impl AsyncRpcStateReader {
         debug!("got a request of get_compiled_class with parameters the class hash: {:?}", class_hash);
         let operation_name = format!("get_compiled_class(class_hash: {:?})", class_hash);
 
-        let contract_class = match self
-            .execute_with_retry(&operation_name, || self.rpc_client.starknet_rpc().get_class(block_id, class_hash.0))
-            .await
+        let contract_class = match execute_with_retry(&operation_name, || {
+            self.rpc_client.starknet_rpc().get_class(block_id, class_hash.0)
+        })
+        .await
         {
             Ok(contract_class) => Ok(contract_class),
             // If the ContractClass is declared in the current block,
@@ -284,10 +212,10 @@ impl AsyncRpcStateReader {
         debug!("get_compiled_class_hash_{} for class_hash: {:?}", version.as_str(), class_hash);
         let operation_name = format!("get_compiled_class_hash_{}(class_hash: {:?})", version.as_str(), class_hash);
 
-        let contract_class = self
-            .execute_with_retry(&operation_name, || self.rpc_client.starknet_rpc().get_class(block_id, class_hash.0))
-            .await
-            .map_err(provider_error_to_state_error)?;
+        let contract_class =
+            execute_with_retry(&operation_name, || self.rpc_client.starknet_rpc().get_class(block_id, class_hash.0))
+                .await
+                .map_err(provider_error_to_state_error)?;
 
         compute_compiled_class_hash_internal(&contract_class, version)
     }

--- a/crates/rpc-client/src/utils.rs
+++ b/crates/rpc-client/src/utils.rs
@@ -1,10 +1,25 @@
 //! Utility functions for async operations and coroutine execution.
 
+use log::{debug, warn};
+use starknet::core::types::StarknetError;
+use starknet::providers::ProviderError;
+use std::future::Future;
 use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::time::sleep;
 
 /// Global Tokio runtime for executing async operations in non-async contexts.
 /// This is used when there's no current runtime available (e.g., in worker threads).
 static GLOBAL_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Maximum number of retry attempts for RPC calls.
+const MAX_RETRY_ATTEMPTS: u32 = 5;
+
+/// Initial delay for exponential backoff (in milliseconds).
+const INITIAL_BACKOFF_MS: u64 = 100;
+
+/// Maximum delay for exponential backoff (in milliseconds).
+const MAX_BACKOFF_MS: u64 = 5000;
 
 /// Gets or creates the global Tokio runtime.
 fn get_global_runtime() -> &'static tokio::runtime::Runtime {
@@ -50,6 +65,47 @@ where
             // No current runtime (e.g., called from a worker thread), use global runtime
             let runtime = get_global_runtime();
             runtime.block_on(coroutine)
+        }
+    }
+}
+
+/// Executes an RPC call with exponential backoff retry logic.
+pub async fn execute_with_retry<T, F, Fut>(operation_name: &str, f: F) -> Result<T, ProviderError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, ProviderError>>,
+{
+    let mut attempts = 0;
+    let mut backoff_ms = INITIAL_BACKOFF_MS;
+
+    loop {
+        attempts += 1;
+
+        match f().await {
+            Ok(result) => {
+                if attempts > 1 {
+                    debug!("{operation_name}: succeeded after {attempts} attempts");
+                }
+                return Ok(result);
+            }
+            Err(e) => {
+                let is_retryable = !matches!(
+                    &e,
+                    ProviderError::StarknetError(StarknetError::ContractNotFound)
+                        | ProviderError::StarknetError(StarknetError::ClassHashNotFound)
+                );
+
+                if !is_retryable || attempts >= MAX_RETRY_ATTEMPTS {
+                    if attempts > 1 {
+                        warn!("{operation_name}: failed after {attempts} attempts with error: {e:?}");
+                    }
+                    return Err(e);
+                }
+
+                warn!("{operation_name}: attempt {attempts} failed with error: {e:?}, retrying in {backoff_ms}ms...");
+                sleep(Duration::from_millis(backoff_ms)).await;
+                backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a shared RPC retry helper for SNOS Starknet RPC call sites
- stop cached-state construction from converting transport/request failures into zero values
- apply retries to remaining raw block/class/state/proof fetch paths and fail cleanly when retries are exhausted
- stop silently dropping class fetch failures during state update processing and replace the additional-proof panic with a typed error

## Why
Recent SNOS failures showed that transient Pathfinder/RPC failures could be turned into zero-valued pre-state reads on the 0.14.1 branch, which later surfaced as Patricia mismatches. This change makes those failures retryable and then explicit instead of silently corrupting the witness.

## Validation
- cargo fmt --all
- cargo check -p rpc-client