### PR TITLE
[codex] fail fast on incomplete RPC data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 DEFAULT_NETWORK := sepolia
 DEFAULT_BLOCK_NUMBERS := 924015
+E2E_TEST_THREADS ?= 1
+E2E_SNOS_MAX_PARALLEL_BLOCKS ?= 1
 
 # Starknet Sepolia
 SEPOLIA_RPC_URL ?= https://pathfinder-sepolia.d.karnot.xyz
@@ -143,7 +145,8 @@ test-e2e: ## Run simple parameterized PIE generation tests
 	RUST_LOG=info \
 	SNOS_RPC_URL="$(MAINNET_RPC_URL)" \
 	SNOS_RPC_URL_SEPOLIA="$(SEPOLIA_RPC_URL)" \
-	cargo test -p e2e-tests test_pie_generation -- --nocapture
+	SNOS_MAX_PARALLEL_BLOCKS="$(E2E_SNOS_MAX_PARALLEL_BLOCKS)" \
+	cargo test -p e2e-tests test_pie_generation -- --nocapture --test-threads=$(E2E_TEST_THREADS)
 
 test-all: test-workspace test-e2e ## Run all tests (unit + integration + e2e)
 

--- a/crates/core/generate-pie/src/conversions.rs
+++ b/crates/core/generate-pie/src/conversions.rs
@@ -63,6 +63,8 @@ pub enum ConversionError {
     FieldConversionFailed { field: String, reason: String },
     #[error("Missing transaction receipt for {tx_hash:#x}")]
     MissingTransactionReceipt { tx_hash: Felt },
+    #[error("Missing proof facts in RPC response for transaction {tx_hash:#x}")]
+    MissingProofFacts { tx_hash: Felt },
 }
 
 // ================================================================================================
@@ -306,8 +308,11 @@ pub(crate) fn transaction_receipt_hash(receipt: &TransactionReceipt) -> Felt {
     }
 }
 
-fn proof_facts_from_rpc(proof_facts: Option<Vec<Felt>>) -> starknet_api::transaction::fields::ProofFacts {
-    proof_facts.unwrap_or_default().into()
+fn proof_facts_from_rpc(
+    tx_hash: Felt,
+    proof_facts: Option<Vec<Felt>>,
+) -> Result<starknet_api::transaction::fields::ProofFacts, ConversionError> {
+    proof_facts.ok_or(ConversionError::MissingProofFacts { tx_hash }).map(Into::into)
 }
 
 #[allow(clippy::result_large_err)]
@@ -425,7 +430,7 @@ impl TryIntoBlockifierAsync<TransactionConversionResult> for InvokeTransactionV3
             account_deployment_data: starknet_api::transaction::fields::AccountDeploymentData(
                 self.account_deployment_data,
             ),
-            proof_facts: proof_facts_from_rpc(self.proof_facts),
+            proof_facts: proof_facts_from_rpc(self.transaction_hash, self.proof_facts)?,
         });
 
         let invoke_tx = starknet_api::executable_transaction::InvokeTransaction::create(api_tx, ctx.chain_id)?;
@@ -794,5 +799,37 @@ mod tests {
 
         assert_eq!(converted_tx.proof_facts_length(), 3);
         assert_eq!(converted_tx.tx_hash().0, tx.transaction_hash);
+    }
+
+    #[tokio::test]
+    async fn invoke_v3_conversion_rejects_missing_proof_facts() {
+        let chain_id = ChainId::Sepolia;
+        let rpc_client = RpcClient::try_new("http://localhost:9545").expect("valid dummy rpc url");
+        let transaction_receipts = HashMap::new();
+        let ctx = ConversionContext::new(&chain_id, 9112643, &rpc_client, &transaction_receipts);
+        let tx = InvokeTransactionV3 {
+            transaction_hash: Felt::from(123_u64),
+            sender_address: Felt::from_hex_unchecked(
+                "0x041c9dbe8ab9b414fa0ec4d22b7a41d80a3911b77a2c9c819ce949faa5edb9f9",
+            ),
+            calldata: vec![Felt::ONE],
+            signature: vec![Felt::TWO],
+            nonce: Felt::from(7_u64),
+            resource_bounds: ResourceBoundsMapping {
+                l1_gas: ResourceBounds { max_amount: 1_000_000, max_price_per_unit: 1 },
+                l2_gas: ResourceBounds { max_amount: 2_000_000, max_price_per_unit: 3 },
+                l1_data_gas: ResourceBounds { max_amount: 4_000_000, max_price_per_unit: 5 },
+            },
+            tip: 0,
+            paymaster_data: vec![],
+            account_deployment_data: vec![],
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+            proof_facts: None,
+        };
+
+        let error = tx.try_into_blockifier_async(&ctx).await.expect_err("missing proof facts must fail");
+
+        assert!(matches!(error, ConversionError::MissingProofFacts { tx_hash } if tx_hash == Felt::from(123_u64)));
     }
 }

