### PR TITLE
Improve retry observability logs

### DIFF
--- a/crates/rpc-client/src/utils.rs
+++ b/crates/rpc-client/src/utils.rs
@@ -1,6 +1,6 @@
 //! Utility functions for async operations and coroutine execution.
 
-use log::{debug, warn};
+use log::warn;
 use starknet::core::types::StarknetError;
 use starknet::providers::ProviderError;
 use std::future::Future;

--- a/crates/rpc-client/src/utils.rs
+++ b/crates/rpc-client/src/utils.rs
@@ -84,7 +84,7 @@ where
         match f().await {
             Ok(result) => {
                 if attempts > 1 {
-                    debug!("{operation_name}: succeeded after {attempts} attempts");
+                    warn!("{operation_name}: succeeded after {attempts} attempts");
                 }
                 return Ok(result);
             }
@@ -98,6 +98,10 @@ where
                 if !is_retryable || attempts >= MAX_RETRY_ATTEMPTS {
                     if attempts > 1 {
                         warn!("{operation_name}: failed after {attempts} attempts with error: {e:?}");
+                    } else {
+                        warn!(
+                            "{operation_name}: failed on first attempt with error: {e:?} (retryable: {is_retryable})"
+                        );
                     }
                     return Err(e);
                 }


### PR DESCRIPTION
## Summary
- promote retry-success logging from debug to warn
- log first-attempt failures with whether the error was considered retryable
- preserve existing retry and exhausted-retry warnings

## Why
This makes it possible to answer from logs whether a retry happened, whether it eventually succeeded, and whether a failure exited on the first attempt.

## Testing
- not run (log-only change)