### PR TITLE
feat(snos): support 0.14.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -125,10 +125,9 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "apollo_compilation_utils"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
- "apollo_infra_utils",
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
@@ -143,12 +142,11 @@ dependencies = [
 
 [[package]]
 name = "apollo_compile_to_native"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
- "apollo_infra_utils",
  "cairo-lang-starknet-classes",
  "cairo-native",
  "tempfile",
@@ -156,8 +154,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_compile_to_native_types"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_config",
  "serde",
@@ -166,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_config"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -184,8 +182,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_infra_utils"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -198,6 +196,7 @@ dependencies = [
  "strum",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -206,11 +205,11 @@ dependencies = [
 
 [[package]]
 name = "apollo_metrics"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_time",
- "indexmap 2.13.0",
+ "const_format",
  "metrics 0.24.3",
  "num-traits",
  "paste",
@@ -220,8 +219,17 @@ dependencies = [
 
 [[package]]
 name = "apollo_proc_macros"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+dependencies = [
+ "apollo_proc_macros_lib",
+ "metrics 0.24.3",
+]
+
+[[package]]
+name = "apollo_proc_macros_lib"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -231,8 +239,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_sizeof"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core",
@@ -240,8 +248,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_sizeof_macros"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -250,8 +258,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_starknet_os_program"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_infra_utils",
  "cairo-vm",
@@ -265,8 +273,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_time"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "chrono",
 ]
@@ -329,7 +337,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "arrayvec",
- "digest",
+ "digest 0.10.7",
  "educe 0.6.0",
  "itertools 0.13.0",
  "num-bigint",
@@ -407,7 +415,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std",
  "arrayvec",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -636,7 +644,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -729,7 +737,7 @@ dependencies = [
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -763,7 +771,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -1010,18 +1018,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -1047,7 +1055,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1060,9 +1068,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array 0.4.10",
+]
+
+[[package]]
 name = "blockifier"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -1085,9 +1102,10 @@ dependencies = [
  "cairo-vm",
  "dashmap",
  "derive_more",
+ "expect-test",
  "indexmap 2.13.0",
  "itertools 0.12.1",
- "keccak",
+ "keccak 0.1.5",
  "log",
  "mockall",
  "num-bigint",
@@ -1102,7 +1120,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "starknet-types-core",
  "starknet_api",
  "strum",
@@ -1112,14 +1130,15 @@ dependencies = [
 
 [[package]]
 name = "blockifier_test_utils"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
- "digest",
+ "digest 0.10.7",
+ "expect-test",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "starknet-types-core",
  "starknet_api",
  "strum",
@@ -1274,9 +1293,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ba7355bf81c515c65e2359593deef373678e719f4847e2a7de82e5cde7a042"
+checksum = "ca8ba4a3d44e9911b757ab231d09c370753ba717fe8b335dffbb6f7b137296fe"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -1288,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182d276f24abb11a44f5cec4901bac2199b140cfae71b93d85a07cd0c10f537c"
+checksum = "b3503898c518d6e8ed5e958d30aa2745bf099c1600b5fde486210719b98a2d10"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -1315,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaa4c21675465a5bec4ac520e0f1e13e5ff182825037943094c070745586fe9"
+checksum = "ed1a9a5aac7b9220d811d8a745fe5e35a7043f741e267a8b00a4c5763b48b1d7"
 dependencies = [
  "cairo-lang-utils",
  "id-arena",
@@ -1326,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231520c12962c5941763a0606b47630e1836d5bd5fcaf1798b10e2cbdd86432c"
+checksum = "d804565b31e141d7909e26a43fb251cf6ec68d36d9918f2e4a970d4326c70bd3"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -1347,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968661e3604c14410da8025ac8e7f3e2c74d3e9bba74e860ccb8651bb13d943e"
+checksum = "d4555f8c2563fa070c2c492bb4a20ee8d9e87ec67239593dab7545a17f8a7d7b"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1361,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3898ff7b4c1cdb0bb1b126985e900421cbdb829b4a0282e3cf5980a3925c186"
+checksum = "bfd052b0c34bac485aefb13f2ba38e5159913f05f6001915db473b6a0ebcd2b9"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -1371,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d83c3699ff1b638fd6570473597df6a2a7d0281cb3ae2773a8077f099e314dc"
+checksum = "9d897c5268fff99a2f093a7d9fd23480ef0a46f7130d6640934bcb13ecc08f9f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-proc-macros",
@@ -1389,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1303aacadc15a44084b9dd1fba84cdb1ee3ac100266fa00274e656bad71f52e8"
+checksum = "05a5fd77897cc7afe835c3c97720835d01fa203aa968777f8df1ae8e6901e748"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -1409,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3028797a71790b7762199f518c445fd6eb7f1b918f8b2d8a5c97bff462e61624"
+checksum = "5d1d5fc3122388882be9c8774ee836d2c7a4db1333c08ff82f36d8f43e84c57c"
 dependencies = [
  "assert_matches",
  "cairo-lang-debug",
@@ -1439,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310b37965b67bd56007a62d62374d6f7cfd68705df727a4abe3f61b02ca76225"
+checksum = "324f258615e2876db65be5eb439999d35f432976c0cf2717778c183ee0ba4708"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -1459,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e88faa8a6f8a6695ef07f0cb292d021b6253d4d3022bfe32b73b071467af1"
+checksum = "133dc9d41b82e97f348e4589d58116473e63bbe97bf8669260a945b5482faec0"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1483,9 +1502,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6242fb69a4333e69387720f3e1ecc10292c42449ff6ae2587dfb310fd48346"
+checksum = "4b253829795dd9e12560f55654631d1605eea1be4d6790eb02e6719e79bde5be"
 dependencies = [
  "cairo-lang-debug",
  "proc-macro2",
@@ -1496,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60e0855b8f2956d5873d4acca0147882c99ca283ae2b8deed364cd298314e65"
+checksum = "7cde3434b466ab9b03d402dbc79cc57adfb9d25a5e4d614c0060cccd955379d8"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -1509,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ece337212dc333bf6886200447aa8a23d6e3c9dd9e47427cf17fe8f758fd30"
+checksum = "3269a2e149811c7a714cd3a465902b1897a9b372c589188b3f53a746e3691b02"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1526,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4be6e8debecd1db3777ea781938da250f7a148ffba60400a35cee3e711d5ec"
+checksum = "0603bfe3285f0b1978aa98741a8fcd757239082a22ca21f3db281a914145d7a1"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -1544,23 +1563,23 @@ dependencies = [
  "cairo-vm",
  "clap",
  "itertools 0.14.0",
- "keccak",
+ "keccak 0.2.0",
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.10.1",
  "salsa",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "starknet-types-core",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db81fec05c8ad0565f7392826491ebbec3b133c7b8395af0aa717eb6ac6e238"
+checksum = "0c2be71c26fc76ff91b1c224d54bede226ba6b66ec6892a4e5c98ad53f399021"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1580,7 +1599,7 @@ dependencies = [
  "postcard",
  "salsa",
  "serde",
- "sha3",
+ "sha3 0.11.0",
  "starknet-types-core",
  "toml",
  "tracing",
@@ -1588,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502621e024cee958383911a0f452dd5ca9f28fb38a19af1c5495959e37a3eb61"
+checksum = "24a109344978f9338afbfceb801af131e41f5b5c7951a2c8f584d9092fd565aa"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -1606,7 +1625,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.11.0",
  "smol_str",
  "starknet-types-core",
  "thiserror 2.0.17",
@@ -1614,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c66ee91c74c1904ef34baa459ba15f6a0862a512bbb21bd31d28c74adeded0d"
+checksum = "7a7e5837455553b09f926ef1e9aab6622fb6091f900d932c979ab722f080e837"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1630,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edc5decd268d87cfb6b1216f97a19251f61036766f86e54e60c28875aa1981b"
+checksum = "17f7337921f6fde562433a015a11ac1367b0cb8f52ede2c3af927d96d5aa3442"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1646,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478bb115f2e9163d07b66875afe43eafac48c631f77a242ccddb4fa82f939ef7"
+checksum = "50a144c32b66f0ede481c8b9bd285722373e3848ae3fabead0080511471039cb"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1671,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383614515e62d7b4cbf57ee957c856cb74f41cdca8d39fd91d4b6167fe7d5205"
+checksum = "cac7497b6627e7c4b69edd9c305eb254298d77a0801bd0b6b3122d53c62d7f07"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -1692,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf49a0eea70720f60a3c62b739e102e731898ab6b86b9137128cb6675b2946f"
+checksum = "5e2c6feaf7f1255e43321e34e3744a9ef853fce98960ab138988c048029c57e6"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1702,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ac5834c14d9f63ee47f5a7014f55868a104472b264d50a18c1d3e6087d9b23"
+checksum = "fd34ae52728e9acb14ac15c2529736493a2c02e144f0233bab55d66c3fdbfd57"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1735,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68338c5f1c1b35ff83e813f2e03c76fff3aa225e623a175339b95c8c8d097752"
+checksum = "9b4961af6fc9d7fa615b20f9dd48df9c63bff3cc54113fe33aeade99b4219e1c"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1751,7 +1770,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.11.0",
  "smol_str",
  "starknet-types-core",
  "thiserror 2.0.17",
@@ -1759,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a78fd0ee5fe06c1cefa753013ae4c5131366db03bda0118b771a72f2249ae05"
+checksum = "c81138a4f169c8d19752fc438e7aadc443123454eb5f1f2b219ca0953a952071"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1778,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1156d7e1f15e5ddcc0bdbd1fc30c2fbf9572c53155a8b0c6a42cee6da8751db6"
+checksum = "6380c1fa17b96823eac53d6a57de949402ee55d2b4d14ae722ac9287f0efc3c1"
 dependencies = [
  "genco",
  "xshell",
@@ -1788,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b1327c8628766d28458acaa1ce3b063de15dca16bd985f0fe366c9fc974003"
+checksum = "e93debf5e87605b99bf3fa26f2c1e262d76173d3e5bfb96588cf76e4288dafde"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-proc-macros",
@@ -1802,11 +1821,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.17.0"
+version = "2.19.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7b5af507f42080931a1562560736a09ba934226189cc6d7404a966d0313cfb"
+checksum = "2ac2d569ef99caab85f4b92d668e61d30ec4877dc24353bb1d1b68b5fb09bf9d"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "num-bigint",
@@ -1824,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-native"
-version = "0.9.0-rc.6"
+version = "0.9.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe61376fbdfb4c121e4d5ca997fa6eee18b4891d8fe22226f60fe27983467339"
+checksum = "eaaf48d22c1c9a0bb5aedf0a66f5b1a37f41dc3df5ce18480ce2abbed9a88657"
 dependencies = [
  "aquamarine",
  "ark-ec",
@@ -1846,7 +1865,7 @@ dependencies = [
  "cairo-lang-utils",
  "educe 0.5.11",
  "itertools 0.14.0",
- "keccak",
+ "keccak 0.1.5",
  "lambdaworks-math",
  "lazy_static",
  "libc",
@@ -1860,7 +1879,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "starknet-curve",
  "starknet-types-core",
  "tempfile",
@@ -1879,7 +1898,7 @@ dependencies = [
  "bitvec",
  "generic-array",
  "indoc",
- "keccak",
+ "keccak 0.1.5",
  "lazy_static",
  "nom",
  "num-bigint",
@@ -1890,8 +1909,8 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
- "sha3",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
  "starknet-crypto",
  "starknet-types-core",
  "thiserror 2.0.17",
@@ -1948,6 +1967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,7 +1997,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -2052,7 +2082,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2090,6 +2120,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -2194,6 +2230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,7 +2260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rand 0.9.2",
  "regex",
  "rustversion",
@@ -2315,7 +2360,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
 dependencies = [
- "hybrid-array",
+ "hybrid-array 0.2.3",
  "num-traits",
  "subtle",
  "zeroize",
@@ -2329,6 +2374,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array 0.4.10",
 ]
 
 [[package]]
@@ -2471,7 +2525,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -2568,9 +2622,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2622,7 +2687,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e-tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cairo-vm",
  "env_logger",
@@ -2682,7 +2747,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2810,7 +2875,7 @@ checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
  "aes",
  "ctr",
- "digest",
+ "digest 0.10.7",
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
@@ -2818,8 +2883,8 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
- "sha3",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
  "thiserror 1.0.69",
  "uuid 0.8.2",
 ]
@@ -3092,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "generate-pie"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3154,9 +3219,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -3280,6 +3359,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3381,7 +3466,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3456,6 +3541,15 @@ name = "hybrid-array"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -4036,14 +4130,24 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "lalrpop"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+checksum = "98a80a963123205c7157323c99611bc4abb65dcbd62ef46dc4bac74a3941bc75"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -4054,7 +4158,7 @@ dependencies = [
  "pico-args",
  "regex",
  "regex-syntax",
- "sha3",
+ "sha3 0.10.8",
  "string_cache",
  "term",
  "unicode-xid",
@@ -4063,12 +4167,11 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+checksum = "884f3e747ed2dcee867cda1b0c31a048f9e20de2d916a248949319921a2e666e"
 dependencies = [
  "regex-automata",
- "rustversion",
 ]
 
 [[package]]
@@ -4081,8 +4184,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
- "sha2",
- "sha3",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -4105,6 +4208,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -4258,7 +4367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4475,7 +4584,7 @@ dependencies = [
  "serde_bytes",
  "serde_with",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.6.1",
  "stringprep",
  "strsim 0.11.1",
@@ -4703,13 +4812,13 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "papyrus_common"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.13.0",
@@ -4795,7 +4904,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -4820,7 +4929,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 2.0.17",
  "vergen",
 ]
@@ -4860,7 +4969,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4869,7 +4978,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4880,11 +4989,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
 ]
 
@@ -4895,7 +5005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4904,7 +5014,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -4915,7 +5025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4926,6 +5036,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -5208,6 +5327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5232,6 +5357,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5271,6 +5407,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -5479,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -5506,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-replay"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -5903,7 +6045,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6054,9 +6196,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -6099,8 +6241,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6110,8 +6252,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6120,8 +6273,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -6135,8 +6298,8 @@ dependencies = [
 
 [[package]]
 name = "shared_execution_objects"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "blockifier",
  "serde",
@@ -6164,7 +6327,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6286,7 +6449,7 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
- "sha3",
+ "sha3 0.10.8",
  "starknet-core-derive",
  "starknet-crypto",
  "starknet-types-core",
@@ -6316,7 +6479,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rfc6979 0.4.0",
- "sha2",
+ "sha2 0.10.9",
  "starknet-curve",
  "starknet-types-core",
  "zeroize",
@@ -6333,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-os-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
@@ -6412,7 +6575,7 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
- "sha3",
+ "sha3 0.10.8",
  "starknet-rust-core-derive 0.1.0",
  "starknet-rust-crypto 0.8.1",
  "starknet-types-core",
@@ -6436,7 +6599,7 @@ dependencies = [
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
- "sha3",
+ "sha3 0.10.8",
  "starknet-rust-core-derive 0.19.0-rc.2",
  "starknet-rust-crypto 0.19.0-rc.2",
  "starknet-types-core",
@@ -6472,14 +6635,14 @@ checksum = "9955e2572fc8e24bff60f238af9969c4062c4238680907423636a7d5e9aa736f"
 dependencies = [
  "blake2",
  "crypto-bigint 0.5.5",
- "digest",
+ "digest 0.10.7",
  "hex",
  "hmac",
  "num-bigint",
  "num-integer",
  "num-traits",
  "rfc6979 0.4.0",
- "sha2",
+ "sha2 0.10.9",
  "starknet-rust-curve 0.6.0",
  "starknet-types-core",
  "zeroize",
@@ -6493,14 +6656,14 @@ checksum = "5bf77ef1ab88a77d148667c04fe4861cd781c69d3ce1d46c1feeef9fb9cacba5"
 dependencies = [
  "blake2",
  "crypto-bigint 0.6.1",
- "digest",
+ "digest 0.10.7",
  "hex",
  "hmac",
  "num-bigint",
  "num-integer",
  "num-traits",
  "rfc6979 0.4.0",
- "sha2",
+ "sha2 0.10.9",
  "starknet-rust-curve 0.19.0-rc.2",
  "starknet-types-core",
  "zeroize",
@@ -6581,7 +6744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90d23b1bc014ee4cce40056ab3114bcbcdc2dbc1e845bbfb1f8bd0bab63507d4"
 dependencies = [
  "blake2",
- "digest",
+ "digest 0.10.7",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "lazy_static",
@@ -6595,8 +6758,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",
@@ -6615,13 +6778,14 @@ dependencies = [
  "json-patch",
  "num-bigint",
  "num-traits",
+ "paste",
  "pretty_assertions",
  "primitive-types 0.12.2",
  "rand 0.8.5",
  "semver",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "starknet-core",
  "starknet-crypto",
  "starknet-types-core",
@@ -6633,14 +6797,13 @@ dependencies = [
 
 [[package]]
 name = "starknet_committer"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_config",
  "async-trait",
  "derive_more",
  "ethnum",
- "hex",
  "pretty_assertions",
  "rand 0.8.5",
  "rand_distr",
@@ -6659,8 +6822,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_os"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_starknet_os_program",
  "ark-bls12-381",
@@ -6676,7 +6839,7 @@ dependencies = [
  "cairo-lang-starknet-classes",
  "cairo-vm",
  "derive_more",
- "digest",
+ "digest 0.10.7",
  "expect-test",
  "indexmap 2.13.0",
  "indoc",
@@ -6692,8 +6855,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2",
- "sha3",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
  "shared_execution_objects",
  "starknet-types-core",
  "starknet_api",
@@ -6707,8 +6870,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_patricia"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "async-recursion",
  "derive_more",
@@ -6728,10 +6891,12 @@ dependencies = [
 
 [[package]]
 name = "starknet_patricia_storage"
-version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.2-RC.7-fix#4251763b664ee50a76889a800b801627f31bfd1c"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
 dependencies = [
  "apollo_config",
+ "async-trait",
+ "futures",
  "hex",
  "lru",
  "serde",
@@ -6739,6 +6904,7 @@ dependencies = [
  "starknet-types-core",
  "starknet_api",
  "thiserror 1.0.69",
+ "tokio",
  "validator",
 ]
 
@@ -6750,13 +6916,13 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -6975,6 +7141,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7105,17 +7291,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7128,31 +7314,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -7573,7 +7768,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -7635,6 +7839,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7684,7 +7922,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8044,6 +8282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8058,6 +8302,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,8 +125,8 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "apollo_compilation_utils"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
@@ -142,8 +142,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_compile_to_native"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_compilation_utils",
  "apollo_compile_to_native_types",
@@ -154,8 +154,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_compile_to_native_types"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_config",
  "serde",
@@ -164,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_config"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_infra_utils",
  "clap",
@@ -182,8 +182,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_infra_utils"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_proc_macros",
  "assert-json-diff",
@@ -205,8 +205,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_metrics"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_time",
  "const_format",
@@ -219,8 +219,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_proc_macros"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_proc_macros_lib",
  "metrics 0.24.3",
@@ -228,8 +228,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_proc_macros_lib"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -239,8 +239,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_sizeof"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_sizeof_macros",
  "starknet-types-core",
@@ -248,8 +248,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_sizeof_macros"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -258,8 +258,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_starknet_os_program"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_infra_utils",
  "cairo-vm",
@@ -273,8 +273,8 @@ dependencies = [
 
 [[package]]
 name = "apollo_time"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "chrono",
 ]
@@ -299,10 +299,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -312,14 +312,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash 0.8.12",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe 0.6.0",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash 0.8.12",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe 0.6.0",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -332,10 +353,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "educe 0.6.0",
@@ -347,10 +368,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe 0.6.0",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -370,18 +418,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash 0.8.12",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe 0.6.0",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash 0.8.12",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe 0.6.0",
+ "fnv",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -390,9 +466,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bd211c48debd3037b48873a7aa22c3aba034e83388aa4124795c9f220b88c7"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41b34e9124731f4834db5a8f92ce085a47cd6f006fdb50359ea508d6256341d"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -401,9 +488,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf8be5820de567729bfa73a410ddd07cec8ad102d9a4bf61fd6b2e60db264e8"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-secp256r1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e7450e67fdd507af9e1b70dbabffe335d425cbcdeb531b8979b3a8e838fd78"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -412,9 +510,21 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
  "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -431,10 +541,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -1078,8 +1209,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "anyhow",
  "apollo_compilation_utils",
@@ -1088,10 +1219,10 @@ dependencies = [
  "apollo_config",
  "apollo_infra_utils",
  "apollo_metrics",
- "ark-ec",
- "ark-ff",
- "ark-secp256k1",
- "ark-secp256r1",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-secp256k1 0.5.0",
+ "ark-secp256r1 0.5.0",
  "blockifier_test_utils",
  "cached",
  "cairo-lang-casm",
@@ -1130,8 +1261,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier_test_utils"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_infra_utils",
  "cairo-lang-starknet-classes",
@@ -1293,9 +1424,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8ba4a3d44e9911b757ab231d09c370753ba717fe8b335dffbb6f7b137296fe"
+checksum = "183d72ae89dff2581523134f127734996b2cae3aefc44df22cae62ab472abdaf"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -1307,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3503898c518d6e8ed5e958d30aa2745bf099c1600b5fde486210719b98a2d10"
+checksum = "4b68b7c69156f0b68ebb5421ec063ad4afb86e38590a04360992fd7b795a1558"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -1334,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1a9a5aac7b9220d811d8a745fe5e35a7043f741e267a8b00a4c5763b48b1d7"
+checksum = "483cb988d3346be274dfa4d8055f8f2730b1f49efd08dc6f13195124534ec5bf"
 dependencies = [
  "cairo-lang-utils",
  "id-arena",
@@ -1345,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d804565b31e141d7909e26a43fb251cf6ec68d36d9918f2e4a970d4326c70bd3"
+checksum = "b5f99066c060b1c24dc561d91089d72eee1347641a4e1e491eeb5b531bcb00ac"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -1366,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4555f8c2563fa070c2c492bb4a20ee8d9e87ec67239593dab7545a17f8a7d7b"
+checksum = "a023b2968c8c790409dc32d91fb91e25be0b0a8ea46ae95765b2a255524d82b2"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1380,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd052b0c34bac485aefb13f2ba38e5159913f05f6001915db473b6a0ebcd2b9"
+checksum = "009d120c9080d7b07d9d88ecf268f8205be24fd82455982fb30afcee26966061"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -1390,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d897c5268fff99a2f093a7d9fd23480ef0a46f7130d6640934bcb13ecc08f9f"
+checksum = "992565f89687b51b7d2c68a6ba9f141f50f1513cea0633b625699d7054522fc9"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-proc-macros",
@@ -1408,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a5fd77897cc7afe835c3c97720835d01fa203aa968777f8df1ae8e6901e748"
+checksum = "24b10b2842e10206ff4a777600414dda10607335bb327151f78f7b4c2f890b3b"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -1428,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d5fc3122388882be9c8774ee836d2c7a4db1333c08ff82f36d8f43e84c57c"
+checksum = "f967c60c5e8cec3b2da58c9e8e92ac3cc8218b036bc87846a20d25dda070a654"
 dependencies = [
  "assert_matches",
  "cairo-lang-debug",
@@ -1458,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324f258615e2876db65be5eb439999d35f432976c0cf2717778c183ee0ba4708"
+checksum = "2b5457a724381a0f393843acb7554dc4c620bfbbcf5dd984b43c59b668ed3677"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -1478,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133dc9d41b82e97f348e4589d58116473e63bbe97bf8669260a945b5482faec0"
+checksum = "d1654b7170385dd9beedb55dbdc477c978555f3f150736bacda3a9c82cc6c716"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1502,9 +1633,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b253829795dd9e12560f55654631d1605eea1be4d6790eb02e6719e79bde5be"
+checksum = "9d79f89d4f557faa2d626e63c1c95e0b1e3148a32dc8b73a155f1e981b8f4bdb"
 dependencies = [
  "cairo-lang-debug",
  "proc-macro2",
@@ -1515,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cde3434b466ab9b03d402dbc79cc57adfb9d25a5e4d614c0060cccd955379d8"
+checksum = "2b5c89af4169ab03d2d314d81864cd17a0362608868e709a6a9e39fe9fcdf8c2"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -1528,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3269a2e149811c7a714cd3a465902b1897a9b372c589188b3f53a746e3691b02"
+checksum = "814f5c50c7f8d788c444752021e2c04a4804d5f7f80bdbdc438bc12067c38d8a"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1545,13 +1676,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runner"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0603bfe3285f0b1978aa98741a8fcd757239082a22ca21f3db281a914145d7a1"
+checksum = "61efd8ddb42b79eb19ed72992e431c3a9f5ca86347abd0d16efcfb9cebe00ac0"
 dependencies = [
- "ark-ff",
- "ark-secp256k1",
- "ark-secp256r1",
+ "ark-ff 0.6.0",
+ "ark-secp256k1 0.6.0",
+ "ark-secp256r1 0.6.0",
  "cairo-lang-casm",
  "cairo-lang-lowering",
  "cairo-lang-runnable-utils",
@@ -1577,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2be71c26fc76ff91b1c224d54bede226ba6b66ec6892a4e5c98ad53f399021"
+checksum = "695f0bc4c2dc8037bba54e097d75a65e0b451baf734dae21eae91d7e45cd59e5"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1599,7 +1730,7 @@ dependencies = [
  "postcard",
  "salsa",
  "serde",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "starknet-types-core",
  "toml",
  "tracing",
@@ -1607,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a109344978f9338afbfceb801af131e41f5b5c7951a2c8f584d9092fd565aa"
+checksum = "2293b7ab2d3c9e1f971033bfa615be1a505a1d6970d4f5143b52c3da00ccaaaf"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -1625,7 +1756,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "smol_str",
  "starknet-types-core",
  "thiserror 2.0.17",
@@ -1633,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7e5837455553b09f926ef1e9aab6622fb6091f900d932c979ab722f080e837"
+checksum = "d59f27df9fe31d67defd884b4367a03faf7ab42bbaba1ea6243c84dbfae86dfb"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1649,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f7337921f6fde562433a015a11ac1367b0cb8f52ede2c3af927d96d5aa3442"
+checksum = "6fdf787006381f9f71a93be3cd3e35c8dbc39671e29bfb2f9bdc69106eef3024"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -1665,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a144c32b66f0ede481c8b9bd285722373e3848ae3fabead0080511471039cb"
+checksum = "b02ea4db29e248f393389ed8318db52629a93e6ef5e9d6ce284d5ca9fd7fd66c"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -1690,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac7497b6627e7c4b69edd9c305eb254298d77a0801bd0b6b3122d53c62d7f07"
+checksum = "294009e7368e2974ca8b6c0cef6144d92745753348cc6b3f3db886ae84be23d2"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -1711,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c6feaf7f1255e43321e34e3744a9ef853fce98960ab138988c048029c57e6"
+checksum = "e8fb38d1f89270a7b78ec2263980572375c1582061d22586f9199fa385dcd383"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1721,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd34ae52728e9acb14ac15c2529736493a2c02e144f0233bab55d66c3fdbfd57"
+checksum = "cdfb58e771f5beba2db38e75364234b625ac7b6410f4f3fcd5810ea89b9c838d"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1754,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4961af6fc9d7fa615b20f9dd48df9c63bff3cc54113fe33aeade99b4219e1c"
+checksum = "f27b641ec3082f2d2dba0ca6828b1946e8bfbf21260175e4a72de1e10c5248c4"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -1770,7 +1901,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "smol_str",
  "starknet-types-core",
  "thiserror 2.0.17",
@@ -1778,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81138a4f169c8d19752fc438e7aadc443123454eb5f1f2b219ca0953a952071"
+checksum = "27da0777ac026094e8f67d32061a77a12cb91035dcf3c6fd92b6b989d6fef3f8"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1797,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6380c1fa17b96823eac53d6a57de949402ee55d2b4d14ae722ac9287f0efc3c1"
+checksum = "e26f34eb95496f27df57a7630fc533eabd8f631f9912a2579421b3095fcc5157"
 dependencies = [
  "genco",
  "xshell",
@@ -1807,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93debf5e87605b99bf3fa26f2c1e262d76173d3e5bfb96588cf76e4288dafde"
+checksum = "cfcd1f9e894db6bc4197a23599a6013930d3b1b98d7dae249d968650882a56c6"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-proc-macros",
@@ -1821,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.19.0-rc.0"
+version = "2.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac2d569ef99caab85f4b92d668e61d30ec4877dc24353bb1d1b68b5fb09bf9d"
+checksum = "baa5f9eff3268b851283232236ffb9af87ecd12320418daf91e2da45c7d039c5"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.13.0",
@@ -1848,10 +1979,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaaf48d22c1c9a0bb5aedf0a66f5b1a37f41dc3df5ce18480ce2abbed9a88657"
 dependencies = [
  "aquamarine",
- "ark-ec",
- "ark-ff",
- "ark-secp256k1",
- "ark-secp256r1",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-secp256k1 0.5.0",
+ "ark-secp256r1 0.5.0",
  "bumpalo",
  "cairo-lang-lowering",
  "cairo-lang-runner",
@@ -2609,11 +2740,12 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+checksum = "10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914"
 dependencies = [
- "nu-ansi-term",
+ "anstyle",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3953,9 +4085,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -4817,8 +4949,8 @@ dependencies = [
 
 [[package]]
 name = "papyrus_common"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "cairo-lang-starknet-classes",
  "indexmap 2.13.0",
@@ -5925,14 +6057,14 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77debccd43ba198e9cee23efd7f10330ff445e46a98a2b107fed9094a1ee676"
+checksum = "4612ff789805e65c87e9b38cb749a293212a615af065bed8a2001086801498c3"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "hashlink",
  "indexmap 2.13.0",
  "intrusive-collections",
@@ -5946,19 +6078,20 @@ dependencies = [
  "smallvec",
  "thin-vec",
  "tracing",
+ "typeid",
 ]
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea07adbf42d91cc076b7daf3b38bc8168c19eb362c665964118a89bc55ef19a5"
+checksum = "58e354cbac6939b9b09cd9c11fb419a53e64b4a0f755d929f56a09f4cc752e41"
 
 [[package]]
 name = "salsa-macros"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d4d8b66451b9c75ddf740b7fc8399bc7b8ba33e854a5d7526d18708f67b05"
+checksum = "3067861075c2b80608f84ad49fb88f2c7610b94cdf8b4201e79ddee87f8980c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6279,12 +6412,13 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
  "digest 0.11.3",
  "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -6298,8 +6432,8 @@ dependencies = [
 
 [[package]]
 name = "shared_execution_objects"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "blockifier",
  "serde",
@@ -6413,6 +6547,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sprs"
@@ -6758,8 +6898,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_infra_utils",
  "apollo_sizeof",
@@ -6797,8 +6937,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_committer"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_config",
  "async-trait",
@@ -6822,15 +6962,15 @@ dependencies = [
 
 [[package]]
 name = "starknet_os"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_starknet_os_program",
  "ark-bls12-381",
- "ark-ff",
- "ark-poly",
- "ark-secp256k1",
- "ark-secp256r1",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-secp256k1 0.5.0",
+ "ark-secp256r1 0.5.0",
  "blake2",
  "blockifier",
  "c-kzg",
@@ -6870,8 +7010,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_patricia"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "async-recursion",
  "derive_more",
@@ -6891,8 +7031,8 @@ dependencies = [
 
 [[package]]
 name = "starknet_patricia_storage"
-version = "0.19.0-rc.0"
-source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.6#613f8410ecdf31915c706781da5f658ea3d05cb6"
+version = "0.19.0-rc.2"
+source = "git+https://github.com/starkware-libs/sequencer?tag=APOLLO-0.14.3-RC.15#12cf3b7d4a55478183662523c10eddb1d71243bf"
 dependencies = [
  "apollo_config",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,33 +10,33 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.89.0"
 repository = "https://github.com/keep-starknet-strange/snos/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-# 0.14.2 baseline: use the published Apollo release tag for the 0.14.2 line.
-starknet_api = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.2-RC.7-fix", features = [
+# 0.14.3 baseline: use the published Apollo release tag for the 0.14.3 line.
+starknet_api = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
   "testing",
 ] }
-starknet_os = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.2-RC.7-fix", features = [
+starknet_os = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
   "testing",
 ] }
-blockifier = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.2-RC.7-fix", features = [
+blockifier = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
   "testing",
   "reexecution",
 ] }
-starknet_patricia = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.2-RC.7-fix", features = [
+starknet_patricia = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
   "testing",
 ] }
-shared_execution_objects = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.2-RC.7-fix" }
+shared_execution_objects = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6" }
 
-cairo-lang-starknet = "=2.17.0"
-cairo-lang-starknet-classes = "=2.17.0"
-cairo-lang-utils = "=2.17.0"
-cairo-lang-casm = "=2.17.0"
+cairo-lang-starknet = "=2.19.0-rc.0"
+cairo-lang-starknet-classes = "=2.19.0-rc.0"
+cairo-lang-utils = "=2.19.0-rc.0"
+cairo-lang-casm = "=2.19.0-rc.0"
 cairo-vm = "=3.2.0"
 
 starknet = {package = "starknet-rust", version = "0.19.0-rc.2"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,31 +12,31 @@ members = [
 [workspace.package]
 version = "0.3.0"
 edition = "2021"
-rust-version = "1.89.0"
+rust-version = "1.95.0"
 repository = "https://github.com/keep-starknet-strange/snos/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
 # 0.14.3 baseline: use the published Apollo release tag for the 0.14.3 line.
-starknet_api = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
+starknet_api = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.15", features = [
   "testing",
 ] }
-starknet_os = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
+starknet_os = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.15", features = [
   "testing",
 ] }
-blockifier = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
+blockifier = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.15", features = [
   "testing",
   "reexecution",
 ] }
-starknet_patricia = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6", features = [
+starknet_patricia = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.15", features = [
   "testing",
 ] }
-shared_execution_objects = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.6" }
+shared_execution_objects = { git = "https://github.com/starkware-libs/sequencer", tag = "APOLLO-0.14.3-RC.15" }
 
-cairo-lang-starknet = "=2.19.0-rc.0"
-cairo-lang-starknet-classes = "=2.19.0-rc.0"
-cairo-lang-utils = "=2.19.0-rc.0"
-cairo-lang-casm = "=2.19.0-rc.0"
+cairo-lang-starknet = "=2.19.4"
+cairo-lang-starknet-classes = "=2.19.4"
+cairo-lang-utils = "=2.19.4"
+cairo-lang-casm = "=2.19.4"
 cairo-vm = "=3.2.0"
 
 starknet = {package = "starknet-rust", version = "0.19.0-rc.2"}

--- a/crates/core/generate-pie/Cargo.toml
+++ b/crates/core/generate-pie/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 yaml = []
 
 [dependencies]
-rpc-client = { path = "../../rpc-client" }
+rpc-client = { path = "../../rpc-client", features = ["cairo_native"] }
 starknet-os-types = { path = "../../starknet-os-types" }
 
 blockifier = { workspace = true }

--- a/crates/core/generate-pie/Cargo.toml
+++ b/crates/core/generate-pie/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 yaml = []
 
 [dependencies]
-rpc-client = { path = "../../rpc-client", features = ["cairo_native"] }
+rpc-client = { path = "../../rpc-client" }
 starknet-os-types = { path = "../../starknet-os-types" }
 
 blockifier = { workspace = true }

--- a/crates/core/generate-pie/src/block_processor.rs
+++ b/crates/core/generate-pie/src/block_processor.rs
@@ -15,7 +15,7 @@ use log::info;
 use rpc_client::RpcClient;
 use starknet::core::types::BlockId;
 use starknet_api::block::BlockHash;
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
+use starknet_api::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress};
 use starknet_api::deprecated_contract_class::ContractClass;
 use starknet_os::io::os_input::OsBlockInput;
 use starknet_types_core::felt::Felt;
@@ -29,6 +29,8 @@ use std::collections::BTreeMap;
 pub struct BlockInfoResult {
     /// The OS block input for the block.
     pub os_block_input: OsBlockInput,
+    /// The chain ID reported by the RPC provider.
+    pub chain_id: ChainId,
     /// Compiled classes used in the block.
     pub compiled_classes: BTreeMap<CompiledClassHash, CasmContractClass>,
     /// Deprecated compiled classes used in the block.
@@ -134,7 +136,7 @@ pub async fn collect_single_block_info(
 
     info!("Successfully completed construction of OsBlockInput for block {}", block_number);
 
-    Ok(BlockInfoResult { os_block_input, compiled_classes, deprecated_compiled_classes })
+    Ok(BlockInfoResult { os_block_input, chain_id: block_data.chain_id, compiled_classes, deprecated_compiled_classes })
 }
 
 // ================================================================================================

--- a/crates/core/generate-pie/src/block_processor.rs
+++ b/crates/core/generate-pie/src/block_processor.rs
@@ -162,6 +162,7 @@ fn build_os_block_input(
         tx_execution_infos: tx_result.central_txn_execution_infos,
         declared_class_hash_to_component_hashes: class_result.declared_class_hash_component_hashes,
         block_info: block_context.block_info().clone(),
+        starknet_version_override: None,
         block_hash_commitments: tx_result.block_hash_commitments,
         prev_block_hash: block_data
             .previous_block

--- a/crates/core/generate-pie/src/lib.rs
+++ b/crates/core/generate-pie/src/lib.rs
@@ -69,7 +69,7 @@ use cairo_vm::types::layout_name::LayoutName;
 use futures::future::join_all;
 use log::{info, warn};
 use rpc_client::RpcClient;
-use starknet_api::core::OsChainInfo;
+use starknet_api::core::{ChainId, OsChainInfo};
 use starknet_os::{
     io::os_input::{OsHints, OsHintsConfig, StarknetOsInput},
     runner::run_os_stateless,
@@ -206,6 +206,7 @@ pub async fn generate_pie(input: PieGenerationInput) -> Result<PieGenerationResu
 
             Ok::<_, PieGenerationError>((
                 block_info.os_block_input,
+                block_info.chain_id,
                 block_info.compiled_classes,
                 block_info.deprecated_compiled_classes,
             ))
@@ -220,10 +221,23 @@ pub async fn generate_pie(input: PieGenerationInput) -> Result<PieGenerationResu
     let mut os_block_inputs = Vec::new();
     let mut compiled_classes = std::collections::BTreeMap::new();
     let mut deprecated_compiled_classes = std::collections::BTreeMap::new();
+    let mut provider_chain_id: Option<ChainId> = None;
 
     for result in results {
         // First unwrap the JoinHandle, then unwrap the inner Result
-        let (block_input, block_compiled_classes, block_deprecated_compiled_classes) = result??;
+        let (block_input, block_chain_id, block_compiled_classes, block_deprecated_compiled_classes) =
+            result.map_err(|e| PieGenerationError::RpcClient(format!("Task join error: {:?}", e)))??;
+
+        if let Some(provider_chain_id) = &provider_chain_id {
+            if provider_chain_id != &block_chain_id {
+                return Err(PieGenerationError::InvalidConfig(format!(
+                    "Blocks belong to different chains: {:?} and {:?}",
+                    provider_chain_id, block_chain_id
+                )));
+            }
+        } else {
+            provider_chain_id = Some(block_chain_id);
+        }
 
         // Add block input to our collection
         os_block_inputs.push(block_input);
@@ -245,6 +259,13 @@ pub async fn generate_pie(input: PieGenerationInput) -> Result<PieGenerationResu
 
     info!("=== Finalizing multi-block processing ===");
     info!("OS inputs prepared with {} block inputs", os_block_inputs.len());
+    let os_chain_id = provider_chain_id.unwrap_or_else(|| input.chain_config.chain_id.clone());
+    if os_chain_id != input.chain_config.chain_id {
+        warn!(
+            "Using provider chain_id {:?} for OS hints instead of configured chain_id {:?}",
+            os_chain_id, input.chain_config.chain_id
+        );
+    }
 
     // Build OS hints configuration
     info!("Building OS hints configuration for multi-block processing");
@@ -254,7 +275,7 @@ pub async fn generate_pie(input: PieGenerationInput) -> Result<PieGenerationResu
             full_output: input.os_hints_config.full_output,
             use_kzg_da: input.os_hints_config.use_kzg_da,
             chain_info: OsChainInfo {
-                chain_id: input.chain_config.chain_id,
+                chain_id: os_chain_id,
                 strk_fee_token_address: input.chain_config.strk_fee_token_address,
             },
             public_keys: input.public_keys.clone(),

--- a/crates/core/generate-pie/src/utils/serialization.rs
+++ b/crates/core/generate-pie/src/utils/serialization.rs
@@ -57,11 +57,10 @@ pub fn sort_abi_entries_for_deprecated_class(
                 if let Some(attr_obj) = attr.as_object_mut() {
                     // Remove empty accessible_scopes arrays
                     match attr_obj.get("accessible_scopes") {
-                        Some(serde_json::Value::Array(array)) => {
-                            if array.is_empty() {
-                                attr_obj.remove("accessible_scopes");
-                            }
+                        Some(serde_json::Value::Array(array)) if array.is_empty() => {
+                            attr_obj.remove("accessible_scopes");
                         }
+                        Some(serde_json::Value::Array(_)) => {}
                         Some(_) => {
                             return Err("Program attribute 'accessible_scopes' was not an array type".into());
                         }

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -23,6 +23,17 @@ const RPC_REQUEST_TIMEOUT_ENV: &str = "SNOS_RPC_REQUEST_TIMEOUT_SECS";
 const RPC_CONNECT_TIMEOUT_ENV: &str = "SNOS_RPC_CONNECT_TIMEOUT_SECS";
 const RPC_POOL_MAX_IDLE_PER_HOST_ENV: &str = "SNOS_RPC_POOL_MAX_IDLE_PER_HOST";
 
+fn starknet_rpc_url(base_url: &str) -> String {
+    let base_url = base_url.trim_end_matches('/');
+    let rpc_suffix = format!("/rpc/{}", STARKNET_RPC_VERSION);
+
+    if base_url.ends_with(&rpc_suffix) {
+        base_url.to_owned()
+    } else {
+        format!("{base_url}{rpc_suffix}")
+    }
+}
+
 pub trait ProofClient {
     fn get_proof(
         &self,
@@ -86,7 +97,7 @@ impl RpcClientInner {
     /// let inner = RpcClientInner::new("https://your-starknet-node.com");
     /// ```
     fn try_new(base_url: &str) -> anyhow::Result<Self> {
-        let starknet_rpc_url = format!("{}/rpc/{}", base_url, STARKNET_RPC_VERSION);
+        let starknet_rpc_url = starknet_rpc_url(base_url);
         info!("Initializing Starknet RPC client with URL: {}", starknet_rpc_url);
 
         let rpc_request_timeout_secs = Self::read_env_u64(RPC_REQUEST_TIMEOUT_ENV, DEFAULT_RPC_REQUEST_TIMEOUT_SECS);
@@ -110,6 +121,27 @@ impl RpcClientInner {
         let provider = JsonRpcClient::new(HttpTransport::new_with_client(starknet_rpc_url, http_client));
 
         Ok(Self { starknet_client: provider })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::starknet_rpc_url;
+
+    #[test]
+    fn appends_rpc_version_to_base_url() {
+        assert_eq!(starknet_rpc_url("https://example.com/path"), "https://example.com/path/rpc/v0_10");
+    }
+
+    #[test]
+    fn keeps_already_versioned_rpc_url() {
+        assert_eq!(starknet_rpc_url("https://example.com/path/rpc/v0_10"), "https://example.com/path/rpc/v0_10");
+    }
+
+    #[test]
+    fn trims_trailing_slashes_before_normalizing() {
+        assert_eq!(starknet_rpc_url("https://example.com/path/"), "https://example.com/path/rpc/v0_10");
+        assert_eq!(starknet_rpc_url("https://example.com/path/rpc/v0_10/"), "https://example.com/path/rpc/v0_10");
     }
 }
 

--- a/crates/rpc-client/src/client.rs
+++ b/crates/rpc-client/src/client.rs
@@ -125,7 +125,7 @@ impl RpcClientInner {
 }
 
 #[cfg(test)]
-mod tests {
+mod url_tests {
     use super::starknet_rpc_url;
 
     #[test]

--- a/crates/rpc-replay/Cargo.toml
+++ b/crates/rpc-replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc-replay"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 # Internal dependencies
 generate-pie = { path = "../core/generate-pie" }
-rpc-client = { path = "../rpc-client", features = ["cairo_native"] }
+rpc-client = { path = "../rpc-client" }
 
 # External dependencies
 aws-config = { workspace = true }

--- a/crates/rpc-replay/Cargo.toml
+++ b/crates/rpc-replay/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 # Internal dependencies
 generate-pie = { path = "../core/generate-pie" }
-rpc-client = { path = "../rpc-client" }
+rpc-client = { path = "../rpc-client", features = ["cairo_native"] }
 
 # External dependencies
 aws-config = { workspace = true }

--- a/crates/rpc-replay/Dockerfile
+++ b/crates/rpc-replay/Dockerfile
@@ -20,11 +20,13 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     git \
     ca-certificates \
+    wget \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust for linux/amd64.
 # Keep the image builder aligned with the workspace toolchain used for local validation.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.89 \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.95 \
     && . /usr/local/cargo/env \
     && rustup target add x86_64-unknown-linux-gnu
 
@@ -56,10 +58,34 @@ RUN if find /usr/local/cargo/git/checkouts -name "requirements.txt" -path "*/scr
         echo "No requirements.txt found, skipping pip install"; \
     fi
 
+# Install the LLVM/MLIR toolchain required by cairo-native.
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+        | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" \
+        > /etc/apt/sources.list.d/llvm.list \
+    && apt-get update \
+    && apt-get install -y \
+        llvm-19 \
+        llvm-19-dev \
+        llvm-19-runtime \
+        clang-19 \
+        clang-tools-19 \
+        libclang-19-dev \
+        lld-19 \
+        libpolly-19-dev \
+        libmlir-19-dev \
+        mlir-19-tools \
+        libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV MLIR_SYS_190_PREFIX=/usr/lib/llvm-19
+ENV LLVM_SYS_191_PREFIX=/usr/lib/llvm-19
+ENV TABLEGEN_190_PREFIX=/usr/lib/llvm-19
+
 # Build the rpc-replay binary
 RUN . sequencer_venv/bin/activate \
     && . /usr/local/cargo/env \
-    && cargo build --release --bin rpc-replay
+    && RUSTFLAGS="-C link-arg=-fuse-ld=lld" cargo build --bin rpc-replay
 
 # Runtime stage
 FROM --platform=linux/amd64 ubuntu:22.04
@@ -71,8 +97,18 @@ RUN apt-get update && apt-get install -y \
     libgmp10 \
     python3 \
     python3-venv \
+    wget \
+    gnupg \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
+
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+        | gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" \
+        > /etc/apt/sources.list.d/llvm.list \
+    && apt-get update \
+    && apt-get install -y llvm-19-runtime libmlir-19 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
 RUN useradd -m -u 1000 appuser
@@ -81,7 +117,7 @@ RUN useradd -m -u 1000 appuser
 RUN mkdir -p /app/output /app/logs && chown -R appuser:appuser /app
 
 # Copy the binary from builder stage
-COPY --from=builder /app/target/release/rpc-replay /usr/local/bin/rpc-replay
+COPY --from=builder /app/target/debug/rpc-replay /usr/local/bin/rpc-replay
 
 # Copy Python virtual environment
 COPY --from=builder /app/sequencer_venv /app/sequencer_venv
@@ -107,6 +143,7 @@ ENV AWS_S3_BUCKET=""
 ENV AWS_ACCESS_KEY_ID=""
 ENV AWS_SECRET_ACCESS_KEY=""
 ENV PATH=/app/sequencer_venv/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/lib/llvm-19/lib
 
 # Expose volumes for output files and logs
 VOLUME ["/app/output", "/app/logs"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ autoflake==2.3.1
 bitarray==3.5.2
 black==23.1a1
 cachetools==6.1.0
-cairo-lang==0.14.1a0
+cairo-lang==0.14.3a2
 certifi==2025.7.14
 charset-normalizer==3.4.2
 ckzg==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ autoflake==2.3.1
 bitarray==3.5.2
 black==23.1a1
 cachetools==6.1.0
-cairo-lang==0.14.3a2
+cairo-lang==0.14.3a3
 certifi==2025.7.14
 charset-normalizer==3.4.2
 ckzg==2.1.1

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89"
+channel = "1.95"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary
- Updates SNOS to the Apollo 0.14.3 RC.6 stack and moves internal services to 0.3.0.
- Aligns Cairo dependencies with the 0.14.3 Apollo release line.
- Supports Pathfinder URLs that already include the Starknet RPC version.
- Uses the provider chain ID for OS hints so integration-sepolia replays match transaction hashes.

## Validation
- Local workspace verification completed.
- RPC URL normalization coverage passed.
- Pathfinder integration PIE generation succeeded for latest block 11490070 and latest-minus-250 block 11489820; both were invoke-only blocks.