--- a/crates/core/generate-pie/src/conversions.rs
+++ b/crates/core/generate-pie/src/conversions.rs
@@ -308,7 +308,10 @@ pub(crate) fn transaction_receipt_hash(receipt: &TransactionReceipt) -> Felt {
     }
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "ConversionError is shared across transaction conversions and not worth boxing here"
+)]
 fn proof_facts_from_rpc(
     tx_hash: Felt,
     proof_facts: Option<Vec<Felt>>,
@@ -832,5 +835,44 @@ mod tests {
         let error = tx.try_into_blockifier_async(&ctx).await.expect_err("missing proof facts must fail");
 
         assert!(matches!(error, ConversionError::MissingProofFacts { tx_hash } if tx_hash == Felt::from(123_u64)));
+    }
+
+    #[tokio::test]
+    async fn invoke_v3_conversion_accepts_empty_proof_facts() {
+        let chain_id = ChainId::Sepolia;
+        let rpc_client = RpcClient::try_new("http://localhost:9545").expect("valid dummy rpc url");
+        let transaction_receipts = HashMap::new();
+        let ctx = ConversionContext::new(&chain_id, 9112643, &rpc_client, &transaction_receipts);
+        let tx = InvokeTransactionV3 {
+            transaction_hash: Felt::ZERO,
+            sender_address: Felt::from_hex_unchecked(
+                "0x041c9dbe8ab9b414fa0ec4d22b7a41d80a3911b77a2c9c819ce949faa5edb9f9",
+            ),
+            calldata: vec![Felt::ONE],
+            signature: vec![Felt::TWO],
+            nonce: Felt::from(7_u64),
+            resource_bounds: ResourceBoundsMapping {
+                l1_gas: ResourceBounds { max_amount: 1_000_000, max_price_per_unit: 1 },
+                l2_gas: ResourceBounds { max_amount: 2_000_000, max_price_per_unit: 3 },
+                l1_data_gas: ResourceBounds { max_amount: 4_000_000, max_price_per_unit: 5 },
+            },
+            tip: 0,
+            paymaster_data: vec![],
+            account_deployment_data: vec![],
+            nonce_data_availability_mode: DataAvailabilityMode::L1,
+            fee_data_availability_mode: DataAvailabilityMode::L1,
+            proof_facts: Some(vec![]),
+        };
+
+        let result = tx.try_into_blockifier_async(&ctx).await.expect("empty proof facts should be accepted");
+
+        let converted_tx = match result.starknet_api_tx {
+            starknet_api::executable_transaction::Transaction::Account(
+                starknet_api::executable_transaction::AccountTransaction::Invoke(invoke_tx),
+            ) => invoke_tx,
+            other => panic!("expected invoke account transaction, got {other:?}"),
+        };
+
+        assert_eq!(converted_tx.proof_facts_length(), 0);
     }
 }

