### PR TITLE
[codex] Expose typed generate-pie errors

### DIFF
--- a/crates/core/generate-pie/src/error.rs
+++ b/crates/core/generate-pie/src/error.rs
@@ -1,7 +1,6 @@
 //! Error types for pie generation, felt conversion operations, and block processing.
 
 use crate::conversions::ConversionError;
-use crate::state_update::StateUpdateError;
 use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::TransactionExecutionError;
 use rpc_client::error::ClientError;
@@ -12,6 +11,8 @@ use starknet_api::StarknetApiError;
 use thiserror::Error;
 
 use starknet_os_types::starknet_core_addons::LegacyContractDecompressionError;
+
+pub use crate::state_update::StateUpdateError;
 
 /// Main error type for PIE generation.
 ///
@@ -27,7 +28,7 @@ pub enum PieGenerationError {
         block_number: u64,
         /// The underlying error that caused the failure.
         #[source]
-        source: Box<dyn std::error::Error + Send + Sync>,
+        source: Box<BlockProcessingError>,
     },
 
     /// RPC client-related error.

--- a/crates/core/generate-pie/tests/public_error_api.rs
+++ b/crates/core/generate-pie/tests/public_error_api.rs
@@ -1,0 +1,23 @@
+use generate_pie::error::{BlockProcessingError, PieGenerationError, StateUpdateError};
+
+#[test]
+fn state_update_error_is_reexported_for_downstream_matching() {
+    let error = StateUpdateError::PendingBlock;
+    assert!(matches!(error, StateUpdateError::PendingBlock));
+}
+
+#[test]
+fn pie_generation_error_exposes_typed_block_processing_source() {
+    let error = PieGenerationError::BlockProcessing {
+        block_number: 7,
+        source: Box::new(BlockProcessingError::StateUpdate(StateUpdateError::PendingBlock)),
+    };
+
+    match error {
+        PieGenerationError::BlockProcessing { block_number, source } => {
+            assert_eq!(block_number, 7);
+            assert!(matches!(*source, BlockProcessingError::StateUpdate(StateUpdateError::PendingBlock)));
+        }
+        _ => panic!("expected block processing error"),
+    }
+}


### PR DESCRIPTION
## Summary
- re-export `StateUpdateError` through `generate_pie::error` so downstream callers can match it structurally
- preserve `BlockProcessingError` as the typed source inside `PieGenerationError::BlockProcessing`
- add an integration test that exercises the public error API from outside the crate

## Why
This is a follow-up to [#525](https://github.com/keep-starknet-strange/snos/pull/525).

The previous change introduced structured `StateUpdateError` and `BlockProcessingError` variants, but two API boundaries still erased that structure for downstream users:
- `StateUpdateError` lived in a private module, so external callers could not match `StateUpdateError::RpcError`
- `PieGenerationError::BlockProcessing` stored its source as `Box<dyn Error + Send + Sync>`, which forced downstream callers to downcast instead of pattern matching directly

This follow-up makes the typed error model usable to consumers such as the orchestrator.

## Validation
- `cargo fmt --all`
- `cargo test -p generate-pie`
- `cargo test -p generate-pie --test public_error_api`
- `source /Users/prakhar/work/karnot/snos/sequencer_venv/bin/activate && cargo clippy -p generate-pie --all-features --tests --no-deps -- -D warnings`
