### PR TITLE
Relax accessed-class fetch failures in state update processing

### DIFF
--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -491,14 +491,15 @@ async fn process_accessed_classes(
 
     // Phase 1: Fetch all contract classes concurrently (network I/O parallelization)
     let class_hashes: Vec<Felt252> = accessed_classes.iter().copied().collect();
-    let class_fetch_results: Vec<(Felt252, Result<starknet::core::types::ContractClass, ProviderError>)> =
+    let class_fetch_results: Vec<(Felt252, Option<starknet::core::types::ContractClass>)> =
         stream::iter(class_hashes.clone())
             .map(|class_hash| async move {
                 debug!("Fetching class hash: {:?}", class_hash);
                 let operation_name = format!("get_class(block_id: {block_id:?}, class_hash: {class_hash:?})");
                 let contract_class =
                     execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(block_id, class_hash))
-                        .await;
+                        .await
+                        .ok();
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
@@ -508,16 +509,13 @@ async fn process_accessed_classes(
     info!("Fetched {} contract classes, now compiling in parallel...", class_fetch_results.len());
 
     // Phase 2: Compile classes in parallel using rayon (CPU parallelization)
-    let successful_class_fetches: Vec<_> = class_fetch_results
-        .into_iter()
-        .map(|(class_hash, contract_class_result)| {
-            contract_class_result.map_err(StateUpdateError::RpcError).map(|contract_class| (class_hash, contract_class))
-        })
-        .collect::<Result<_, _>>()?;
-
-    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = successful_class_fetches
+    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = class_fetch_results
         .into_par_iter()
-        .map(|(class_hash, contract_class)| (class_hash, compile_contract_class(contract_class)))
+        .filter_map(|(class_hash, contract_class_opt)| {
+            let contract_class = contract_class_opt?;
+            let compiled_result = compile_contract_class(contract_class);
+            Some((class_hash, compiled_result))
+        })
         .collect();
 
     // Add compiled classes to result


### PR DESCRIPTION
## Summary
- revert only the `process_accessed_classes` path in `state_update.rs` back to best-effort class fetch behavior
- keep the rest of PR #514 intact, including proof retrying, improved proof error messages, and the panic-to-error cleanup

## Why
`ClassHashNotFound` from the source RPC can currently fail the whole block during accessed-class processing.
This change narrows the rollback to the one accessed-class fetch path that previously tolerated missing class fetches, while preserving the rest of the hardening from #514.

## Validation
- `cargo fmt --all`
- `cargo check -p generate-pie` *(blocked locally: missing `cairo-compile` / sequencer venv required by `apollo_starknet_os_program` build script)*