--- a/crates/core/generate-pie/src/conversions.rs
+++ b/crates/core/generate-pie/src/conversions.rs
@@ -308,6 +308,7 @@ pub(crate) fn transaction_receipt_hash(receipt: &TransactionReceipt) -> Felt {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn proof_facts_from_rpc(
     tx_hash: Felt,
     proof_facts: Option<Vec<Felt>>,

--- a/crates/core/generate-pie/src/error.rs
+++ b/crates/core/generate-pie/src/error.rs
@@ -164,6 +164,19 @@ pub enum BlockProcessingError {
         source: StarknetApiError,
     },
 
+    /// Missing field in an RPC proof payload.
+    #[error("Missing proof field `{field}` in {proof_side} {proof_kind} proof")]
+    MissingProofField { proof_side: &'static str, proof_kind: &'static str, field: &'static str },
+
+    /// Missing field in an RPC proof payload for a specific contract.
+    #[error("Missing proof field `{field}` in {proof_side} {proof_kind} proof for contract {contract_address:#x}")]
+    MissingProofFieldForContract {
+        proof_side: &'static str,
+        proof_kind: &'static str,
+        field: &'static str,
+        contract_address: Felt,
+    },
+
     /// Initial reads storage extension error.
     #[error("Failed to extend initial reads storage witness: {source}")]
     InitialReadsExtension {

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -319,6 +319,36 @@ fn collect_fetched_items<K, T>(
         .collect()
 }
 
+fn plan_accessed_address_class_fetches(
+    addresses_to_process: &[Felt252],
+    pre_state_class_hashes: &HashMap<Felt252, ClassHash>,
+    previous_block_id: PreviousBlockId,
+    block_id: BlockId,
+) -> (Vec<(Felt252, BlockId, bool)>, Vec<(Felt252, BlockId, bool, Felt)>) {
+    let mut address_block_pairs = Vec::new();
+    let mut class_fetch_pairs = Vec::new();
+
+    for address in addresses_to_process {
+        if let Some(previous_block_id) = previous_block_id {
+            if let Some(previous_class_hash) = pre_state_class_hashes.get(address) {
+                if previous_class_hash.0 == Felt::ZERO {
+                    debug!(
+                        "Contract {:?} has no class hash in the previous state; skipping previous class fetch",
+                        address
+                    );
+                } else {
+                    class_fetch_pairs.push((*address, previous_block_id, true, previous_class_hash.0));
+                }
+            } else {
+                address_block_pairs.push((*address, previous_block_id, true));
+            }
+        }
+        address_block_pairs.push((*address, block_id, false));
+    }
+
+    (address_block_pairs, class_fetch_pairs)
+}
+
 /// Builds compiled classes from accessed addresses and classes.
 async fn build_compiled_classes(
     rpc_client: &RpcClient,
@@ -392,18 +422,12 @@ async fn process_accessed_addresses(
 
     // Phase 1: Reuse pre-state class hashes from Blockifier when available, and only hit RPC
     // for the remaining previous-block lookups plus all current-block lookups.
-    let mut address_block_pairs = Vec::new();
-    let mut class_fetch_pairs = Vec::new();
-    for address in &addresses_to_process {
-        if let Some(previous_block_id) = previous_block_id {
-            if let Some(previous_class_hash) = pre_state_class_hashes.get(address) {
-                class_fetch_pairs.push((*address, previous_block_id, true, previous_class_hash.0));
-            } else {
-                address_block_pairs.push((*address, previous_block_id, true));
-            }
-        }
-        address_block_pairs.push((*address, block_id, false));
-    }
+    let (address_block_pairs, mut class_fetch_pairs) = plan_accessed_address_class_fetches(
+        &addresses_to_process,
+        pre_state_class_hashes,
+        previous_block_id,
+        block_id,
+    );
 
     let class_hash_results: Vec<(Felt252, BlockId, bool, Result<Felt, ProviderError>)> =
         stream::iter(address_block_pairs)
@@ -641,6 +665,35 @@ mod tests {
         let error = collect_fetched_items(fetched_results).expect_err("rpc errors must not be dropped");
 
         assert!(matches!(error, StateUpdateError::RpcError(ProviderError::RateLimited)));
+    }
+
+    #[test]
+    fn plan_accessed_address_class_fetches_skips_zero_pre_state_class_hashes() {
+        let address = Felt::from_hex_unchecked("0x123");
+        let previous_block_id = Some(BlockId::Number(10));
+        let block_id = BlockId::Number(11);
+        let pre_state_class_hashes = HashMap::from([(address, ClassHash::default())]);
+
+        let (address_block_pairs, class_fetch_pairs) =
+            plan_accessed_address_class_fetches(&[address], &pre_state_class_hashes, previous_block_id, block_id);
+
+        assert!(class_fetch_pairs.is_empty(), "zero pre-state class hashes must not trigger get_class()");
+        assert_eq!(address_block_pairs, vec![(address, block_id, false)]);
+    }
+
+    #[test]
+    fn plan_accessed_address_class_fetches_reuses_non_zero_pre_state_class_hashes() {
+        let address = Felt::from_hex_unchecked("0x123");
+        let previous_class_hash = ClassHash(Felt::from_hex_unchecked("0x456"));
+        let previous_block_id = Some(BlockId::Number(10));
+        let block_id = BlockId::Number(11);
+        let pre_state_class_hashes = HashMap::from([(address, previous_class_hash)]);
+
+        let (address_block_pairs, class_fetch_pairs) =
+            plan_accessed_address_class_fetches(&[address], &pre_state_class_hashes, previous_block_id, block_id);
+
+        assert_eq!(class_fetch_pairs, vec![(address, BlockId::Number(10), true, previous_class_hash.0)]);
+        assert_eq!(address_block_pairs, vec![(address, block_id, false)]);
     }
 }
 

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -310,6 +310,15 @@ fn extract_migrated_compiled_classes(state_diff: &StateDiff) -> HashMap<Felt252,
         .unwrap_or_default()
 }
 
+fn collect_fetched_items<K, T>(
+    fetched_results: Vec<(K, Result<T, ProviderError>)>,
+) -> Result<Vec<(K, T)>, StateUpdateError> {
+    fetched_results
+        .into_iter()
+        .map(|(key, result)| result.map(|value| (key, value)).map_err(StateUpdateError::RpcError))
+        .collect()
+}
+
 /// Builds compiled classes from accessed addresses and classes.
 async fn build_compiled_classes(
     rpc_client: &RpcClient,
@@ -446,23 +455,20 @@ async fn process_accessed_addresses(
     info!("Fetched {} contract classes, now compiling in parallel...", class_results.len());
 
     // Phase 3: Compile classes in parallel using rayon (CPU parallelization)
-    let compilation_results: Vec<(Felt, Result<GenericCompiledClass, StateUpdateError>)> = class_results
+    let fetched_classes = collect_fetched_items(class_results)?;
+
+    let compilation_results: Vec<Result<(Felt, GenericCompiledClass), StateUpdateError>> = fetched_classes
         .into_par_iter()
-        .filter_map(|(class_hash, contract_class_result)| {
-            let contract_class = contract_class_result.ok()?;
-            let compiled_result = compile_contract_class(contract_class);
-            Some((class_hash, compiled_result))
+        .map(|(class_hash, contract_class)| {
+            let compiled_class = compile_contract_class(contract_class)?;
+            Ok((class_hash, compiled_class))
         })
         .collect();
 
     // Add compiled classes to result
-    for (class_hash, compiled_result) in compilation_results {
-        match compiled_result {
-            Ok(compiled_class) => {
-                add_compiled_class_internal(class_hash, compiled_class, class_hash_to_compiled_class_hash, result)?;
-            }
-            Err(e) => return Err(e),
-        }
+    for compiled_result in compilation_results {
+        let (class_hash, compiled_class) = compiled_result?;
+        add_compiled_class_internal(class_hash, compiled_class, class_hash_to_compiled_class_hash, result)?;
     }
 
     Ok(())
@@ -488,41 +494,37 @@ async fn process_accessed_classes(
 
     // Phase 1: Fetch all contract classes concurrently (network I/O parallelization)
     let class_hashes: Vec<Felt252> = accessed_classes.iter().copied().collect();
-    let class_fetch_results: Vec<(Felt252, Option<starknet::core::types::ContractClass>)> =
+    let class_fetch_results: Vec<(Felt252, Result<starknet::core::types::ContractClass, ProviderError>)> =
         stream::iter(class_hashes.clone())
             .map(|class_hash| async move {
                 debug!("Fetching class hash: {:?}", class_hash);
                 let operation_name = format!("get_class(block_id: {block_id:?}, class_hash: {class_hash:?})");
                 let contract_class =
                     execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(block_id, class_hash))
-                        .await
-                        .ok();
+                        .await;
                 (class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
             .collect()
             .await;
 
-    info!("Fetched {} contract classes, now compiling in parallel...", class_fetch_results.len());
+    let fetched_classes = collect_fetched_items(class_fetch_results)?;
+
+    info!("Fetched {} contract classes, now compiling in parallel...", fetched_classes.len());
 
     // Phase 2: Compile classes in parallel using rayon (CPU parallelization)
-    let compilation_results: Vec<(Felt252, Result<GenericCompiledClass, StateUpdateError>)> = class_fetch_results
+    let compilation_results: Vec<Result<(Felt252, GenericCompiledClass), StateUpdateError>> = fetched_classes
         .into_par_iter()
-        .filter_map(|(class_hash, contract_class_opt)| {
-            let contract_class = contract_class_opt?;
-            let compiled_result = compile_contract_class(contract_class);
-            Some((class_hash, compiled_result))
+        .map(|(class_hash, contract_class)| {
+            let compiled_class = compile_contract_class(contract_class)?;
+            Ok((class_hash, compiled_class))
         })
         .collect();
 
     // Add compiled classes to result
-    for (class_hash, compiled_result) in compilation_results {
-        match compiled_result {
-            Ok(compiled_class) => {
-                add_compiled_class_internal(class_hash, compiled_class, class_hash_to_compiled_class_hash, result)?;
-            }
-            Err(e) => return Err(e),
-        }
+    for compiled_result in compilation_results {
+        let (class_hash, compiled_class) = compiled_result?;
+        add_compiled_class_internal(class_hash, compiled_class, class_hash_to_compiled_class_hash, result)?;
     }
 
     Ok(())
@@ -626,6 +628,20 @@ fn compile_contract_class(
     };
 
     Ok(compiled_class)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_fetched_items_propagates_rpc_errors() {
+        let fetched_results = vec![(Felt::ONE, Ok("ok")), (Felt::TWO, Err(ProviderError::RateLimited))];
+
+        let error = collect_fetched_items(fetched_results).expect_err("rpc errors must not be dropped");
+
+        assert!(matches!(error, StateUpdateError::RpcError(ProviderError::RateLimited)));
+    }
 }
 
 /// Formats declared classes for OS consumption by setting compiled class hashes to zero.

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -150,6 +150,10 @@ struct CompiledClassBuildInputs<'a> {
     accessed_classes: &'a HashSet<Felt252>,
 }
 
+type AddressBlockLookup = (Felt252, BlockId, bool);
+type AddressClassFetch = (Felt252, BlockId, bool, Felt);
+type AddressClassFetchPlan = (Vec<AddressBlockLookup>, Vec<AddressClassFetch>);
+
 /// Result containing processed contract class data.
 pub struct ContractClassProcessingResult {
     pub compiled_classes: std::collections::BTreeMap<
@@ -324,7 +328,7 @@ fn plan_accessed_address_class_fetches(
     pre_state_class_hashes: &HashMap<Felt252, ClassHash>,
     previous_block_id: PreviousBlockId,
     block_id: BlockId,
-) -> (Vec<(Felt252, BlockId, bool)>, Vec<(Felt252, BlockId, bool, Felt)>) {
+) -> AddressClassFetchPlan {
     let mut address_block_pairs = Vec::new();
     let mut class_fetch_pairs = Vec::new();
 
@@ -422,12 +426,8 @@ async fn process_accessed_addresses(
 
     // Phase 1: Reuse pre-state class hashes from Blockifier when available, and only hit RPC
     // for the remaining previous-block lookups plus all current-block lookups.
-    let (address_block_pairs, mut class_fetch_pairs) = plan_accessed_address_class_fetches(
-        &addresses_to_process,
-        pre_state_class_hashes,
-        previous_block_id,
-        block_id,
-    );
+    let (address_block_pairs, mut class_fetch_pairs) =
+        plan_accessed_address_class_fetches(&addresses_to_process, pre_state_class_hashes, previous_block_id, block_id);
 
     let class_hash_results: Vec<(Felt252, BlockId, bool, Result<Felt, ProviderError>)> =
         stream::iter(address_block_pairs)
@@ -654,6 +654,15 @@ fn compile_contract_class(
     Ok(compiled_class)
 }
 
+/// Formats declared classes for OS consumption by setting compiled class hashes to zero.
+fn format_declared_classes(state_diff: &StateDiff, class_hash_to_compiled_class_hash: &mut HashMap<Felt252, Felt252>) {
+    debug!("Formatting {} declared classes", state_diff.declared_classes.len());
+
+    for class in &state_diff.declared_classes {
+        class_hash_to_compiled_class_hash.insert(class.class_hash, Felt::ZERO);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -694,14 +703,5 @@ mod tests {
 
         assert_eq!(class_fetch_pairs, vec![(address, BlockId::Number(10), true, previous_class_hash.0)]);
         assert_eq!(address_block_pairs, vec![(address, block_id, false)]);
-    }
-}
-
-/// Formats declared classes for OS consumption by setting compiled class hashes to zero.
-fn format_declared_classes(state_diff: &StateDiff, class_hash_to_compiled_class_hash: &mut HashMap<Felt252, Felt252>) {
-    debug!("Formatting {} declared classes", state_diff.declared_classes.len());
-
-    for class in &state_diff.declared_classes {
-        class_hash_to_compiled_class_hash.insert(class.class_hash, Felt::ZERO);
     }
 }

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -150,8 +150,27 @@ struct CompiledClassBuildInputs<'a> {
     accessed_classes: &'a HashSet<Felt252>,
 }
 
-type AddressBlockLookup = (Felt252, BlockId, bool);
-type AddressClassFetch = (Felt252, BlockId, bool, Felt);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StateScope {
+    Previous,
+    Current,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AddressBlockLookup {
+    address: Felt252,
+    block_id: BlockId,
+    scope: StateScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AddressClassFetch {
+    address: Felt252,
+    block_id: BlockId,
+    scope: StateScope,
+    class_hash: Felt,
+}
+
 type AddressClassFetchPlan = (Vec<AddressBlockLookup>, Vec<AddressClassFetch>);
 
 /// Result containing processed contract class data.
@@ -341,13 +360,22 @@ fn plan_accessed_address_class_fetches(
                         address
                     );
                 } else {
-                    class_fetch_pairs.push((*address, previous_block_id, true, previous_class_hash.0));
+                    class_fetch_pairs.push(AddressClassFetch {
+                        address: *address,
+                        block_id: previous_block_id,
+                        scope: StateScope::Previous,
+                        class_hash: previous_class_hash.0,
+                    });
                 }
             } else {
-                address_block_pairs.push((*address, previous_block_id, true));
+                address_block_pairs.push(AddressBlockLookup {
+                    address: *address,
+                    block_id: previous_block_id,
+                    scope: StateScope::Previous,
+                });
             }
         }
-        address_block_pairs.push((*address, block_id, false));
+        address_block_pairs.push(AddressBlockLookup { address: *address, block_id, scope: StateScope::Current });
     }
 
     (address_block_pairs, class_fetch_pairs)
@@ -429,32 +457,58 @@ async fn process_accessed_addresses(
     let (address_block_pairs, mut class_fetch_pairs) =
         plan_accessed_address_class_fetches(&addresses_to_process, pre_state_class_hashes, previous_block_id, block_id);
 
-    let class_hash_results: Vec<(Felt252, BlockId, bool, Result<Felt, ProviderError>)> =
-        stream::iter(address_block_pairs)
-            .map(|(address, bid, is_prev)| async move {
-                let operation_name = format!("get_class_hash_at(block_id: {bid:?}, address: {address:?})");
-                let class_hash =
-                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class_hash_at(bid, address))
-                        .await;
-                (address, bid, is_prev, class_hash)
+    let class_hash_results: Vec<(AddressBlockLookup, Result<Felt, ProviderError>)> = stream::iter(address_block_pairs)
+        .map(|lookup| async move {
+            let operation_name =
+                format!("get_class_hash_at(block_id: {:?}, address: {:?})", lookup.block_id, lookup.address);
+            let class_hash = execute_with_retry(&operation_name, || {
+                rpc_client.starknet_rpc().get_class_hash_at(lookup.block_id, lookup.address)
             })
-            .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
-            .collect()
             .await;
+            (lookup, class_hash)
+        })
+        .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
+        .collect()
+        .await;
+
+    let mut addresses_present_in_previous_state: HashSet<Felt252> = pre_state_class_hashes
+        .iter()
+        .filter_map(|(address, class_hash)| (class_hash.0 != Felt::ZERO).then_some(*address))
+        .collect();
+    for (lookup, class_hash_result) in &class_hash_results {
+        if lookup.scope == StateScope::Previous
+            && matches!(class_hash_result, Ok(class_hash) if *class_hash != Felt::ZERO)
+        {
+            addresses_present_in_previous_state.insert(lookup.address);
+        }
+    }
 
     // Phase 2: Fetch all contract classes concurrently.
-    for (address, bid, is_prev, class_hash_result) in class_hash_results {
+    for (lookup, class_hash_result) in class_hash_results {
         match class_hash_result {
             Ok(class_hash) => {
-                class_fetch_pairs.push((address, bid, is_prev, class_hash));
+                class_fetch_pairs.push(AddressClassFetch {
+                    address: lookup.address,
+                    block_id: lookup.block_id,
+                    scope: lookup.scope,
+                    class_hash,
+                });
             }
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
-                if is_prev {
-                    debug!("Contract {:?} not found in previous block (likely deployed in current block)", address);
+                if lookup.scope == StateScope::Previous {
+                    debug!(
+                        "Contract {:?} not found in previous block (likely deployed in current block)",
+                        lookup.address
+                    );
+                } else if addresses_present_in_previous_state.contains(&lookup.address) {
+                    return Err(StateUpdateError::ConversionFailed(format!(
+                        "Contract {:#x} was present in the previous state but RPC reported ContractNotFound in current block {:?}",
+                        lookup.address, lookup.block_id
+                    )));
                 } else {
                     debug!(
                         "Contract {:?} not found in current block {:?}; skipping class fetch for non-deployed accessed address",
-                        address, bid
+                        lookup.address, lookup.block_id
                     );
                 }
             }
@@ -466,11 +520,14 @@ async fn process_accessed_addresses(
 
     let class_results: Vec<(Felt, Result<starknet::core::types::ContractClass, ProviderError>)> =
         stream::iter(class_fetch_pairs)
-            .map(|(_, bid, _, class_hash)| async move {
-                let operation_name = format!("get_class(block_id: {bid:?}, class_hash: {class_hash:?})");
-                let contract_class =
-                    execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class(bid, class_hash)).await;
-                (class_hash, contract_class)
+            .map(|fetch| async move {
+                let operation_name =
+                    format!("get_class(block_id: {:?}, class_hash: {:?})", fetch.block_id, fetch.class_hash);
+                let contract_class = execute_with_retry(&operation_name, || {
+                    rpc_client.starknet_rpc().get_class(fetch.block_id, fetch.class_hash)
+                })
+                .await;
+                (fetch.class_hash, contract_class)
             })
             .buffer_unordered(MAX_CONCURRENT_GET_CLASS_REQUESTS)
             .collect()
@@ -666,6 +723,7 @@ fn format_declared_classes(state_diff: &StateDiff, class_hash_to_compiled_class_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn collect_fetched_items_propagates_rpc_errors() {
@@ -676,24 +734,22 @@ mod tests {
         assert!(matches!(error, StateUpdateError::RpcError(ProviderError::RateLimited)));
     }
 
-    #[test]
-    fn plan_accessed_address_class_fetches_skips_zero_pre_state_class_hashes() {
+    #[rstest]
+    #[case::zero_pre_state_hash(ClassHash::default(), vec![])]
+    #[case::non_zero_pre_state_hash(
+        ClassHash(Felt::from_hex_unchecked("0x456")),
+        vec![AddressClassFetch {
+            address: Felt::from_hex_unchecked("0x123"),
+            block_id: BlockId::Number(10),
+            scope: StateScope::Previous,
+            class_hash: Felt::from_hex_unchecked("0x456"),
+        }]
+    )]
+    fn plan_accessed_address_class_fetches_respects_pre_state_class_hash(
+        #[case] previous_class_hash: ClassHash,
+        #[case] expected_class_fetch_pairs: Vec<AddressClassFetch>,
+    ) {
         let address = Felt::from_hex_unchecked("0x123");
-        let previous_block_id = Some(BlockId::Number(10));
-        let block_id = BlockId::Number(11);
-        let pre_state_class_hashes = HashMap::from([(address, ClassHash::default())]);
-
-        let (address_block_pairs, class_fetch_pairs) =
-            plan_accessed_address_class_fetches(&[address], &pre_state_class_hashes, previous_block_id, block_id);
-
-        assert!(class_fetch_pairs.is_empty(), "zero pre-state class hashes must not trigger get_class()");
-        assert_eq!(address_block_pairs, vec![(address, block_id, false)]);
-    }
-
-    #[test]
-    fn plan_accessed_address_class_fetches_reuses_non_zero_pre_state_class_hashes() {
-        let address = Felt::from_hex_unchecked("0x123");
-        let previous_class_hash = ClassHash(Felt::from_hex_unchecked("0x456"));
         let previous_block_id = Some(BlockId::Number(10));
         let block_id = BlockId::Number(11);
         let pre_state_class_hashes = HashMap::from([(address, previous_class_hash)]);
@@ -701,7 +757,7 @@ mod tests {
         let (address_block_pairs, class_fetch_pairs) =
             plan_accessed_address_class_fetches(&[address], &pre_state_class_hashes, previous_block_id, block_id);
 
-        assert_eq!(class_fetch_pairs, vec![(address, BlockId::Number(10), true, previous_class_hash.0)]);
-        assert_eq!(address_block_pairs, vec![(address, block_id, false)]);
+        assert_eq!(class_fetch_pairs, expected_class_fetch_pairs);
+        assert_eq!(address_block_pairs, vec![AddressBlockLookup { address, block_id, scope: StateScope::Current }]);
     }
 }

--- a/crates/core/generate-pie/src/types/block.rs
+++ b/crates/core/generate-pie/src/types/block.rs
@@ -13,6 +13,7 @@ use blockifier::blockifier::transaction_executor::{TransactionExecutor, Transact
 use blockifier::blockifier_versioned_constants::VersionedConstants;
 use blockifier::bouncer::BouncerConfig;
 use blockifier::context::{BlockContext, ChainInfo, FeeTokenAddresses};
+use blockifier::state::cached_state::StateMaps;
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::Felt252;
 use log::{debug, info, warn};
@@ -39,6 +40,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 
 const BLOCKIFIER_TXN_EXECUTOR_CONFIG_ENV: &str = "SNOS_BLOCKIFIER_TXN_EXECUTOR_CONFIG";
+const ALIAS_INITIAL_READ_VALIDATION_RETRIES: usize = 3;
 
 /// Result containing fetched block data needed for processing.
 #[derive(Debug)]
@@ -384,6 +386,12 @@ impl BlockData {
         extend_initial_reads_storage(&blockifier_state_reader, &mut initial_reads, &accessed_keys_by_address)
             .await
             .map_err(|source| BlockProcessingError::InitialReadsExtension { source })?;
+        ensure_alias_contract_initial_reads_consistency(
+            &blockifier_state_reader,
+            &mut initial_reads,
+            &processed_state_update.thin_state_diff,
+        )
+        .await?;
 
         Ok(TransactionProcessingResult {
             starknet_api_txns,
@@ -599,6 +607,126 @@ fn populate_alias_contract_keys(
     }
 }
 
+fn alias_counter_storage_key() -> StorageKey {
+    StorageKey::try_from(Felt::ZERO).expect("zero should always be a valid storage key")
+}
+
+fn validate_alias_contract_initial_reads(
+    initial_reads: &StateMaps,
+    alias_storage_diffs: &[(StorageKey, Felt)],
+) -> Result<(), String> {
+    if alias_storage_diffs.is_empty() {
+        return Ok(());
+    }
+
+    let counter_key = alias_counter_storage_key();
+    let current_counter = alias_storage_diffs
+        .iter()
+        .find_map(|(key, value)| (*key == counter_key).then_some(*value))
+        .ok_or_else(|| "alias contract diff is missing the counter key 0x0".to_string())?;
+    let previous_counter = initial_reads
+        .storage
+        .get(&(ALIAS_CONTRACT_ADDRESS, counter_key))
+        .copied()
+        .ok_or_else(|| "initial reads are missing the alias counter key 0x0".to_string())?;
+
+    let mut alias_entries: Vec<_> =
+        alias_storage_diffs.iter().filter(|(key, _)| *key != counter_key).copied().collect();
+    alias_entries.sort_by_key(|(_, value)| *value);
+
+    let mut expected_next_alias =
+        if previous_counter == Felt::ZERO { STATEFUL_MAPPING_START } else { previous_counter };
+
+    for (alias_key, new_alias_value) in &alias_entries {
+        let previous_value = initial_reads
+            .storage
+            .get(&(ALIAS_CONTRACT_ADDRESS, *alias_key))
+            .copied()
+            .ok_or_else(|| format!("initial reads are missing alias key {:#x}", Into::<Felt>::into(*alias_key)))?;
+
+        if previous_value != Felt::ZERO {
+            return Err(format!(
+                "alias key {:#x} should be zero in the previous state but SNOS fetched {:#x}",
+                Into::<Felt>::into(*alias_key),
+                previous_value
+            ));
+        }
+
+        if *new_alias_value != expected_next_alias {
+            return Err(format!(
+                "alias key {:#x} has new value {:#x}, expected next alias {:#x}",
+                Into::<Felt>::into(*alias_key),
+                *new_alias_value,
+                expected_next_alias
+            ));
+        }
+
+        expected_next_alias += Felt::ONE;
+    }
+
+    let expected_counter = if alias_entries.is_empty() && previous_counter == Felt::ZERO {
+        STATEFUL_MAPPING_START
+    } else if alias_entries.is_empty() {
+        previous_counter
+    } else {
+        expected_next_alias
+    };
+
+    if current_counter != expected_counter {
+        return Err(format!(
+            "alias counter advanced to {:#x}, expected {:#x} from previous counter {:#x} and {} new aliases",
+            current_counter,
+            expected_counter,
+            previous_counter,
+            alias_entries.len()
+        ));
+    }
+
+    Ok(())
+}
+
+async fn ensure_alias_contract_initial_reads_consistency(
+    state_reader: &AsyncRpcStateReader,
+    initial_reads: &mut StateMaps,
+    thin_state_diff: &starknet_api::state::ThinStateDiff,
+) -> Result<(), BlockProcessingError> {
+    let Some(alias_storage_diffs) = thin_state_diff.storage_diffs.get(&ALIAS_CONTRACT_ADDRESS) else {
+        return Ok(());
+    };
+
+    let alias_storage_diffs: Vec<_> = alias_storage_diffs.iter().map(|(key, value)| (*key, *value)).collect();
+    let keys_to_refresh: Vec<_> = alias_storage_diffs.iter().map(|(key, _)| *key).collect();
+    for attempt in 1..=ALIAS_INITIAL_READ_VALIDATION_RETRIES {
+        match validate_alias_contract_initial_reads(initial_reads, &alias_storage_diffs) {
+            Ok(()) => return Ok(()),
+            Err(details) if attempt < ALIAS_INITIAL_READ_VALIDATION_RETRIES => {
+                warn!(
+                    "Alias contract initial reads inconsistent on attempt {}: {}. Refetching {} alias keys.",
+                    attempt,
+                    details,
+                    keys_to_refresh.len()
+                );
+
+                for key in &keys_to_refresh {
+                    let value = state_reader
+                        .get_storage_at_async(ALIAS_CONTRACT_ADDRESS, *key)
+                        .await
+                        .map_err(|source| BlockProcessingError::InitialReadsExtension { source })?;
+                    initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, *key), value);
+                }
+            }
+            Err(details) => {
+                return Err(BlockProcessingError::StateUpdateProcessing(format!(
+                    "Alias contract initial reads remain inconsistent after {} attempts: {}",
+                    attempt, details
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_migrated_compiled_classes(
     processed_state_update: &crate::state_update::FormattedStateUpdate,
     class_hashes_to_migrate: &[(ClassHash, CompiledClassHash, CompiledClassHash)],
@@ -794,5 +922,52 @@ mod tests {
         );
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_alias_contract_initial_reads_accepts_consecutive_alias_allocations() {
+        let counter_key = alias_counter_storage_key();
+        let alias_key_a = StorageKey::try_from(Felt::from_hex_unchecked("0x80")).unwrap();
+        let alias_key_b = StorageKey::try_from(Felt::from_hex_unchecked("0x81")).unwrap();
+        let mut initial_reads = StateMaps::default();
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, counter_key), Felt::from(0x80_u64));
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, alias_key_a), Felt::ZERO);
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, alias_key_b), Felt::ZERO);
+
+        let alias_storage_diffs = vec![
+            (alias_key_a, Felt::from(0x80_u64)),
+            (alias_key_b, Felt::from(0x81_u64)),
+            (counter_key, Felt::from(0x82_u64)),
+        ];
+
+        assert!(validate_alias_contract_initial_reads(&initial_reads, &alias_storage_diffs).is_ok());
+    }
+
+    #[test]
+    fn validate_alias_contract_initial_reads_rejects_non_zero_previous_alias_value() {
+        let counter_key = alias_counter_storage_key();
+        let alias_key = StorageKey::try_from(Felt::from_hex_unchecked("0x80")).unwrap();
+        let mut initial_reads = StateMaps::default();
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, counter_key), Felt::from(0x80_u64));
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, alias_key), Felt::from(0x999_u64));
+
+        let alias_storage_diffs = vec![(alias_key, Felt::from(0x80_u64)), (counter_key, Felt::from(0x81_u64))];
+
+        let error = validate_alias_contract_initial_reads(&initial_reads, &alias_storage_diffs).unwrap_err();
+        assert!(error.contains("should be zero in the previous state"));
+    }
+
+    #[test]
+    fn validate_alias_contract_initial_reads_rejects_counter_one_too_low() {
+        let counter_key = alias_counter_storage_key();
+        let alias_key = StorageKey::try_from(Felt::from_hex_unchecked("0x80")).unwrap();
+        let mut initial_reads = StateMaps::default();
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, counter_key), Felt::from(0x80_u64));
+        initial_reads.storage.insert((ALIAS_CONTRACT_ADDRESS, alias_key), Felt::ZERO);
+
+        let alias_storage_diffs = vec![(alias_key, Felt::from(0x80_u64)), (counter_key, Felt::from(0x80_u64))];
+
+        let error = validate_alias_contract_initial_reads(&initial_reads, &alias_storage_diffs).unwrap_err();
+        assert!(error.contains("alias counter advanced"));
     }
 }

--- a/crates/core/generate-pie/src/types/proof.rs
+++ b/crates/core/generate-pie/src/types/proof.rs
@@ -30,13 +30,29 @@ pub struct CommitmentCalculationResult {
 
 fn required_contract_data<'a>(
     proof: &'a ContractProof,
-    context: &str,
+    proof_side: &'static str,
+    contract_address: Felt,
 ) -> Result<&'a rpc_client::types::ContractData, BlockProcessingError> {
-    proof.contract_data.as_ref().ok_or_else(|| BlockProcessingError::new_custom(context.to_string()))
+    proof.contract_data.as_ref().ok_or(BlockProcessingError::MissingProofFieldForContract {
+        proof_side,
+        proof_kind: "storage",
+        field: "contract_data",
+        contract_address,
+    })
 }
 
-fn required_class_commitment(proof: &ContractProof, context: &str) -> Result<Felt, BlockProcessingError> {
-    proof.class_commitment.ok_or_else(|| BlockProcessingError::new_custom(context.to_string()))
+fn required_class_commitment(
+    proof: &ContractProof,
+    proof_side: &'static str,
+    proof_kind: &'static str,
+    contract_address: Felt,
+) -> Result<Felt, BlockProcessingError> {
+    proof.class_commitment.ok_or(BlockProcessingError::MissingProofFieldForContract {
+        proof_side,
+        proof_kind,
+        field: "class_commitment",
+        contract_address,
+    })
 }
 
 impl ProofCollectionResult {
@@ -80,14 +96,13 @@ impl ProofCollectionResult {
                         })?;
 
                     let previous_contract_data =
-                        required_contract_data(previous_storage_proof, "Previous storage proof missing contract data")?;
+                        required_contract_data(previous_storage_proof, "previous", contract_address)?;
 
                     (format_commitment_facts(&previous_contract_data.storage_proofs), previous_contract_data.root)
                 }
             };
 
-            let current_contract_data =
-                required_contract_data(&storage_proof, "Current storage proof missing contract data")?;
+            let current_contract_data = required_contract_data(&storage_proof, "current", contract_address)?;
 
             let current_contract_commitment_facts = format_commitment_facts(&current_contract_data.storage_proofs);
 
@@ -147,13 +162,17 @@ impl ProofCollectionResult {
         // Class commitment tree roots
         let updated_root = required_class_commitment(
             block_hash_storage_proof,
-            "Current block hash storage proof missing class commitment",
+            "current",
+            "block-hash storage",
+            BLOCK_HASH_CONTRACT_ADDRESS_FELT,
         )?;
         let previous_root = match block_id {
             BlockId::Number(0) => Felt::ZERO,
             BlockId::Number(_) => required_class_commitment(
                 previous_block_hash_storage_proof,
-                "Previous block hash storage proof missing class commitment",
+                "previous",
+                "block-hash storage",
+                BLOCK_HASH_CONTRACT_ADDRESS_FELT,
             )?,
             _ => return Err(BlockProcessingError::new_custom(format!("unexpected block_id {:?}", block_id))),
         };

--- a/crates/core/generate-pie/src/types/proof.rs
+++ b/crates/core/generate-pie/src/types/proof.rs
@@ -28,6 +28,17 @@ pub struct CommitmentCalculationResult {
     pub contract_class_commitment_info: CommitmentInfo,
 }
 
+fn required_contract_data<'a>(
+    proof: &'a ContractProof,
+    context: &str,
+) -> Result<&'a rpc_client::types::ContractData, BlockProcessingError> {
+    proof.contract_data.as_ref().ok_or_else(|| BlockProcessingError::new_custom(context.to_string()))
+}
+
+fn required_class_commitment(proof: &ContractProof, context: &str) -> Result<Felt, BlockProcessingError> {
+    proof.class_commitment.ok_or_else(|| BlockProcessingError::new_custom(context.to_string()))
+}
+
 impl ProofCollectionResult {
     /// Calculates commitment information for contracts and classes.
     ///
@@ -68,34 +79,17 @@ impl ProofCollectionResult {
                             ))
                         })?;
 
-                    let previous_contract_storage_root: Felt = previous_storage_proof
-                        .contract_data
-                        .as_ref()
-                        .map(|contract_data| contract_data.root)
-                        .unwrap_or(Felt::ZERO);
+                    let previous_contract_data =
+                        required_contract_data(previous_storage_proof, "Previous storage proof missing contract data")?;
 
-                    (
-                        format_commitment_facts(
-                            &previous_storage_proof
-                                .clone()
-                                .contract_data
-                                .ok_or_else(|| {
-                                    BlockProcessingError::new_custom("Previous storage proof missing contract data")
-                                })?
-                                .storage_proofs,
-                        ),
-                        previous_contract_storage_root,
-                    )
+                    (format_commitment_facts(&previous_contract_data.storage_proofs), previous_contract_data.root)
                 }
             };
 
-            let current_contract_commitment_facts = format_commitment_facts(
-                &storage_proof
-                    .clone()
-                    .contract_data
-                    .ok_or_else(|| BlockProcessingError::new_custom("Current storage proof missing contract data"))?
-                    .storage_proofs,
-            );
+            let current_contract_data =
+                required_contract_data(&storage_proof, "Current storage proof missing contract data")?;
+
+            let current_contract_commitment_facts = format_commitment_facts(&current_contract_data.storage_proofs);
 
             let global_contract_commitment_facts: HashMap<HashOutput, Vec<Felt252>> =
                 previous_contract_commitment_facts
@@ -104,12 +98,9 @@ impl ProofCollectionResult {
                     .map(|(key, value)| (HashOutput(key), value))
                     .collect();
 
-            let current_contract_storage_root: Felt =
-                storage_proof.contract_data.as_ref().map(|contract_data| contract_data.root).unwrap_or(Felt::ZERO);
-
             let contract_state_commitment_info = CommitmentInfo {
                 previous_root: HashOutput(previous_contract_storage_root),
-                updated_root: HashOutput(current_contract_storage_root),
+                updated_root: HashOutput(current_contract_data.root),
                 tree_height: SubTreeHeight(DEFAULT_STORAGE_TREE_HEIGHT as u8),
                 commitment_facts: global_contract_commitment_facts,
             };
@@ -154,8 +145,18 @@ impl ProofCollectionResult {
         };
 
         // Class commitment tree roots
-        let updated_root = block_hash_storage_proof.class_commitment.unwrap_or(Felt::ZERO);
-        let previous_root = previous_block_hash_storage_proof.class_commitment.unwrap_or(Felt::ZERO);
+        let updated_root = required_class_commitment(
+            block_hash_storage_proof,
+            "Current block hash storage proof missing class commitment",
+        )?;
+        let previous_root = match block_id {
+            BlockId::Number(0) => Felt::ZERO,
+            BlockId::Number(_) => required_class_commitment(
+                previous_block_hash_storage_proof,
+                "Previous block hash storage proof missing class commitment",
+            )?,
+            _ => return Err(BlockProcessingError::new_custom(format!("unexpected block_id {:?}", block_id))),
+        };
 
         // Contract trie roots
         let previous_contract_trie_root = previous_block_hash_storage_proof.contract_commitment;

--- a/crates/rpc-client/src/types/proofs/contract.rs
+++ b/crates/rpc-client/src/types/proofs/contract.rs
@@ -151,9 +151,8 @@ impl TryFrom<StorageProof> for ContractProof {
             contract_commitment: proof.global_roots.contracts_tree_root,
             class_commitment: Some(proof.global_roots.classes_tree_root),
             contract_proof: snos_contract_proof,
-            // TODO: Remove the unwrap. Make the root field Optional if possible or handle the error
             contract_data: Some(ContractData {
-                root: contract_leaf.storage_root.unwrap(),
+                root: contract_leaf.storage_root.ok_or(ProviderError::ArrayLengthMismatch)?,
                 storage_proofs: snos_storage_proofs,
             }),
         })


### PR DESCRIPTION
## What changed
- stop silently accepting missing or failed `get_class` RPC results while building SNOS inputs
- reject transactions that arrive without `proof_facts` instead of converting them to an empty/default value
- require storage proof fields such as contract roots and class commitment roots instead of fabricating fallback values
- validate alias-contract initial reads against the current block state diff, refetch those reads when they are inconsistent, and fail clearly if they remain inconsistent

## Why
SNOS was still able to continue in a few places after incomplete or inconsistent Pathfinder RPC responses. That let malformed witnesses survive long enough to fail later inside the Cairo OS with Patricia diff asserts, which is much harder to debug.

## Impact
RPC data now has to be present and self-consistent. If Pathfinder does not return a required value, or returns an inconsistent alias-contract pre-state, SNOS will retry where appropriate and then fail early with an explicit error instead of using a default and continuing.

## Validation
- `cargo test -p generate-pie --lib`
- `cargo test -p rpc-client fetch_proof_chunks_retries_only_failed_chunk -- --nocapture`
