### PR TITLE
feat: add SNOS logging instrumentation

### DIFF
--- a/crates/core/generate-pie/src/types/proof.rs
+++ b/crates/core/generate-pie/src/types/proof.rs
@@ -103,6 +103,7 @@ impl ProofCollectionResult {
                     .chain(current_contract_commitment_facts)
                     .map(|(key, value)| (HashOutput(key), value))
                     .collect();
+            let merged_contract_fact_count = global_contract_commitment_facts.len();
 
             let current_contract_storage_root: Felt =
                 storage_proof.contract_data.as_ref().map(|contract_data| contract_data.root).unwrap_or(Felt::ZERO);
@@ -113,6 +114,15 @@ impl ProofCollectionResult {
                 tree_height: SubTreeHeight(DEFAULT_STORAGE_TREE_HEIGHT as u8),
                 commitment_facts: global_contract_commitment_facts,
             };
+
+            info!(
+                "Prepared storage commitment info for block {:?}, contract {:#x}: previous_root={:#x} updated_root={:#x} merged_facts={}",
+                block_id,
+                contract_address,
+                previous_contract_storage_root,
+                current_contract_storage_root,
+                merged_contract_fact_count
+            );
 
             address_to_storage_commitment_info.insert(
                 ContractAddress::try_from(contract_address)
@@ -177,6 +187,7 @@ impl ProofCollectionResult {
             .chain(current_state_commitment_facts)
             .map(|(k, v)| (HashOutput(k), v))
             .collect();
+        let merged_global_state_fact_count = global_state_commitment_facts.len();
 
         let contract_state_commitment_info = CommitmentInfo {
             previous_root: HashOutput(previous_contract_trie_root),
@@ -184,6 +195,18 @@ impl ProofCollectionResult {
             tree_height: SubTreeHeight(DEFAULT_STORAGE_TREE_HEIGHT as u8),
             commitment_facts: global_state_commitment_facts,
         };
+
+        info!(
+            "Prepared global contract-state commitment for block {:?}: previous_root={:#x} updated_root={:#x} merged_facts={}",
+            block_id,
+            previous_contract_trie_root,
+            current_contract_trie_root,
+            merged_global_state_fact_count
+        );
+        info!(
+            "Prepared class commitment roots for block {:?}: previous_root={:#x} updated_root={:#x}",
+            block_id, previous_root, updated_root
+        );
 
         // Compute class commitment
         let contract_class_commitment_info =

--- a/crates/core/generate-pie/src/utils/rpc.rs
+++ b/crates/core/generate-pie/src/utils/rpc.rs
@@ -16,6 +16,14 @@ use starknet_api::state::StorageKey;
 use starknet_types_core::felt::Felt;
 use std::collections::{HashMap, HashSet};
 
+fn summarize_felts(values: &[Felt], limit: usize) -> String {
+    let mut summary: Vec<String> = values.iter().take(limit).map(|felt| format!("{:#x}", felt)).collect();
+    if values.len() > limit {
+        summary.push(format!("... +{}", values.len() - limit));
+    }
+    summary.join(", ")
+}
+
 /// Comprehensive structure that captures all access information from transaction execution
 #[derive(Debug, Clone)]
 pub struct BlockAccessInfo {
@@ -148,7 +156,12 @@ pub(crate) async fn get_class_proofs(
         let proof =
             execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class_proof(block_number, class_hash))
                 .await
-                .map_err(|e| ClientError::CustomError(format!("{}", e)))?;
+                .map_err(|e| {
+                    let message =
+                        format!("class proof request failed for block {block_number} class_hash {class_hash:#x}: {e}");
+                    warn!("{message}");
+                    ClientError::CustomError(message)
+                })?;
         // TODO: need to combine these, similar to merge_chunked_storage_proofs above?
         proofs.insert(**class_hash, proof);
     }
@@ -188,10 +201,24 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
 
     let contract_data = match &contract_proof.contract_data {
         None => {
+            warn!(
+                "Storage proof for contract {} at block {} returned no contract_data",
+                contract_address, block_number
+            );
             return Ok(contract_proof);
         }
         Some(contract_data) => contract_data,
     };
+
+    info!(
+        "Fetched initial storage proof for contract {} at block {}: root={:#x} storage_proof_sets={} contract_nodes={} requested_keys=[{}]",
+        contract_address,
+        block_number,
+        contract_data.root,
+        contract_data.storage_proofs.len(),
+        contract_proof.contract_proof.len(),
+        summarize_felts(&keys, 8)
+    );
 
     let additional_keys = if contract_data.root != Felt::ZERO {
         contract_data.get_additional_keys(&keys).map_err(|e| ClientError::CustomError(format!("{}", e)))?
@@ -199,7 +226,12 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
         vec![]
     };
 
-    info!("Got {} additional keys for contract {}", additional_keys.len(), contract_address);
+    info!(
+        "Got {} additional keys for contract {} [{}]",
+        additional_keys.len(),
+        contract_address,
+        summarize_felts(&additional_keys, 8)
+    );
 
     // Fetch additional proofs required to fill gaps in the storage trie that could make
     // the OS crash otherwise.
@@ -210,7 +242,12 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
         // Combine all storage proofs into a single vector
         match &additional_proof.contract_data {
             None => {
-                panic!("Failed to fetch additional proof for contract {}", contract_address)
+                let message = format!(
+                    "Additional storage proof for contract {} at block {} returned no contract_data",
+                    contract_address, block_number
+                );
+                warn!("{message}");
+                return Err(ClientError::CustomError(message));
             }
             Some(contract_data) => {
                 additional_proof.contract_data = Some(ContractData {
@@ -221,6 +258,17 @@ async fn get_storage_proof_for_contract<KeyIter: Iterator<Item = StorageKey>>(
             }
         }
         contract_proof = merge_storage_proofs(vec![contract_proof.clone(), additional_proof]);
+    }
+
+    if let Some(contract_data) = &contract_proof.contract_data {
+        info!(
+            "Final merged storage proof for contract {} at block {}: root={:#x} storage_proof_sets={} contract_nodes={}",
+            contract_address,
+            block_number,
+            contract_data.root,
+            contract_data.storage_proofs.len(),
+            contract_proof.contract_proof.len()
+        );
     }
 
     Ok(contract_proof)
@@ -235,7 +283,12 @@ async fn fetch_storage_proof_for_contract(
     keys: &[Felt],
     block_number: u64,
 ) -> Result<ContractProof, ClientError> {
-    info!("Fetching storage proof for contract {} with {} keys", contract_address, keys.len());
+    info!(
+        "Fetching storage proof for contract {} with {} keys [{}]",
+        contract_address,
+        keys.len(),
+        summarize_felts(keys, 8)
+    );
 
     let operation_name = format!(
         "get_proof(block_number: {block_number}, contract_address: {contract_address:#x}, keys: {})",
@@ -244,7 +297,18 @@ async fn fetch_storage_proof_for_contract(
 
     execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_proof(block_number, contract_address, keys))
         .await
-        .map_err(|e| ClientError::CustomError(format!("{}", e)))
+        .map_err(|e| {
+            let message = format!(
+                "storage proof request failed for block {} contract {:#x} keys={} [{}]: {}",
+                block_number,
+                contract_address,
+                keys.len(),
+                summarize_felts(keys, 8),
+                e
+            );
+            warn!("{message}");
+            ClientError::CustomError(message)
+        })
 }
 
 /// Merges the storage proofs of the SAME contract.

--- a/crates/rpc-client/src/state_reader/mod.rs
+++ b/crates/rpc-client/src/state_reader/mod.rs
@@ -2,7 +2,7 @@ use blockifier::execution::contract_class::{CompiledClassV0, CompiledClassV1, Ru
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader, StateResult};
 use cairo_lang_starknet_classes::contract_class::version_id_from_serialized_sierra_program;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use starknet::core::types::{BlockId, Felt, StarknetError};
 use starknet::providers::{Provider, ProviderError};
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
@@ -50,6 +50,26 @@ impl AsyncRpcStateReader {
     }
 }
 
+fn log_cached_state_zero_fallback(
+    field_name: &str,
+    block_id: BlockId,
+    contract_address: ContractAddress,
+    key: Option<StorageKey>,
+    error: &ProviderError,
+) {
+    let key_suffix = key.map(|key| format!(", key={:#x}", Felt::from(*key.0.key()))).unwrap_or_default();
+    let message = format!(
+        "Cached state {field_name} fallback to zero for block {block_id:?}, contract={:#x}{key_suffix}: {error}",
+        Felt::from(*contract_address.key())
+    );
+
+    match error {
+        ProviderError::StarknetError(StarknetError::ContractNotFound) => info!("{message}"),
+        ProviderError::StarknetError(StarknetError::ClassHashNotFound) => info!("{message}"),
+        _ => warn!("{message}"),
+    }
+}
+
 // Helper function to convert provider error to state error
 fn provider_error_to_state_error(provider_error: ProviderError) -> StateError {
     StateError::StateReadError(provider_error.to_string())
@@ -80,7 +100,10 @@ impl AsyncRpcStateReader {
         .await
         {
             Ok(value) => Ok(value.value()),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
+            Err(err @ ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                log_cached_state_zero_fallback("storage", block_id, contract_address, Some(key), &err);
+                Ok(Felt::ZERO)
+            }
             Err(e) => Err(provider_error_to_state_error(e)),
         }?;
 
@@ -103,7 +126,10 @@ impl AsyncRpcStateReader {
         .await
         {
             Ok(value) => Ok(value),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Felt::ZERO),
+            Err(err @ ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                log_cached_state_zero_fallback("nonce", block_id, contract_address, None, &err);
+                Ok(Felt::ZERO)
+            }
             Err(e) => Err(provider_error_to_state_error(e)),
         }?;
         Ok(Nonce(nonce))
@@ -125,7 +151,10 @@ impl AsyncRpcStateReader {
         .await
         {
             Ok(class_hash) => Ok(class_hash),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(ClassHash::default().0),
+            Err(err @ ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                log_cached_state_zero_fallback("class_hash", block_id, contract_address, None, &err);
+                Ok(ClassHash::default().0)
+            }
             Err(e) => Err(provider_error_to_state_error(e)),
         }?;
 

--- a/crates/rpc-client/src/types/proofs/contract.rs
+++ b/crates/rpc-client/src/types/proofs/contract.rs
@@ -1,5 +1,5 @@
 use anyhow::bail;
-use log::info;
+use log::{info, warn};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use starknet::providers::ProviderError;
@@ -50,12 +50,31 @@ impl ContractData {
         info!("Fetching additional keys for a contract which already have {} keys", keys.len());
         let mut additional_keys = vec![];
         if let Err(errors) = self.verify(keys) {
+            warn!(
+                "Contract proof verification produced {} errors for root {:#x} across {} requested keys",
+                errors.len(),
+                self.root,
+                keys.len()
+            );
+            for (index, error) in errors.iter().take(10).enumerate() {
+                warn!("Proof verification error {}/{}: {:?}", index + 1, errors.len(), error);
+            }
+            if errors.len() > 10 {
+                warn!("... {} additional proof verification errors omitted", errors.len() - 10);
+            }
             for error in errors {
                 match error {
                     ProofVerificationError::NonExistenceProof { key, height, node } => {
                         if let TrieNode::Edge { child: _, path, .. } = &node {
                             if height.0 < DEFAULT_STORAGE_TREE_HEIGHT {
                                 let modified_key = path.get_key_following_edge(key, height);
+                                info!(
+                                    "Derived additional key {:#x} from non-existence proof on root {:#x} (original key {:#x}, height={})",
+                                    modified_key,
+                                    self.root,
+                                    key,
+                                    height.0
+                                );
                                 additional_keys.push(modified_key);
                             }
                         }


### PR DESCRIPTION
## Summary
- extract the logging-only pieces from #513 onto current `main`
- surface cached-state zero fallbacks so orchestrator users can enable SNOS diagnostics with `RUST_LOG`
- log proof verification, additional-key derivation, storage/class proof context, and commitment root summaries

## Why
`madara-orchestrator` calls SNOS as a Rust library, so the practical way to inspect SNOS internals is to emit structured crate logs that can be enabled from orchestrator log filters.

## Verification
- `cargo fmt --all`
- `cargo check -p rpc-client`
- `cargo check -p generate-pie -p rpc-client` *(blocked locally by missing Cairo 0 `cairo-compile` toolchain required by `apollo_starknet_os_program` build script)*