### PR TITLE
[codex] Preserve typed SNOS RPC errors

### DIFF
--- a/crates/core/generate-pie/src/error.rs
+++ b/crates/core/generate-pie/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types for pie generation, felt conversion operations, and block processing.
 
 use crate::conversions::ConversionError;
+use crate::state_update::StateUpdateError;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::TransactionExecutionError;
+use rpc_client::error::ClientError;
 use starknet::core::types::Felt;
 use starknet::providers::ProviderError;
 use starknet_api::core::{ClassHash, ContractAddress};
@@ -31,6 +33,10 @@ pub enum PieGenerationError {
     /// RPC client-related error.
     #[error("RPC client error: {0}")]
     RpcClient(String),
+
+    /// A worker task panicked or was cancelled while collecting block data.
+    #[error("Task join error: {0}")]
+    TaskJoin(#[from] tokio::task::JoinError),
 
     /// OS execution related error.
     #[error("OS execution error: {0}")]
@@ -132,13 +138,17 @@ pub enum BlockProcessingError {
     #[error("State update processing error: {0}")]
     StateUpdateProcessing(String),
 
+    /// Structured state update error.
+    #[error("State update error: {0}")]
+    StateUpdate(#[source] StateUpdateError),
+
     /// Storage proof error.
     #[error("Storage proof error: {0}")]
-    StorageProof(String),
+    StorageProof(#[source] ClientError),
 
     /// Class proof error.
     #[error("Class proof error: {0}")]
-    ClassProof(String),
+    ClassProof(#[source] ClientError),
 
     /// Contract class conversion error.
     #[error("Contract class conversion error: {0}")]

--- a/crates/core/generate-pie/src/lib.rs
+++ b/crates/core/generate-pie/src/lib.rs
@@ -223,8 +223,7 @@ pub async fn generate_pie(input: PieGenerationInput) -> Result<PieGenerationResu
 
     for result in results {
         // First unwrap the JoinHandle, then unwrap the inner Result
-        let (block_input, block_compiled_classes, block_deprecated_compiled_classes) =
-            result.map_err(|e| PieGenerationError::RpcClient(format!("Task join error: {:?}", e)))??;
+        let (block_input, block_compiled_classes, block_deprecated_compiled_classes) = result??;
 
         // Add block input to our collection
         os_block_inputs.push(block_input);

--- a/crates/core/generate-pie/src/state_update.rs
+++ b/crates/core/generate-pie/src/state_update.rs
@@ -242,13 +242,14 @@ pub(crate) async fn get_formatted_state_update(
     accessed_addresses: HashSet<Felt>,
     accessed_classes: HashSet<Felt>,
     pre_state_class_hashes: &HashMap<Felt252, ClassHash>,
-) -> Result<FormattedStateUpdate, Box<dyn std::error::Error>> {
+) -> Result<FormattedStateUpdate, StateUpdateError> {
     info!("Starting state update processing for block {:?}", block_id);
 
     // Fetch and validate state update
     let state_update = fetch_state_update(rpc_client, block_id).await?;
     let state_diff = &state_update.state_diff;
-    let thin_state_diff = core_state_diff_to_thin_state_diff(state_diff)?;
+    let thin_state_diff = core_state_diff_to_thin_state_diff(state_diff)
+        .map_err(|e| StateUpdateError::ConversionFailed(format!("Failed to convert state diff: {e}")))?;
 
     // Extract declared classes
     let declared_classes = extract_declared_classes(state_diff);

--- a/crates/core/generate-pie/src/types/block.rs
+++ b/crates/core/generate-pie/src/types/block.rs
@@ -330,9 +330,7 @@ impl BlockData {
             &pre_state_class_hashes,
         )
         .await
-        .map_err(|e| {
-            BlockProcessingError::StateUpdateProcessing(format!("Failed to get formatted state update: {:?}", e))
-        })?;
+        .map_err(BlockProcessingError::StateUpdate)?;
         info!("Fetched processed state update successfully");
         let class_hashes_to_migrate = build_class_hashes_to_migrate(&processed_state_update, &blockifier_state_reader)?;
         apply_pre_migration_compiled_class_hashes(&mut initial_reads, &class_hashes_to_migrate);

--- a/crates/core/generate-pie/src/types/transaction.rs
+++ b/crates/core/generate-pie/src/types/transaction.rs
@@ -56,15 +56,15 @@ impl TransactionProcessingResult {
         // Fetch storage proofs for the current block
         let storage_proofs = get_storage_proofs(rpc_client, block_number, &self.accessed_keys_by_address)
             .await
-            .map_err(|e| BlockProcessingError::StorageProof(format!("Failed to fetch storage proofs: {:?}", e)))?;
+            .map_err(BlockProcessingError::StorageProof)?;
         info!("Got {} storage proofs for block {}", storage_proofs.len(), block_number);
 
         // Fetch storage proofs for the previous block
         let previous_storage_proofs = match previous_block_id {
             Some(BlockId::Number(previous_block_id)) => {
-                get_storage_proofs(rpc_client, previous_block_id, &self.accessed_keys_by_address).await.map_err(
-                    |e| BlockProcessingError::StorageProof(format!("Failed to fetch previous storage proofs: {:?}", e)),
-                )?
+                get_storage_proofs(rpc_client, previous_block_id, &self.accessed_keys_by_address)
+                    .await
+                    .map_err(BlockProcessingError::StorageProof)?
             }
             // No previous storage proofs for block 0
             None => HashMap::new(),
@@ -93,15 +93,15 @@ impl TransactionProcessingResult {
         // Fetch class proofs for the current block
         let class_proofs = get_class_proofs(rpc_client, block_number, &class_hashes[..])
             .await
-            .map_err(|e| BlockProcessingError::ClassProof(format!("Failed to fetch class proofs: {:?}", e)))?;
+            .map_err(BlockProcessingError::ClassProof)?;
         info!("Got {} class proofs for {} class hashes", class_proofs.len(), class_hashes.len());
 
         // Fetch previous class proofs
         let previous_class_proofs = match previous_block_id {
             Some(BlockId::Number(previous_block_id)) => {
-                get_class_proofs(rpc_client, previous_block_id, &class_hashes[..]).await.map_err(|e| {
-                    BlockProcessingError::ClassProof(format!("Failed to fetch previous class proofs: {:?}", e))
-                })?
+                get_class_proofs(rpc_client, previous_block_id, &class_hashes[..])
+                    .await
+                    .map_err(BlockProcessingError::ClassProof)?
             }
             _ => Default::default(),
         };

--- a/crates/core/generate-pie/src/utils/rpc.rs
+++ b/crates/core/generate-pie/src/utils/rpc.rs
@@ -148,7 +148,7 @@ pub(crate) async fn get_class_proofs(
         let proof =
             execute_with_retry(&operation_name, || rpc_client.starknet_rpc().get_class_proof(block_number, class_hash))
                 .await
-                .map_err(|e| ClientError::CustomError(format!("{}", e)))?;
+                .map_err(ClientError::ProviderError)?;
         // TODO: need to combine these, similar to merge_chunked_storage_proofs above?
         proofs.insert(**class_hash, proof);
     }
@@ -236,11 +236,7 @@ async fn fetch_storage_proof_for_contract(
     block_number: u64,
 ) -> Result<ContractProof, ClientError> {
     info!("Fetching storage proof for contract {} with {} keys", contract_address, keys.len());
-    rpc_client
-        .starknet_rpc()
-        .get_proof(block_number, contract_address, keys)
-        .await
-        .map_err(|e| ClientError::CustomError(format!("{}", e)))
+    rpc_client.starknet_rpc().get_proof(block_number, contract_address, keys).await.map_err(ClientError::ProviderError)
 }
 
 /// Merges the storage proofs of the SAME contract.

--- a/crates/rpc-client/src/error.rs
+++ b/crates/rpc-client/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for Pathfinder RPC operations and proof verification.
 
+use starknet::providers::ProviderError;
 use starknet_types_core::felt::Felt;
 
 use crate::types::{Height, TrieNode};
@@ -11,6 +12,10 @@ use crate::types::{Height, TrieNode};
 /// custom application errors.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
+    /// A Starknet provider error occurred while calling an RPC endpoint.
+    #[error("Provider error: {0}")]
+    ProviderError(#[from] ProviderError),
+
     /// A network or HTTP request error occurred.
     #[error("Encountered a request error: {0}")]
     ReqwestError(#[from] reqwest::Error),


### PR DESCRIPTION
## What changed
- preserve typed provider, proof, and state-update errors instead of collapsing them into generic strings
- expose structured join/state/proof errors from `generate-pie` so downstream callers can distinguish retryable RPC failures from deterministic execution failures

## Why
Orchestrator needs reliable SNOS error typing to avoid fail-fasting on intermittent RPC and proof-fetch failures while still failing immediately on deterministic Cairo execution errors.

## Impact
- SNOS callers can now inspect RPC/proof/state-update failures structurally
- downstream retry logic can key off real error variants rather than string parsing

## Validation
- `cargo clippy --workspace --all-features --tests --no-deps -- -D warnings`
- `cargo fmt`
